### PR TITLE
Add transactions, risk-score, and balance API endpoints

### DIFF
--- a/CODEX_HANDOFF.md
+++ b/CODEX_HANDOFF.md
@@ -21,7 +21,7 @@ exemption and Bearer-token authentication.
 | POST | `/api/v1/auth/logout` | Revoke current Bearer token |
 | GET | `/api/v1/auth/me` | Current user profile |
 
-**Read-only data endpoints (6):**
+**Read-only data endpoints (9):**
 
 | Method | Path | Purpose |
 |--------|------|---------|
@@ -31,6 +31,9 @@ exemption and Bearer-token authentication.
 | GET | `/api/v1/scenarios` | List what-if scenario items |
 | GET | `/api/v1/holds` | List held (paused) schedule items |
 | GET | `/api/v1/skips` | List skipped transaction instances |
+| GET | `/api/v1/transactions` | Upcoming transactions expanded from schedules (90 days) |
+| GET | `/api/v1/risk-score` | Detailed risk assessment with decimal-string amounts |
+| GET | `/api/v1/balance` | Current balance snapshot (lightweight, no projections) |
 
 **Supporting infrastructure:**
 
@@ -89,8 +92,9 @@ web routes. No API equivalent exists.
 
 ### Balance history
 
-Only the latest balance is exposed (via `/dashboard`). There is no endpoint to
-list historical balances or create a new balance entry.
+The latest balance is now exposed via both `/dashboard` and the dedicated
+`/balance` endpoint. There is no endpoint to list historical balances or
+create a new balance entry.
 
 ### AI Insights
 
@@ -113,7 +117,9 @@ No API for reading or updating IMAP email configuration.
    The risk dict keys (`score`, `status`, `color`, `runway_days`,
    `lowest_balance`, etc.) are not formally serialized through a dedicated
    serializer — they pass through as-is from the engine, including Python
-   floats rather than decimal strings.
+   floats rather than decimal strings. **Mitigation:** The new `/risk-score`
+   endpoint properly serializes monetary values as decimal strings. The
+   `/dashboard` `risk` object is kept as-is for backward compatibility.
 
 3. **`upcoming_transactions` in `/dashboard`** uses `_amount()` and `_date()`
    for serialization but does not go through a named serializer function. The
@@ -169,12 +175,12 @@ No API for reading or updating IMAP email configuration.
 
 ## 5. Test Status
 
-**173 tests, all passing** (as of this snapshot).
+**197 tests, all passing** (as of this snapshot).
 
 | Test file | Count | Scope |
 |-----------|-------|-------|
 | `test_api_foundation.py` | ~35 | Token auth lifecycle, response/error shapes, serialization |
-| `test_api_data.py` | ~50 | All 6 data endpoints, guest isolation |
+| `test_api_data.py` | ~55 | All 9 data endpoints, guest isolation, response shapes |
 | `test_routes.py` | ~45 | Web routes, form validation, authorization |
 | `test_projection_engine.py` | ~50 | Business-day adjustments, frequency expansion, 90-day window |
 | `test_scenarios.py` | ~20 | Scenario projections, baseline immutability |
@@ -244,8 +250,9 @@ No API for reading or updating IMAP email configuration.
 6. **Extract validation logic** — pull form-validation rules from `main.py`
    into a shared module usable by both web and API routes.
 
-7. **Add a risk-score serializer** — formalize the dict shape with decimal
-   strings and document it in `API_CONVENTIONS.md`.
+7. ~~**Add a risk-score serializer**~~ — done via `GET /api/v1/risk-score`
+   endpoint which serializes monetary values as decimal strings. The
+   `/dashboard` `risk` object still passes through raw floats.
 
 8. **Fix `Query.get()` deprecation** — migrate to `Session.get()` across
    the codebase.

--- a/MOBILE_API_REFERENCE.md
+++ b/MOBILE_API_REFERENCE.md
@@ -576,6 +576,149 @@ List all skipped transaction instances.
 
 ---
 
