### PR TITLE
Harden API auth and passkey flows: bearer-only writes, one-time 2FA, token revocation, and passkey enumeration fix

### DIFF
--- a/SECURITY_REVIEW_PASSKEY_API.md
+++ b/SECURITY_REVIEW_PASSKEY_API.md
@@ -1,0 +1,101 @@
+# Security Review: Passkey + REST API
+
+Date: 2026-04-10  
+Scope: `app/auth.py`, `app/api/*`, supporting auth/session wiring.
+
+## Executive summary
+
+I reviewed the new passkey and REST API authentication/data flows for common authn/authz, CSRF, replay, and account-enumeration issues.
+
+**Overall:** the implementation includes several good controls (hashed API tokens, challenge TTLs, RP/origin validation, user-verification-required passkeys), but there are some meaningful risks that should be addressed.
+
+## Findings
+
+### 1) Account enumeration in passkey login options (Medium)
+
+**Where**
+- `POST /passkey_login/options` returns a specific error when a user has no registered passkeys (or account is inactive/nonexistent).  
+  (`"No passkeys are registered for this account."`)
+
+**Why it matters**
+- This leaks account state to unauthenticated callers and can be used for targeted phishing/password-spraying prep.
+
+**Evidence**
+- `app/auth.py` `passkey_login_options()` distinguishes on user/passkey existence and returns specific message.
+
+**Recommendation**
+- Return a single generic response for all non-success cases (e.g., `{"error": "Unable to start passkey login."}`) and keep details in server logs only.
+
+---
+
+### 2) 2FA API challenge appears replayable within TTL (Medium)
+
+**Where**
+- API login challenge is signed+timestamped, but not server-side one-time tracked.
+- `_build_twofa_challenge()` includes a nonce, yet `_verify_twofa_challenge()` validates only signature+age and user id.
+
+**Why it matters**
+- If a challenge token is intercepted/leaked, it can be retried until expiry (5 minutes).
+- This is mitigated by TOTP freshness and rate limiting, but still weaker than one-time semantics.
+
+**Evidence**
+- `app/api/routes/auth.py`: `_build_twofa_challenge()` embeds `nonce`; `_verify_twofa_challenge()` does not consume/check nonce state.
+
+**Recommendation**
+- Persist challenge IDs/nonces server-side and mark them consumed on first valid attempt.
+- Optionally tie challenge to client metadata (e.g., UA hash) to reduce replay utility.
+
+---
+
+### 3) Password change does not revoke existing API tokens (High)
+
+**Where**
+- `PUT /api/v1/auth/password` updates password only.
+
+**Why it matters**
+- If bearer tokens are stolen, they remain valid after a password reset/change, allowing persistent account access until token expiry.
+
+**Evidence**
+- `app/api/routes/auth.py` `api_change_password()` commits new password but does not delete `UserToken` rows for that user.
+
+**Recommendation**
+- Revoke all active API tokens on password change (and ideally on 2FA/passkey disable/reset as well).
+
+---
+
+### 4) CSRF-exempt API + session-auth fallback increases blast radius (Medium)
+
+**Where**
+- API blueprint is CSRF-exempt globally.
+- `@api_login_required` accepts Flask session cookie fallback in addition to bearer token.
+- API includes many state-changing endpoints (`POST/PUT/DELETE`).
+
+**Why it matters**
+- Current cookie hardening (`SameSite=Lax`) reduces classic cross-site CSRF, but combining write-capable session auth with CSRF exemption is risky defense-in-depth-wise.
+- Any regression in cookie policy, same-site gadget, or browser quirk increases exposure.
+
+**Evidence**
+- `app/__init__.py`: `csrf.exempt(api_blueprint)`.
+- `app/api/auth_utils.py`: `api_login_required` accepts `current_user.is_authenticated` fallback.
+- `app/api/routes/data.py` and `app/api/routes/auth.py`: write endpoints use `@api_login_required`.
+
+**Recommendation**
+- Restrict session fallback to read-only API endpoints, or
+- require bearer tokens for mutating API routes, or
+- re-enable CSRF protection for session-authenticated API writes.
+
+## Positive controls observed
+
+- Passwords and backup codes use `scrypt` hashing.
+- API tokens are randomly generated and stored as SHA-256 hashes only.
+- Passkey verification requires expected origin + RP ID + user verification.
+- Passkey challenge TTL implemented for registration/login.
+- Login endpoint includes dummy hash behavior to reduce timing-based username enumeration.
+- Cookie flags are hardened (`HttpOnly`, `Secure` default, `SameSite=Lax`).
+
+## Suggested remediation order
+
+1. **High**: revoke all API tokens on password change.
+2. **Medium**: remove passkey account-state enumeration response differences.
+3. **Medium**: make API 2FA challenges one-time.
+4. **Medium**: reduce/remove session-auth writes on CSRF-exempt API.

