### PR TITLE
Fix yearly start-date advancement never firing in commit mode

### DIFF
--- a/app/cashflow.py
+++ b/app/cashflow.py
@@ -82,7 +82,7 @@ def calc_schedule(schedules, holds, skips, scenarios=None, commit=True):
 
     months = 13
     weeks = 53
-    years = 1
+    years = 2
     quarters = 4
     biweeks = 27
 

--- a/tests/test_projection_engine.py
+++ b/tests/test_projection_engine.py
@@ -298,11 +298,11 @@ class TestCalcScheduleFrequencies:
         rows = total[total["name"] == "QuarterlyBonus"]
         assert len(rows) == 4
 
-    def test_yearly_schedule_produces_1_entry(self, app_ctx):
+    def test_yearly_schedule_produces_2_entries(self, app_ctx):
         s = make_schedule_obj("AnnualFee", 200, "Yearly", days_offset=10, type_="Expense")
         total, _ = calc_schedule([s], [], [], [])
         rows = total[total["name"] == "AnnualFee"]
-        assert len(rows) == 1
+        assert len(rows) == 2
 
     def test_onetime_future_produces_1_entry(self, app_ctx):
         s = make_schedule_obj("OneTimePurchase", 500, "Onetime", days_offset=10, type_="Expense")


### PR DESCRIPTION
With years=1, the window_delta passed to _fast_forward_start was
relativedelta(years=0), causing it to advance startdate past today.
The single-iteration loop (range(1)) then only saw a future date,
so the commit path (existing.startdate = ...) was never reached.
Changing years to 2 aligns yearly with other frequencies: the window
covers 1 year and the loop produces 2 points, allowing the commit
path to fire for overdue yearly schedules.

https://claude.ai/code/session_01B2SH2cknNuVFx3thtfckSf