+### GET /api/v1/transactions
+
+List all upcoming transactions for the next 90 days. Each transaction is an
+individual occurrence expanded from the user's recurring schedules, with holds
+and skips applied. This is the dedicated equivalent of the
+`upcoming_transactions` array inside `/dashboard`, but as a standalone
+collection endpoint.
+
+**Auth required:** Yes (Bearer or session)
+
+**Response `200 OK`:**
+
+```json
+{
+  "data": [
+    {
+      "name": "Rent",
+      "type": "Expense",
+      "amount": "1200.00",
+      "date": "2026-04-15"
+    },
+    {
+      "name": "Salary",
+      "type": "Income",
+      "amount": "5000.00",
+      "date": "2026-04-30"
+    }
+  ],
+  "meta": {
+    "total": 2
+  }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `name` | string | Transaction name (from schedule) |
+| `type` | string | `"Income"` or `"Expense"` |
+| `amount` | string (decimal) | Serialized with 2 decimal places |
+| `date` | string (date) | ISO 8601 date of this occurrence |
+
+**Note:** Transactions do not have `id`, `frequency`, or `start_date` fields —
+they are expanded instances of schedules, not the schedule definitions
+themselves. Use `/schedules` to get the schedule records.
+
+**Empty state:** `data` will be `[]` with `meta.total` of `0` when no
+upcoming transactions exist.
+
+---
+
+### GET /api/v1/risk-score
+
+Detailed cash-flow risk assessment. Returns the full risk-score breakdown
+with monetary values serialized as decimal strings (unlike the `risk` object
+inside `/dashboard`, which passes through raw Python floats).
+
+**Auth required:** Yes (Bearer or session)
+
+**Response `200 OK`:**
+
+```json
+{
+  "data": {
+    "score": 85,
+    "status": "Safe",
+    "color": "green",
+    "runway_days": 120.0,
+    "lowest_balance": "2500.00",
+    "days_to_lowest": 15,
+    "avg_daily_expense": "45.50",
+    "days_below_threshold": 0,
+    "pct_below_threshold": 0.0,
+    "recovery_days": 0,
+    "near_term_buffer": "3200.00"
+  }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `score` | integer | 0–100 (higher is safer) |
+| `status` | string | `"Safe"` / `"Stable"` / `"Watch"` / `"Risk"` / `"Critical"` |
+| `color` | string | CSS color name for UI theming |
+| `runway_days` | number | Days until funds run out at current burn rate |
+| `lowest_balance` | string (decimal) | Lowest projected balance (decimal string) |
+| `days_to_lowest` | integer | Days until projected lowest point |
+| `avg_daily_expense` | string (decimal) | Average daily expense (decimal string) |
+| `days_below_threshold` | integer | Days projected below 1-month expense reserve |
+| `pct_below_threshold` | number | Fraction of horizon below threshold (0.0–1.0) |
+| `recovery_days` | integer or `null` | Days from lowest back to threshold; `null` if never recovers; `0` if threshold never breached |
+| `near_term_buffer` | string (decimal) | Minimum balance over next 14 days (decimal string) |
+
+**Difference from `/dashboard`:** The `/risk-score` endpoint serializes
+`lowest_balance`, `avg_daily_expense`, and `near_term_buffer` as decimal
+strings, consistent with the API's amount conventions. The `risk` object in
+`/dashboard` returns these as raw JSON numbers for backward compatibility.
+
+**Status thresholds:**
+
+| Score | Status | Color |
+|-------|--------|-------|
+| 80–100 | Safe | green |
+| 60–79 | Stable | blue |
+| 40–59 | Watch | yellow |
+| 20–39 | Risk | orange |
+| 0–19 | Critical | red |
+
+---
+
+### GET /api/v1/balance
+
+Current balance snapshot. A lightweight endpoint that returns only the
+latest balance record without running the projection engine. Ideal for
+widgets, notifications, and quick balance checks.
+
+**Auth required:** Yes (Bearer or session)
+
+**Response `200 OK`:**
+
+```json
+{
+  "data": {
+    "id": 1,
+    "amount": "5000.00",
+    "date": "2026-04-09"
+  }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | integer or `null` | Balance record ID; `null` if no balance exists |
+| `amount` | string (decimal) | Current balance, 2 decimal places |
+| `date` | string (date) | Date of the balance record |
+
+**No balance record:** When no balance has been set, the response returns
+`id: null`, `amount: "0.00"`, and `date` set to today's date.
+
+**Note:** This is a single-resource response (`"data": { ... }`) — there is
+no `meta` key. Use `/dashboard` if you also need risk score and projections.
+
+---
+
 ## Client Implementation Notes
 
 ### Token Storage
@@ -602,8 +745,12 @@ informational scores and ratios, not currency values.
 
 ### Empty States
 
-- `/schedules`, `/scenarios`, `/holds`, `/skips` — `data` will be `[]` with
-  `meta.total` of `0` when the user has no items.
+- `/schedules`, `/scenarios`, `/holds`, `/skips`, `/transactions` — `data`
+  will be `[]` with `meta.total` of `0` when the user has no items.
 - `/projections` — `schedule` will be `[]`; `scenario` will be `null`.
 - `/dashboard` — `upcoming_transactions` will be `[]`; `balance` defaults to
   `"0.00"` if no balance record exists.
+- `/balance` — returns `id: null`, `amount: "0.00"`, `date: "<today>"` when
+  no balance record exists.
+- `/risk-score` — always returns a valid score object; when no schedules
+  exist the score reflects a neutral assessment.

--- a/SAMPLE_PAYLOADS.md
+++ b/SAMPLE_PAYLOADS.md
@@ -381,6 +381,141 @@ curl https://your-server/api/v1/skips \
 
 ---
 
+### GET /api/v1/transactions
+
+Returns upcoming transactions expanded from recurring schedules (next 90 days), with holds and skips applied.
+
+**Request:**
+```bash
+curl https://your-server/api/v1/transactions \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response 200:**
+```json
+{
+  "data": [
+    {
+      "name": "Payroll",
+      "type": "Income",
+      "amount": "3500.00",
+      "date": "2026-04-15"
+    },
+    {
+      "name": "Rent",
+      "type": "Expense",
+      "amount": "1800.00",
+      "date": "2026-05-01"
+    },
+    {
+      "name": "Internet",
+      "type": "Expense",
+      "amount": "89.99",
+      "date": "2026-05-03"
+    }
+  ],
+  "meta": {
+    "total": 3
+  }
+}
+```
+
+**Response 200 (empty):**
+```json
+{
+  "data": [],
+  "meta": {
+    "total": 0
+  }
+}
+```
+
+---
+
+### GET /api/v1/risk-score
+
+Returns a detailed cash-flow risk assessment with monetary values as decimal strings.
+
+**Request:**
+```bash
+curl https://your-server/api/v1/risk-score \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response 200:**
+```json
+{
+  "data": {
+    "score": 82,
+    "status": "Safe",
+    "color": "green",
+    "runway_days": 45.3,
+    "lowest_balance": "2150.50",
+    "days_to_lowest": 28,
+    "avg_daily_expense": "110.75",
+    "days_below_threshold": 0,
+    "pct_below_threshold": 0.0,
+    "recovery_days": 0,
+    "near_term_buffer": "4200.00"
+  }
+}
+```
+
+**Response 200 (no schedules / fresh account):**
+```json
+{
+  "data": {
+    "score": 50,
+    "status": "Watch",
+    "color": "yellow",
+    "runway_days": 0,
+    "lowest_balance": "5000.00",
+    "days_to_lowest": 0,
+    "avg_daily_expense": "0.00",
+    "days_below_threshold": 0,
+    "pct_below_threshold": 0.0,
+    "recovery_days": null,
+    "near_term_buffer": "5000.00"
+  }
+}
+```
+
+---
+
+### GET /api/v1/balance
+
+Returns the current balance snapshot without running the projection engine.
+
+**Request:**
+```bash
+curl https://your-server/api/v1/balance \
+  -H "Authorization: Bearer <token>"
+```
+
+**Response 200:**
+```json
+{
+  "data": {
+    "id": 1,
+    "amount": "5000.00",
+    "date": "2026-04-09"
+  }
+}
+```
+
+**Response 200 (no balance record):**
+```json
+{
+  "data": {
+    "id": null,
+    "amount": "0.00",
+    "date": "2026-04-10"
+  }
+}
+```
+
+---
+
 ## Endpoint Summary
 
 | Method | Path | Auth | Description |
@@ -394,6 +529,9 @@ curl https://your-server/api/v1/skips \
 | GET | `/api/v1/scenarios` | Bearer | List what-if scenarios |
 | GET | `/api/v1/holds` | Bearer | List paused schedule items |
 | GET | `/api/v1/skips` | Bearer | List skipped transaction instances |
+| GET | `/api/v1/transactions` | Bearer | Upcoming transactions (next 90 days) |
+| GET | `/api/v1/risk-score` | Bearer | Detailed cash-flow risk assessment |
+| GET | `/api/v1/balance` | Bearer | Current balance snapshot |
 
 ## Notes for SwiftUI Clients
 

--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -8,6 +8,9 @@ GET   /api/v1/projections   Running-balance projection data points
 GET   /api/v1/scenarios     List what-if scenario items
 GET   /api/v1/holds         List held (paused) schedule items
 GET   /api/v1/skips         List skipped transaction instances
+GET   /api/v1/transactions  Upcoming transactions list (next 90 days)
+GET   /api/v1/risk-score    Detailed cash-flow risk assessment
+GET   /api/v1/balance       Current balance snapshot
 
 All endpoints require authentication via Bearer token or active session.
 """
@@ -236,3 +239,166 @@ def api_skips():
         [serialize_skip(s) for s in items],
         total=len(items),
     )
+
+
+# ── GET /api/v1/transactions ────────────────────────────────────────────────
+
+@api.route("/transactions", methods=["GET"])
+@api_login_required
+def api_transactions():
+    """Return upcoming transactions for the next 90 days.
+
+    Each transaction is an individual occurrence expanded from the user's
+    recurring schedules, with holds and skips applied.  This is the same
+    data shown on the web app's ``/transactions`` page.
+
+    Response 200::
+
+        {
+          "data": [
+            { "name": "Rent", "type": "Expense", "amount": "1200.00", "date": "2026-04-15" },
+            ...
+          ],
+          "meta": { "total": N }
+        }
+    """
+    user_id = _effective_user_id()
+
+    balance = Balance.query.filter_by(user_id=user_id).order_by(
+        desc(Balance.date), desc(Balance.id)
+    ).first()
+
+    try:
+        balance_amount = float(balance.amount)
+    except (ValueError, TypeError, AttributeError):
+        balance_amount = 0.0
+
+    schedules = Schedule.query.filter_by(user_id=user_id).all()
+    holds = Hold.query.filter_by(user_id=user_id).all()
+    skips = Skip.query.filter_by(user_id=user_id).all()
+    scenarios = Scenario.query.filter_by(user_id=user_id).all()
+
+    trans, _run, _run_scenario = update_cash(
+        balance_amount, schedules, holds, skips, scenarios
+    )
+
+    items = []
+    if not trans.empty:
+        for row in trans.itertuples(index=False):
+            items.append({
+                "name": row.name,
+                "type": row.type,
+                "amount": _amount(row.amount),
+                "date": _date(row.date),
+            })
+
+    return api_list(items, total=len(items))
+
+
+# ── GET /api/v1/risk-score ──────────────────────────────────────────────────
+
+@api.route("/risk-score", methods=["GET"])
+@api_login_required
+def api_risk_score():
+    """Return a detailed cash-flow risk assessment.
+
+    Provides the full risk-score breakdown computed by
+    ``calculate_cash_risk_score()``, with monetary values serialized as
+    decimal strings for consistency with the rest of the API.
+
+    Response 200::
+
+        {
+          "data": {
+            "score": 85,
+            "status": "Safe",
+            "color": "green",
+            "runway_days": 120.0,
+            "lowest_balance": "2500.00",
+            "days_to_lowest": 15,
+            "avg_daily_expense": "45.50",
+            "days_below_threshold": 0,
+            "pct_below_threshold": 0.0,
+            "recovery_days": 0,
+            "near_term_buffer": "3200.00"
+          }
+        }
+    """
+    user_id = _effective_user_id()
+
+    balance = Balance.query.filter_by(user_id=user_id).order_by(
+        desc(Balance.date), desc(Balance.id)
+    ).first()
+
+    try:
+        balance_amount = float(balance.amount)
+    except (ValueError, TypeError, AttributeError):
+        balance_amount = 0.0
+
+    schedules = Schedule.query.filter_by(user_id=user_id).all()
+    holds = Hold.query.filter_by(user_id=user_id).all()
+    skips = Skip.query.filter_by(user_id=user_id).all()
+    scenarios = Scenario.query.filter_by(user_id=user_id).all()
+
+    _trans, run, _run_scenario = update_cash(
+        balance_amount, schedules, holds, skips, scenarios
+    )
+
+    raw = calculate_cash_risk_score(balance_amount, run)
+
+    # Re-serialize monetary/float values as decimal strings for API consistency.
+    return api_ok({
+        "score": raw["score"],
+        "status": raw["status"],
+        "color": raw["color"],
+        "runway_days": raw["runway_days"],
+        "lowest_balance": _amount(raw["lowest_balance"]),
+        "days_to_lowest": raw["days_to_lowest"],
+        "avg_daily_expense": _amount(raw["avg_daily_expense"]),
+        "days_below_threshold": raw["days_below_threshold"],
+        "pct_below_threshold": raw["pct_below_threshold"],
+        "recovery_days": raw["recovery_days"],
+        "near_term_buffer": _amount(raw["near_term_buffer"]),
+    })
+
+
+# ── GET /api/v1/balance ─────────────────────────────────────────────────────
+
+@api.route("/balance", methods=["GET"])
+@api_login_required
+def api_balance():
+    """Return the current balance snapshot.
+
+    A lightweight endpoint that returns only the latest balance record
+    without running the projection engine.  Ideal for widgets and quick
+    balance checks.
+
+    Response 200::
+
+        {
+          "data": {
+            "id": 1,
+            "amount": "5000.00",
+            "date": "2026-04-09"
+          }
+        }
+
+    If no balance record exists, ``amount`` defaults to ``"0.00"`` and
+    ``date`` defaults to today.
+    """
+    user_id = _effective_user_id()
+
+    balance = Balance.query.filter_by(user_id=user_id).order_by(
+        desc(Balance.date), desc(Balance.id)
+    ).first()
+
+    if balance:
+        return api_ok(serialize_balance(balance))
+
+    # No balance record — return a sensible default.
+    todaydate = datetime.today().date()
+    return api_ok({
+        "id": None,
+        "amount": _amount(0),
+        "date": _date(todaydate),
+    })

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -7,6 +7,9 @@ Covers:
   - Schedules list endpoint
   - Projections endpoint returns schedule (and scenario) series
   - Scenarios, holds, skips list endpoints
+  - Transactions list endpoint
+  - Risk-score detailed assessment endpoint
+  - Balance snapshot endpoint
   - Response shapes follow API conventions (data key, meta key for lists)
 """
 
@@ -56,6 +59,9 @@ class TestDataEndpointsRequireAuth:
         "/api/v1/scenarios",
         "/api/v1/holds",
         "/api/v1/skips",
+        "/api/v1/transactions",
+        "/api/v1/risk-score",
+        "/api/v1/balance",
     ])
     def test_unauthenticated_returns_401(self, client, path):
         resp = client.get(path)
@@ -449,4 +455,273 @@ class TestGuestUserDataAccess:
         with flask_app.app_context():
             Schedule.query.filter_by(name="_test_owner_sched").delete()
             User.query.filter_by(email="_guest_api@test.local").delete()
+            _db.session.commit()
+
+
+# ── Transactions endpoint ──────────────────────────────────────────────────
+
+
+class TestTransactions:
+    """GET /api/v1/transactions returns upcoming expanded transactions."""
+
+    def test_transactions_returns_200(self, client):
+        token = _login(client)
+        resp = client.get("/api/v1/transactions", headers=_bearer(token))
+        assert resp.status_code == 200
+
+    def test_transactions_response_shape(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/transactions", headers=_bearer(token)))
+        assert "data" in body
+        assert isinstance(body["data"], list)
+        assert "meta" in body
+        assert "total" in body["meta"]
+
+    def test_transactions_reflects_schedule(self, flask_app, client):
+        """Upcoming transactions should include expanded schedule occurrences."""
+        with flask_app.app_context():
+            user = User.query.filter_by(email="admin@test.local").first()
+            future = date.today() + timedelta(days=7)
+            sched = Schedule(
+                user_id=user.id,
+                name="_test_txn_rent",
+                amount="1500.00",
+                frequency="Monthly",
+                startdate=future,
+                firstdate=future,
+                type="Expense",
+            )
+            _db.session.add(sched)
+            _db.session.commit()
+
+        token = _login(client)
+        body = _json(client.get("/api/v1/transactions", headers=_bearer(token)))
+        names = [t["name"] for t in body["data"]]
+        assert "_test_txn_rent" in names
+
+        # Verify each transaction has the expected fields
+        item = next(t for t in body["data"] if t["name"] == "_test_txn_rent")
+        assert item["amount"] == "1500.00"
+        assert item["type"] == "Expense"
+        assert "date" in item
+
+        # Clean up
+        with flask_app.app_context():
+            Schedule.query.filter_by(name="_test_txn_rent").delete()
+            _db.session.commit()
+
+    def test_transactions_empty_when_no_schedules(self, flask_app, client):
+        """With no schedules, the transaction list should be empty."""
+        with flask_app.app_context():
+            user = User.query.filter_by(email="admin@test.local").first()
+            # Temporarily clear all schedules
+            existing = Schedule.query.filter_by(user_id=user.id).all()
+            saved = [(s.name, s.amount, s.frequency, s.startdate, s.firstdate, s.type)
+                     for s in existing]
+            Schedule.query.filter_by(user_id=user.id).delete()
+            _db.session.commit()
+
+        token = _login(client)
+        body = _json(client.get("/api/v1/transactions", headers=_bearer(token)))
+        assert body["data"] == []
+        assert body["meta"]["total"] == 0
+
+        # Restore schedules
+        with flask_app.app_context():
+            user = User.query.filter_by(email="admin@test.local").first()
+            for name, amount, freq, start, first, typ in saved:
+                _db.session.add(Schedule(
+                    user_id=user.id, name=name, amount=amount,
+                    frequency=freq, startdate=start, firstdate=first, type=typ,
+                ))
+            _db.session.commit()
+
+    def test_transactions_via_session_auth(self, auth_client):
+        """Session-authenticated requests should also work."""
+        resp = auth_client.get("/api/v1/transactions")
+        assert resp.status_code == 200
+        body = _json(resp)
+        assert "data" in body
+        assert isinstance(body["data"], list)
+
+
+# ── Risk-score endpoint ────────────────────────────────────────────────────
+
+
+class TestRiskScore:
+    """GET /api/v1/risk-score returns a detailed risk assessment."""
+
+    def test_risk_score_returns_200(self, client):
+        token = _login(client)
+        resp = client.get("/api/v1/risk-score", headers=_bearer(token))
+        assert resp.status_code == 200
+
+    def test_risk_score_has_data_key(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/risk-score", headers=_bearer(token)))
+        assert "data" in body
+
+    def test_risk_score_contains_all_fields(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/risk-score", headers=_bearer(token)))
+        data = body["data"]
+        expected_keys = [
+            "score", "status", "color", "runway_days",
+            "lowest_balance", "days_to_lowest", "avg_daily_expense",
+            "days_below_threshold", "pct_below_threshold",
+            "recovery_days", "near_term_buffer",
+        ]
+        for key in expected_keys:
+            assert key in data, f"Missing key: {key}"
+
+    def test_risk_score_field_types(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/risk-score", headers=_bearer(token)))
+        data = body["data"]
+        # Integer fields
+        assert isinstance(data["score"], int)
+        assert isinstance(data["days_to_lowest"], int)
+        assert isinstance(data["days_below_threshold"], int)
+        # String fields
+        assert isinstance(data["status"], str)
+        assert isinstance(data["color"], str)
+        # Monetary values are decimal strings
+        assert isinstance(data["lowest_balance"], str)
+        assert "." in data["lowest_balance"]
+        assert isinstance(data["avg_daily_expense"], str)
+        assert "." in data["avg_daily_expense"]
+        assert isinstance(data["near_term_buffer"], str)
+        assert "." in data["near_term_buffer"]
+
+    def test_risk_score_valid_status(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/risk-score", headers=_bearer(token)))
+        assert body["data"]["status"] in ("Safe", "Stable", "Watch", "Risk", "Critical")
+
+    def test_risk_score_valid_range(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/risk-score", headers=_bearer(token)))
+        score = body["data"]["score"]
+        assert 0 <= score <= 100
+
+    def test_risk_score_via_session_auth(self, auth_client):
+        """Session-authenticated requests should also work."""
+        resp = auth_client.get("/api/v1/risk-score")
+        assert resp.status_code == 200
+        body = _json(resp)
+        assert "data" in body
+        assert "score" in body["data"]
+
+    def test_risk_score_with_expense(self, flask_app, client):
+        """Adding an expense schedule should affect the risk score."""
+        token = _login(client)
+
+        # Get baseline score
+        body_before = _json(client.get("/api/v1/risk-score", headers=_bearer(token)))
+        score_before = body_before["data"]["score"]
+
+        with flask_app.app_context():
+            user = User.query.filter_by(email="admin@test.local").first()
+            future = date.today() + timedelta(days=3)
+            sched = Schedule(
+                user_id=user.id,
+                name="_test_risk_expense",
+                amount="4000.00",
+                frequency="Monthly",
+                startdate=future,
+                firstdate=future,
+                type="Expense",
+            )
+            _db.session.add(sched)
+            _db.session.commit()
+
+        body_after = _json(client.get("/api/v1/risk-score", headers=_bearer(token)))
+        score_after = body_after["data"]["score"]
+
+        # A large expense relative to the balance should lower the risk score
+        assert score_after <= score_before
+
+        # Clean up
+        with flask_app.app_context():
+            Schedule.query.filter_by(name="_test_risk_expense").delete()
+            _db.session.commit()
+
+
+# ── Balance endpoint ───────────────────────────────────────────────────────
+
+
+class TestBalance:
+    """GET /api/v1/balance returns the current balance snapshot."""
+
+    def test_balance_returns_200(self, client):
+        token = _login(client)
+        resp = client.get("/api/v1/balance", headers=_bearer(token))
+        assert resp.status_code == 200
+
+    def test_balance_has_data_key(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/balance", headers=_bearer(token)))
+        assert "data" in body
+
+    def test_balance_contains_expected_fields(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/balance", headers=_bearer(token)))
+        data = body["data"]
+        assert "id" in data
+        assert "amount" in data
+        assert "date" in data
+
+    def test_balance_amount_is_decimal_string(self, client):
+        token = _login(client)
+        body = _json(client.get("/api/v1/balance", headers=_bearer(token)))
+        amount = body["data"]["amount"]
+        assert isinstance(amount, str)
+        assert "." in amount
+        # Should have exactly 2 decimal places
+        assert len(amount.split(".")[1]) == 2
+
+    def test_balance_reflects_seeded_data(self, client):
+        """The seeded balance from conftest should be 5000.00."""
+        token = _login(client)
+        body = _json(client.get("/api/v1/balance", headers=_bearer(token)))
+        assert body["data"]["amount"] == "5000.00"
+
+    def test_balance_no_meta_key(self, client):
+        """Balance is a single resource, not a collection — no meta key."""
+        token = _login(client)
+        body = _json(client.get("/api/v1/balance", headers=_bearer(token)))
+        assert "meta" not in body
+
+    def test_balance_via_session_auth(self, auth_client):
+        """Session-authenticated requests should also work."""
+        resp = auth_client.get("/api/v1/balance")
+        assert resp.status_code == 200
+        body = _json(resp)
+        assert "data" in body
+        assert "amount" in body["data"]
+
+    def test_balance_default_when_none(self, flask_app, client):
+        """When no balance record exists, return a sensible default."""
+        with flask_app.app_context():
+            # Create a user with no balance records
+            user2 = User(
+                email="_nobal@test.local",
+                password=generate_password_hash("nobalpass", method="scrypt"),
+                name="No Balance User",
+                admin=True,
+                is_active=True,
+            )
+            _db.session.add(user2)
+            _db.session.commit()
+
+        token = _login(client, email="_nobal@test.local", password="nobalpass")
+        body = _json(client.get("/api/v1/balance", headers=_bearer(token)))
+        data = body["data"]
+        assert data["id"] is None
+        assert data["amount"] == "0.00"
+        assert data["date"] is not None  # Should be today's date
+
+        # Clean up
+        with flask_app.app_context():
+            User.query.filter_by(email="_nobal@test.local").delete()
             _db.session.commit()


### PR DESCRIPTION
Extend the mobile API with three new read-only endpoints that reuse
existing business logic without requiring new infrastructure:

- GET /api/v1/transactions — upcoming transactions expanded from
  recurring schedules (next 90 days), with holds and skips applied
- GET /api/v1/risk-score — detailed risk assessment with monetary
  values properly serialized as decimal strings (fixes the raw float
  inconsistency in /dashboard's risk object)
- GET /api/v1/balance — lightweight current balance snapshot that
  skips the projection engine, suitable for widgets

Adds 24 new tests (197 total, all passing). Updates MOBILE_API_REFERENCE.md,
SAMPLE_PAYLOADS.md, and CODEX_HANDOFF.md.

https://claude.ai/code/session_01AM18XZ5h8qhVi4Kki8SMBD