### PR TITLE
Harden API validators for non-string payload fields

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -117,18 +117,22 @@ def api_login():
 def api_login_2fa():
     body = request.get_json(silent=True) or {}
     errors: dict = {}
-    if not body.get("challenge", "").strip():
+    challenge_raw = body.get("challenge")
+    challenge = challenge_raw.strip() if isinstance(challenge_raw, str) else ""
+    if not challenge:
         errors["challenge"] = "Challenge is required"
-    if not body.get("code", "").strip():
+    code_raw = body.get("code")
+    code = code_raw.strip() if isinstance(code_raw, str) else ""
+    if not code:
         errors["code"] = "Code is required"
     if errors:
         return validation_error(errors)
 
-    user = _verify_twofa_challenge(body["challenge"].strip())
+    user = _verify_twofa_challenge(challenge)
     if user is None or not user.is_active or not user.twofa_enabled:
         return unauthorized("Invalid or expired 2FA challenge")
 
-    submitted = body["code"].strip()
+    submitted = code
     twofa_ok = False
 
     try:
@@ -145,7 +149,7 @@ def api_login_2fa():
     if not twofa_ok:
         return unauthorized("Invalid verification code")
 
-    _mark_twofa_challenge_consumed(body["challenge"].strip())
+    _mark_twofa_challenge_consumed(challenge)
     raw_token, _record = create_token_for_user(user)
     return api_ok({"token": raw_token, "user": serialize_user(user)})
 

--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -80,7 +80,8 @@ def _parse_limit_offset():
 
 def _validate_schedule_payload(body: dict) -> dict:
     errors = {}
-    name = (body.get("name") or "").strip()
+    name_raw = body.get("name")
+    name = name_raw.strip() if isinstance(name_raw, str) else ""
     if not name or len(name) > _MAX_NAME_LEN:
         errors["name"] = f"Name must be between 1 and {_MAX_NAME_LEN} characters"
 
@@ -116,7 +117,7 @@ def _validate_balance_payload(body: dict) -> dict:
     if date_val:
         try:
             datetime.strptime(date_val, "%Y-%m-%d")
-        except ValueError:
+        except (TypeError, ValueError):
             errors["date"] = "date must be YYYY-MM-DD"
     return errors
 

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -802,6 +802,38 @@ class TestWriteEndpoints:
         assert "meta" in body
         assert "limit" in body["meta"]
 
+    def test_create_schedule_rejects_non_string_name(self, client):
+        token = _login(client)
+        resp = client.post(
+            "/api/v1/schedules",
+            headers=_bearer(token),
+            json={
+                "name": 123,
+                "amount": "50.00",
+                "type": "Expense",
+                "frequency": "Monthly",
+                "start_date": date.today().isoformat(),
+            },
+            content_type="application/json",
+        )
+        assert resp.status_code == 422
+        body = _json(resp)
+        assert body["code"] == "validation_error"
+        assert "name" in body["fields"]
+
+    def test_balance_post_rejects_non_string_date(self, client):
+        token = _login(client)
+        resp = client.post(
+            "/api/v1/balance",
+            headers=_bearer(token),
+            json={"amount": "999.00", "date": 123},
+            content_type="application/json",
+        )
+        assert resp.status_code == 422
+        body = _json(resp)
+        assert body["code"] == "validation_error"
+        assert "date" in body["fields"]
+
     def test_settings_and_insights_read(self, client):
         token = _login(client)
         settings = client.get("/api/v1/settings", headers=_bearer(token))

--- a/tests/test_api_foundation.py
+++ b/tests/test_api_foundation.py
@@ -439,6 +439,14 @@ class TestAuthEnhancements:
                 user.twofa_secret = None
                 _db.session.commit()
 
+    def test_login_2fa_validation_rejects_non_string_fields(self, client):
+        resp = client.post("/api/v1/auth/login/2fa", json={"challenge": 123, "code": 456})
+        assert resp.status_code == 422
+        body = _json(resp)
+        assert body["code"] == "validation_error"
+        assert "challenge" in body["fields"]
+        assert "code" in body["fields"]
+
     def test_change_password(self, client):
         token = _json(_login(client))["data"]["token"]
         resp = client.put(


### PR DESCRIPTION
### Motivation
- Prevent API handlers from raising `AttributeError`/`TypeError` when clients send non-string JSON types for string/date fields. 
- Ensure malformed client input consistently returns a 422 `validation_error` instead of a 500, preserving the API contract.

### Description
- Guarded schedule name parsing in `app/api/routes/data.py` by checking `isinstance(name_raw, str)` before calling `.strip()` and treating non-strings as invalid names. 
- Broadened balance date validation in `app/api/routes/data.py` to catch both `TypeError` and `ValueError` from `datetime.strptime`. 
- Hardened `/api/v1/auth/login/2fa` in `app/api/routes/auth.py` by validating and normalizing `challenge` and `code` as strings before `.strip()`, and reusing the sanitized values for verification and consumption. 
- Added regression tests in `tests/test_api_foundation.py` and `tests/test_api_data.py` that assert 422 responses for non-string `challenge`/`code`, schedule `name`, and balance `date` payloads.

### Testing
- Ran the added regression tests: `python -m pytest -q tests/test_api_foundation.py::TestAuthEnhancements::test_login_2fa_validation_rejects_non_string_fields tests/test_api_data.py::TestWriteEndpoints::test_create_schedule_rejects_non_string_name tests/test_api_data.py::TestWriteEndpoints::test_balance_post_rejects_non_string_date`.
- All listed tests passed (`3 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8560b3f248320bed8d84fca470472)