### PR TITLE
Align iOS SwiftUI styling with web CSS theme

### DIFF
--- a/ios-app/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/PyCashFlowApp/App/RootView.swift
@@ -11,5 +11,6 @@ struct RootView: View {
                 LoginView()
             }
         }
+        .preferredColorScheme(.dark)
     }
 }

--- a/ios-app/PyCashFlowApp/Core/Theme/AppTheme.swift
+++ b/ios-app/PyCashFlowApp/Core/Theme/AppTheme.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+/// Shared visual style aligned to the web app's `improved.css` palette.
+enum AppTheme {
+    // Web parity colors from CSS variables in app/static/css/improved.css.
+    static let secondaryDark = Color(red: 15/255, green: 23/255, blue: 42/255)   // #0f172a
+    static let primaryDark = Color(red: 30/255, green: 41/255, blue: 59/255)      // #1e293b
+    static let surface = Color(red: 51/255, green: 65/255, blue: 85/255)          // #334155
+    static let surfaceLight = Color(red: 71/255, green: 85/255, blue: 105/255)    // #475569
+
+    static let accent = Color(red: 59/255, green: 130/255, blue: 246/255)         // #3b82f6
+    static let accentHover = Color(red: 37/255, green: 99/255, blue: 235/255)     // #2563eb
+
+    static let success = Color(red: 16/255, green: 185/255, blue: 129/255)        // #10b981
+    static let danger = Color(red: 239/255, green: 68/255, blue: 68/255)          // #ef4444
+
+    static let textPrimary = Color(red: 241/255, green: 245/255, blue: 249/255)   // #f1f5f9
+    static let textSecondary = Color(red: 203/255, green: 213/255, blue: 225/255) // #cbd5e1
+    static let textMuted = Color(red: 148/255, green: 163/255, blue: 184/255)     // #94a3b8
+
+    static let border = Color(red: 71/255, green: 85/255, blue: 105/255)          // #475569
+
+    static let pageGradient = LinearGradient(
+        colors: [secondaryDark, primaryDark],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+    )
+}
+
+struct AppBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        ZStack {
+            AppTheme.pageGradient
+                .ignoresSafeArea()
+            content
+        }
+        .tint(AppTheme.accent)
+    }
+}
+
+struct SurfaceCard: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding(16)
+            .background(AppTheme.surface.opacity(0.9), in: RoundedRectangle(cornerRadius: 12))
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(AppTheme.border.opacity(0.9), lineWidth: 1)
+            )
+    }
+}
+
+struct PrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .fontWeight(.semibold)
+            .foregroundStyle(AppTheme.textPrimary)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(configuration.isPressed ? AppTheme.accentHover : AppTheme.accent)
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+            .opacity(configuration.isPressed ? 0.95 : 1)
+    }
+}
+
+extension View {
+    func appBackground() -> some View { modifier(AppBackground()) }
+    func surfaceCard() -> some View { modifier(SurfaceCard()) }
+}

--- a/ios-app/PyCashFlowApp/Features/Accounts/AccountsView.swift
+++ b/ios-app/PyCashFlowApp/Features/Accounts/AccountsView.swift
@@ -2,7 +2,18 @@ import SwiftUI
 
 struct AccountsView: View {
     var body: some View {
-        Text("Accounts")
-            .navigationTitle("Accounts")
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Accounts")
+                .font(.title2.bold())
+                .foregroundStyle(AppTheme.textPrimary)
+            Text("Account screens will follow the web app surface and typography style.")
+                .foregroundStyle(AppTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(20)
+        .appBackground()
+        .navigationTitle("Accounts")
+        .toolbarBackground(AppTheme.secondaryDark, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
     }
 }

--- a/ios-app/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -2,13 +2,49 @@ import SwiftUI
 
 struct DashboardView: View {
     var body: some View {
-        List {
-            NavigationLink("Accounts", destination: AccountsView())
-            NavigationLink("Projections", destination: ProjectionsView())
-            NavigationLink("Schedules", destination: SchedulesView())
-            NavigationLink("Scenarios", destination: ScenariosView())
-            NavigationLink("Settings", destination: SettingsView())
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Dashboard")
+                    .font(.largeTitle.bold())
+                    .foregroundStyle(AppTheme.textPrimary)
+
+                Text("Use the same workflow as the web app sections below.")
+                    .foregroundStyle(AppTheme.textSecondary)
+
+                VStack(spacing: 10) {
+                    navRow("Accounts", systemImage: "creditcard", destination: AccountsView())
+                    navRow("Projections", systemImage: "chart.line.uptrend.xyaxis", destination: ProjectionsView())
+                    navRow("Schedules", systemImage: "calendar", destination: SchedulesView())
+                    navRow("Scenarios", systemImage: "slider.horizontal.3", destination: ScenariosView())
+                    navRow("Settings", systemImage: "gearshape", destination: SettingsView())
+                }
+            }
+            .padding(20)
         }
+        .appBackground()
         .navigationTitle("Dashboard")
+        .toolbarBackground(AppTheme.secondaryDark, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+    }
+
+    private func navRow<Destination: View>(
+        _ title: String,
+        systemImage: String,
+        destination: Destination
+    ) -> some View {
+        NavigationLink(destination: destination) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .foregroundStyle(AppTheme.accent)
+                    .frame(width: 20)
+                Text(title)
+                    .foregroundStyle(AppTheme.textPrimary)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(AppTheme.textMuted)
+            }
+            .surfaceCard()
+        }
     }
 }