--- a/app/api/auth_utils.py
+++ b/app/api/auth_utils.py
@@ -131,25 +131,33 @@ def get_api_user():
 
 # ── Decorator ─────────────────────────────────────────────────────────────────
 
-def api_login_required(f):
+def api_login_required(f=None, *, require_bearer: bool = False):
     """Require authentication via Bearer token or active Flask-Login session.
 
     On success, the authenticated user is available via ``get_api_user()``.
     On failure, returns a 401 JSON error.
     """
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        # 1. Bearer token takes precedence
-        user = _load_user_from_bearer()
-        if user is not None:
-            g.api_user = user
-            return f(*args, **kwargs)
+    def _decorate(func):
+        @wraps(func)
+        def decorated(*args, **kwargs):
+            # 1. Bearer token takes precedence
+            user = _load_user_from_bearer()
+            if user is not None:
+                g.api_user = user
+                return func(*args, **kwargs)
 
-        # 2. Session cookie fallback (Flask-Login)
-        if current_user.is_authenticated:
-            g.api_user = current_user._get_current_object()
-            return f(*args, **kwargs)
+            # 2. Optional session cookie fallback (Flask-Login)
+            if not require_bearer and current_user.is_authenticated:
+                g.api_user = current_user._get_current_object()
+                return func(*args, **kwargs)
 
-        return unauthorized()
+            if require_bearer:
+                return unauthorized("Bearer token required")
+            return unauthorized()
 
-    return decorated
+        return decorated
+
+    # Supports both @api_login_required and @api_login_required(require_bearer=True)
+    if f is None:
+        return _decorate
+    return _decorate(f)

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -7,7 +7,7 @@ from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from app import limiter, db
-from app.models import User
+from app.models import User, UserToken
 from app.auth import _DUMMY_HASH
 from app.totp_utils import decrypt_totp_secret, verify_totp, verify_and_consume_backup_code
 
@@ -25,10 +25,24 @@ from app.api.serializers import serialize_user
 
 
 _TWOFA_CHALLENGE_MAX_AGE_SECONDS = 300
+_CONSUMED_TWOFA_CHALLENGES: dict[str, datetime] = {}
 
 
 def _challenge_serializer() -> URLSafeTimedSerializer:
     return URLSafeTimedSerializer(current_app.config["SECRET_KEY"], salt="api-login-2fa")
+
+
+def _purge_expired_consumed_challenges(now: datetime | None = None) -> None:
+    now = now or datetime.now(timezone.utc)
+    expired = [token for token, expires_at in _CONSUMED_TWOFA_CHALLENGES.items() if expires_at <= now]
+    for token in expired:
+        _CONSUMED_TWOFA_CHALLENGES.pop(token, None)
+
+
+def _mark_twofa_challenge_consumed(challenge: str) -> None:
+    now = datetime.now(timezone.utc)
+    _purge_expired_consumed_challenges(now)
+    _CONSUMED_TWOFA_CHALLENGES[challenge] = now + timedelta(seconds=_TWOFA_CHALLENGE_MAX_AGE_SECONDS)
 
 
 def _build_twofa_challenge(user: User) -> str:
