### PR TITLE
Fix 2FA challenge race conditions and exclude iOS app from Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ __pycache__/
 *.pyc
 *.pyo
 .env
+ios-app/

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -1,6 +1,7 @@
 """API v1 authentication routes."""
 
 from datetime import datetime, timedelta, timezone
+from threading import Lock
 
 from flask import current_app, request
 from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
@@ -26,6 +27,7 @@ from app.api.serializers import serialize_user
 
 _TWOFA_CHALLENGE_MAX_AGE_SECONDS = 300
 _CONSUMED_TWOFA_CHALLENGES: dict[str, datetime] = {}
+_CONSUMED_TWOFA_CHALLENGES_LOCK = Lock()
 
 
 def _challenge_serializer() -> URLSafeTimedSerializer:
@@ -34,15 +36,31 @@ def _challenge_serializer() -> URLSafeTimedSerializer:
 
 def _purge_expired_consumed_challenges(now: datetime | None = None) -> None:
     now = now or datetime.now(timezone.utc)
-    expired = [token for token, expires_at in _CONSUMED_TWOFA_CHALLENGES.items() if expires_at <= now]
+    expired = [
+        token
+        for token, expires_at in _CONSUMED_TWOFA_CHALLENGES.items()
+        if expires_at <= now
+    ]
     for token in expired:
         _CONSUMED_TWOFA_CHALLENGES.pop(token, None)
 
 
-def _mark_twofa_challenge_consumed(challenge: str) -> None:
+def _is_twofa_challenge_consumed(challenge: str) -> bool:
+    with _CONSUMED_TWOFA_CHALLENGES_LOCK:
+        _purge_expired_consumed_challenges()
+        return challenge in _CONSUMED_TWOFA_CHALLENGES
+
+
+def _try_mark_twofa_challenge_consumed(challenge: str) -> bool:
     now = datetime.now(timezone.utc)
-    _purge_expired_consumed_challenges(now)
-    _CONSUMED_TWOFA_CHALLENGES[challenge] = now + timedelta(seconds=_TWOFA_CHALLENGE_MAX_AGE_SECONDS)
+    with _CONSUMED_TWOFA_CHALLENGES_LOCK:
+        _purge_expired_consumed_challenges(now)
+        if challenge in _CONSUMED_TWOFA_CHALLENGES:
+            return False
+        _CONSUMED_TWOFA_CHALLENGES[challenge] = now + timedelta(
+            seconds=_TWOFA_CHALLENGE_MAX_AGE_SECONDS
+        )
+        return True
 
 
 def _build_twofa_challenge(user: User) -> str:
@@ -55,8 +73,7 @@ def _build_twofa_challenge(user: User) -> str:
 
 
 def _verify_twofa_challenge(challenge: str) -> User | None:
-    _purge_expired_consumed_challenges()
-    if challenge in _CONSUMED_TWOFA_CHALLENGES:
+    if _is_twofa_challenge_consumed(challenge):
         return None
 
     try:
@@ -149,7 +166,8 @@ def api_login_2fa():
     if not twofa_ok:
         return unauthorized("Invalid verification code")
 
-    _mark_twofa_challenge_consumed(challenge)
+    if not _try_mark_twofa_challenge_consumed(challenge):
+        return unauthorized("Invalid or expired 2FA challenge")
     raw_token, _record = create_token_for_user(user)
     return api_ok({"token": raw_token, "user": serialize_user(user)})
 

--- a/tests/test_api_foundation.py
+++ b/tests/test_api_foundation.py
@@ -371,6 +371,14 @@ class TestSerializers:
 
 
 class TestAuthEnhancements:
+    def test_twofa_challenge_mark_consumed_is_single_use(self):
+        challenge = "challenge-token"
+        with api_auth_routes._CONSUMED_TWOFA_CHALLENGES_LOCK:
+            api_auth_routes._CONSUMED_TWOFA_CHALLENGES.clear()
+
+        assert api_auth_routes._try_mark_twofa_challenge_consumed(challenge) is True
+        assert api_auth_routes._try_mark_twofa_challenge_consumed(challenge) is False
+
     def test_login_twofa_required_returns_challenge(self, flask_app, client):
         with flask_app.app_context():
             user = User.query.filter_by(email="admin@test.local").first()


### PR DESCRIPTION
### Motivation
- Prevent a race where concurrent `/api/v1/auth/login/2fa` requests could both pass the consumed-challenge check and mint multiple bearer tokens from a single one-time challenge.
- Avoid unsynchronized iteration/mutation of the in-memory consumed-challenge map which can raise runtime errors under concurrent traffic.
- Keep the iOS client out of the backend Docker build context to avoid sending unnecessary sources into the container.

### Description
- Added a `Lock` (`_CONSUMED_TWOFA_CHALLENGES_LOCK`) and synchronized helper functions to guard the in-memory `_CONSUMED_TWOFA_CHALLENGES` map in `app/api/routes/auth.py`.
- Replaced the non-atomic mark operation with `_try_mark_twofa_challenge_consumed(challenge: str) -> bool` that purges expired entries and atomically records a consumed challenge only if not already present, and added `_is_twofa_challenge_consumed` for synchronized checks.
- Gated token issuance in `api_login_2fa` on the atomic `_try_mark_twofa_challenge_consumed` result so only one request can consume a challenge and obtain a token.
- Added a unit test `test_twofa_challenge_mark_consumed_is_single_use` to `tests/test_api_foundation.py` that verifies the new helper is single-use, and updated `.dockerignore` to include `ios-app/`.

### Testing
- Ran the targeted tests with `python -m pytest -q tests/test_api_foundation.py::TestAuthEnhancements::test_twofa_challenge_mark_consumed_is_single_use tests/test_api_foundation.py::TestAuthEnhancements::test_twofa_challenge_cannot_be_reused` which passed (2 passed).
- Ran the full test suite with `python -m pytest -q` which succeeded (`215 passed`, `41 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d856f1183083208c8317b7fd93fb16)