--- a/ios-app/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/PyCashFlowApp/Features/Login/LoginView.swift
@@ -7,16 +7,49 @@ struct LoginView: View {
     @State private var errorText: String?
 
     var body: some View {
-        Form {
-            TextField("Email", text: $email)
-                .textInputAutocapitalization(.never)
-            SecureField("Password", text: $password)
-            if let errorText { Text(errorText).foregroundStyle(.red) }
-            Button("Login") {
-                Task { await login() }
+        ScrollView {
+            VStack(spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("PyCashFlow")
+                        .font(.largeTitle.bold())
+                        .foregroundStyle(AppTheme.textPrimary)
+                    Text("Sign in to continue")
+                        .foregroundStyle(AppTheme.textSecondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(spacing: 12) {
+                    TextField("Email", text: $email)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .padding(12)
+                        .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+                        .foregroundStyle(AppTheme.textPrimary)
+
+                    SecureField("Password", text: $password)
+                        .padding(12)
+                        .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+                        .foregroundStyle(AppTheme.textPrimary)
+
+                    if let errorText {
+                        Text(errorText)
+                            .foregroundStyle(AppTheme.danger)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    Button("Login") {
+                        Task { await login() }
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                }
+                .surfaceCard()
             }
+            .padding(20)
         }
+        .appBackground()
         .navigationTitle("Login")
+        .toolbarBackground(AppTheme.secondaryDark, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
     }
 
     private func login() async {

--- a/ios-app/PyCashFlowApp/Features/Projections/ProjectionsView.swift
+++ b/ios-app/PyCashFlowApp/Features/Projections/ProjectionsView.swift
@@ -2,7 +2,18 @@ import SwiftUI
 
 struct ProjectionsView: View {
     var body: some View {
-        Text("Projections")
-            .navigationTitle("Projections")
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Projections")
+                .font(.title2.bold())
+                .foregroundStyle(AppTheme.textPrimary)
+            Text("Projection views now use the same dark palette as the web app.")
+                .foregroundStyle(AppTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(20)
+        .appBackground()
+        .navigationTitle("Projections")
+        .toolbarBackground(AppTheme.secondaryDark, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
     }
 }

--- a/ios-app/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -2,7 +2,18 @@ import SwiftUI
 
 struct ScenariosView: View {
     var body: some View {
-        Text("Scenarios")
-            .navigationTitle("Scenarios")
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Scenarios")
+                .font(.title2.bold())
+                .foregroundStyle(AppTheme.textPrimary)
+            Text("Scenario screens now use matching slate surfaces and blue accents.")
+                .foregroundStyle(AppTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(20)
+        .appBackground()
+        .navigationTitle("Scenarios")
+        .toolbarBackground(AppTheme.secondaryDark, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
     }
 }

--- a/ios-app/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -2,7 +2,18 @@ import SwiftUI
 
 struct SchedulesView: View {
     var body: some View {
-        Text("Schedules")
-            .navigationTitle("Schedules")
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Schedules")
+                .font(.title2.bold())
+                .foregroundStyle(AppTheme.textPrimary)
+            Text("Schedule screens now align with the web color tokens and contrast.")
+                .foregroundStyle(AppTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(20)
+        .appBackground()
+        .navigationTitle("Schedules")
+        .toolbarBackground(AppTheme.secondaryDark, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
     }
 }

--- a/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -2,7 +2,18 @@ import SwiftUI
 
 struct SettingsView: View {
     var body: some View {
-        Text("Settings")
-            .navigationTitle("Settings")
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Settings")
+                .font(.title2.bold())
+                .foregroundStyle(AppTheme.textPrimary)
+            Text("Settings follows the same visual language as web (dark theme + card surfaces).")
+                .foregroundStyle(AppTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding(20)
+        .appBackground()
+        .navigationTitle("Settings")
+        .toolbarBackground(AppTheme.secondaryDark, for: .navigationBar)
+        .toolbarColorScheme(.dark, for: .navigationBar)
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure the iOS SwiftUI client visually matches the web app by reusing the same dark palette, surfaces, and accent tokens from the web CSS.
- Provide shared UI primitives so screens use consistent background, card, and button styles across the mobile app.
- Improve perceived parity for users switching between web and mobile by making navigation and form surfaces match the web look-and-feel.

### Description
- Added a shared theme file `ios-app/PyCashFlowApp/Core/Theme/AppTheme.swift` that maps color tokens from `app/static/css/improved.css` and provides `AppBackground`, `SurfaceCard`, and `PrimaryButtonStyle` modifiers.
- Forced dark appearance at the app root by setting `.preferredColorScheme(.dark)` in `ios-app/PyCashFlowApp/App/RootView.swift` to match the web dark baseline.
- Restyled `LoginView` and `DashboardView` to use the new theme, including gradient background, card surfaces, accent icons/buttons, and dark navigation styling while preserving existing login behavior and API calls.
- Updated placeholder screens (`AccountsView`, `ProjectionsView`, `SchedulesView`, `ScenariosView`, `SettingsView`) to adopt the themed background, typography tokens, and dark navigation bar for consistent presentation.

### Testing
- Ran the full test suite with `python -m pytest -q`, which completed successfully with `215 passed` and reported warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d87bd5524483208e7978c3eef81677)