@@ -41,6 +55,10 @@ def _build_twofa_challenge(user: User) -> str:
 
 
 def _verify_twofa_challenge(challenge: str) -> User | None:
+    _purge_expired_consumed_challenges()
+    if challenge in _CONSUMED_TWOFA_CHALLENGES:
+        return None
+
     try:
         payload = _challenge_serializer().loads(
             challenge,
@@ -127,12 +145,13 @@ def api_login_2fa():
     if not twofa_ok:
         return unauthorized("Invalid verification code")
 
+    _mark_twofa_challenge_consumed(body["challenge"].strip())
     raw_token, _record = create_token_for_user(user)
     return api_ok({"token": raw_token, "user": serialize_user(user)})
 
 
 @api.route("/auth/refresh", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_refresh_token():
     auth_header = request.headers.get("Authorization", "")
     if not auth_header.startswith("Bearer "):
@@ -148,7 +167,7 @@ def api_refresh_token():
 
 
 @api.route("/auth/logout", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_logout():
     auth_header = request.headers.get("Authorization", "")
     if auth_header.startswith("Bearer "):
@@ -159,7 +178,7 @@ def api_logout():
 
 
 @api.route("/auth/password", methods=["PUT"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_change_password():
     user = get_api_user()
     if not user.admin:
@@ -180,6 +199,7 @@ def api_change_password():
         return unauthorized("Current password is incorrect")
 
     user.password = generate_password_hash(body["new_password"], method="scrypt")
+    UserToken.query.filter_by(user_id=user.id).delete(synchronize_session=False)
     db.session.commit()
     return api_ok({"message": "Password updated"})
 

--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -215,7 +215,7 @@ def api_schedules():
 
 
 @api.route("/schedules", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_create_schedule():
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -246,7 +246,7 @@ def api_create_schedule():
 
 
 @api.route("/schedules/<int:schedule_id>", methods=["PUT"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_update_schedule(schedule_id: int):
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -279,7 +279,7 @@ def api_update_schedule(schedule_id: int):
 
 
 @api.route("/schedules/<int:schedule_id>", methods=["DELETE"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_delete_schedule(schedule_id: int):
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -323,7 +323,7 @@ def api_scenarios():
 
 
 @api.route("/scenarios", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_create_scenario():
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -353,7 +353,7 @@ def api_create_scenario():
 
 
 @api.route("/scenarios/<int:scenario_id>", methods=["PUT"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_update_scenario(scenario_id: int):
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -386,7 +386,7 @@ def api_update_scenario(scenario_id: int):
 
 
 @api.route("/scenarios/<int:scenario_id>", methods=["DELETE"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_delete_scenario(scenario_id: int):
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -416,7 +416,7 @@ def api_holds():
 
 
 @api.route("/holds", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_create_hold():
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -438,7 +438,7 @@ def api_create_hold():
 
 
 @api.route("/holds/<int:hold_id>", methods=["DELETE"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_delete_hold(hold_id: int):
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -453,7 +453,7 @@ def api_delete_hold(hold_id: int):
 
 
 @api.route("/holds", methods=["DELETE"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_clear_holds():
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -481,7 +481,7 @@ def api_skips():
 
 
 @api.route("/skips", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_create_skip():
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -517,7 +517,7 @@ def api_create_skip():
 
 
 @api.route("/skips/<int:skip_id>", methods=["DELETE"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_delete_skip(skip_id: int):
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -532,7 +532,7 @@ def api_delete_skip(skip_id: int):
 
 
 @api.route("/skips", methods=["DELETE"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_clear_skips():
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -600,7 +600,7 @@ def api_balance():
 
 
 @api.route("/balance", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_set_balance():
     if (resp := _forbid_guest_writes()) is not None:
         return resp
@@ -695,7 +695,7 @@ def api_insights():
 
 
 @api.route("/insights/refresh", methods=["POST"])
-@api_login_required
+@api_login_required(require_bearer=True)
 def api_insights_refresh():
     if (resp := _forbid_guest_writes()) is not None:
         return resp

--- a/app/auth.py
+++ b/app/auth.py
@@ -290,11 +290,11 @@ def passkey_login_options():
     payload = request.get_json(silent=True) or {}
     email = (payload.get('email') or '').strip().lower()
     if not email:
-        return jsonify({"error": "Email is required."}), 400
+        return jsonify({"error": "Unable to start passkey login."}), 400
 
     user = User.query.filter_by(email=email).first()
     if not user or not user.is_active or not user.passkey_credentials:
-        return jsonify({"error": "No passkeys are registered for this account."}), 400
+        return jsonify({"error": "Unable to start passkey login."}), 400
 
     allow_credentials = [
         PublicKeyCredentialDescriptor(id=base64url_to_bytes(c.credential_id))

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -69,6 +69,21 @@ class TestDataEndpointsRequireAuth:
         body = _json(resp)
         assert body["code"] == "unauthorized"
 
+    def test_mutating_endpoint_requires_bearer_not_session(self, auth_client):
+        resp = auth_client.post(
+            "/api/v1/schedules",
+            json={
+                "name": "Session Write Attempt",
+                "amount": "10.00",
+                "type": "Expense",
+                "frequency": "Onetime",
+                "start_date": "2026-04-10",
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 401
+        assert _json(resp)["code"] == "unauthorized"
+
 
 # ── Dashboard endpoint ───────────────────────────────────────────────────────
 

--- a/tests/test_api_foundation.py
+++ b/tests/test_api_foundation.py
@@ -29,6 +29,7 @@ from app import db as _db
 from app.models import UserToken, User
 from app.api.serializers import serialize_balance, serialize_user, _amount, _date, _datetime
 from app.api.auth_utils import hash_token
+import app.api.routes.auth as api_auth_routes
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -401,6 +402,43 @@ class TestAuthEnhancements:
         ok = client.get("/api/v1/auth/me", headers=_bearer(new_token))
         assert ok.status_code == 200
 
+    def test_refresh_requires_bearer_even_with_session(self, auth_client):
+        resp = auth_client.post("/api/v1/auth/refresh")
+        assert resp.status_code == 401
+        assert _json(resp)["code"] == "unauthorized"
+
+    def test_logout_requires_bearer_even_with_session(self, auth_client):
+        resp = auth_client.post("/api/v1/auth/logout")
+        assert resp.status_code == 401
+        assert _json(resp)["code"] == "unauthorized"
+
+    def test_twofa_challenge_cannot_be_reused(self, flask_app, client, monkeypatch):
+        with flask_app.app_context():
+            user = User.query.filter_by(email="admin@test.local").first()
+            user.twofa_enabled = True
+            user.twofa_secret = "encrypted"
+            _db.session.commit()
+
+        try:
+            monkeypatch.setattr(api_auth_routes, "verify_totp", lambda _secret, _code: True)
+            monkeypatch.setattr(api_auth_routes, "decrypt_totp_secret", lambda _encrypted: "secret")
+
+            login_resp = _login(client)
+            assert login_resp.status_code == 200
+            challenge = _json(login_resp)["data"]["challenge"]
+
+            first = client.post("/api/v1/auth/login/2fa", json={"challenge": challenge, "code": "123456"})
+            assert first.status_code == 200
+
+            second = client.post("/api/v1/auth/login/2fa", json={"challenge": challenge, "code": "123456"})
+            assert second.status_code == 401
+        finally:
+            with flask_app.app_context():
+                user = User.query.filter_by(email="admin@test.local").first()
+                user.twofa_enabled = False
+                user.twofa_secret = None
+                _db.session.commit()
+
     def test_change_password(self, client):
         token = _json(_login(client))["data"]["token"]
         resp = client.put(
@@ -419,6 +457,32 @@ class TestAuthEnhancements:
         revert = client.put(
             "/api/v1/auth/password",
             headers=_bearer(new_token),
+            json={"current_password": "newpass1234", "new_password": "testpass123"},
+            content_type="application/json",
+        )
+        assert revert.status_code == 200
+
+    def test_change_password_revokes_all_existing_tokens(self, client):
+        token_a = _json(_login(client))["data"]["token"]
+        token_b = _json(_login(client))["data"]["token"]
+
+        change = client.put(
+            "/api/v1/auth/password",
+            headers=_bearer(token_a),
+            json={"current_password": "testpass123", "new_password": "newpass1234"},
+            content_type="application/json",
+        )
+        assert change.status_code == 200
+
+        revoked = client.get("/api/v1/auth/me", headers=_bearer(token_b))
+        assert revoked.status_code == 401
+
+        new_login = _login(client, password="newpass1234")
+        assert new_login.status_code == 200
+        rotate_token = _json(new_login)["data"]["token"]
+        revert = client.put(
+            "/api/v1/auth/password",
+            headers=_bearer(rotate_token),
             json={"current_password": "newpass1234", "new_password": "testpass123"},
             content_type="application/json",
         )

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -19,7 +19,7 @@ def test_passkey_login_options_requires_email(client, monkeypatch):
     resp = client.post("/passkey_login/options", json={})
 
     assert resp.status_code == 400
-    assert "Email is required" in resp.get_json()["error"]
+    assert "Unable to start passkey login." in resp.get_json()["error"]
 
 
 def test_passkey_login_verify_without_challenge_redirects(client, monkeypatch):


### PR DESCRIPTION
### Motivation

- Reduce attack surface by preventing session-cookie CSRF abuse for mutating API routes, close passkey account-enumeration leaks, and make 2FA challenges one-time to prevent replay.  
- Ensure password changes revoke long-lived API tokens to limit persistence of stolen credentials.  
- Capture and document a security review of the passkey + REST API flows.

### Description

- Added a security review document `SECURITY_REVIEW_PASSKEY_API.md` summarizing findings and recommended remediations.  
- Extended `api_login_required` in `app/api/auth_utils.py` to accept `require_bearer` (default false) so callers can force Bearer-only authentication for endpoints.  
- Marked mutating API endpoints (schedules, scenarios, holds, skips, balance, insights refresh, and auth refresh/logout/password) to require bearer tokens via `@api_login_required(require_bearer=True)`.  
- Implemented one-time 2FA challenge consumption in `app/api/routes/auth.py` with an in-memory consumed-challenge registry and purge logic, and mark a challenge consumed when used.  
- Revoke all `UserToken` rows for a user on password change in `api_change_password()` to invalidate existing API tokens.  
- Prevent account enumeration in passkey login setup by returning a single generic error message from `passkey_login_options()` in `app/auth.py` when email is missing or no passkeys exist.  
- Updated tests to assert the new behaviors and added tests that cover bearer-only mutating endpoints, 2FA challenge reuse prevention, token revocation on password change, and updated passkey error expectations.

### Testing

- Ran the test suite with the updated specs; focused tests include `tests/test_api_data.py::TestDataEndpointsRequireAuth::test_mutating_endpoint_requires_bearer_not_session`, `tests/test_api_foundation.py::TestAuthEnhancements` (refresh/logout/bearer checks, 2FA challenge reuse, password revocation), and `tests/test_passkey_auth.py::test_passkey_login_options_requires_email`, and all ran successfully.  
- Full `pytest` run completed with all modified and added tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d853938b5c8320a021420e7486a219)