### PR TITLE
Fix 2FA credential-validation oracle in API login

### DIFF
--- a/AUTH_API.md
+++ b/AUTH_API.md
@@ -42,7 +42,7 @@ No cookies, CSRF tokens, or API keys are required. The entire `/api/v1/` bluepri
 
 ### Two-Factor Authentication (2FA)
 
-Accounts with TOTP 2FA enabled **cannot** obtain API tokens via `/api/v1/auth/login`. The server returns 401 with the message `"Two-factor authentication is required for API login"`. This is a deliberate security constraint — 2FA users must authenticate through the browser flow until a dedicated 2FA API challenge endpoint is added in a future release.
+Accounts with TOTP 2FA enabled **cannot** obtain API tokens via `/api/v1/auth/login`. The server returns the same generic 401 response as any other credential failure, to avoid leaking whether the password was correct. This is a deliberate security constraint — 2FA users must authenticate through the browser flow until a dedicated 2FA API challenge endpoint is added in a future release.
 
 ### Inactive Accounts
 

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -78,13 +78,10 @@ def api_login():
     candidate_hash = user.password if user else _DUMMY_HASH
     password_ok = check_password_hash(candidate_hash, password)
 
-    if not password_ok or user is None or not user.is_active:
+    # 2FA check is intentionally in the same condition to avoid leaking
+    # whether the password was correct (credential-validation oracle).
+    if not password_ok or user is None or not user.is_active or user.twofa_enabled:
         return unauthorized("Invalid credentials or account is not active")
-
-    # Keep API auth policy aligned with web login flow: accounts with 2FA
-    # enabled must complete a second factor in the browser flow.
-    if user.twofa_enabled:
-        return unauthorized("Two-factor authentication is required for API login")
 
     raw_token, _record = create_token_for_user(user)
 


### PR DESCRIPTION
Merge the 2FA check into the same conditional as credential validation
so that 2FA-enabled accounts return the identical generic 401 response,
preventing attackers from confirming correct passwords via distinct
error messages.

https://claude.ai/code/session_016FneV4FExSiL4GgNr5b13M