### PR TITLE
iOS: Fix API query encoding, clear session on password change, and store token in Keychain

### DIFF
--- a/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -1,7 +1,8 @@
 import Foundation
+import Security
 
 final class SessionManager: ObservableObject {
-    @Published var token: String? = UserDefaults.standard.string(forKey: "api_token")
+    @Published var token: String? = TokenKeychainStore.readToken()
     @Published var user: UserDTO?
 
     var isAuthenticated: Bool { token != nil }
@@ -9,12 +10,60 @@ final class SessionManager: ObservableObject {
     func setSession(token: String, user: UserDTO) {
         self.token = token
         self.user = user
-        UserDefaults.standard.set(token, forKey: "api_token")
+        TokenKeychainStore.saveToken(token)
+        UserDefaults.standard.removeObject(forKey: "api_token")
     }
 
     func clear() {
         token = nil
         user = nil
+        TokenKeychainStore.deleteToken()
         UserDefaults.standard.removeObject(forKey: "api_token")
+    }
+}
+
+private enum TokenKeychainStore {
+    private static let service = "PyCashFlow"
+    private static let account = "api_token"
+
+    static func saveToken(_ token: String) {
+        guard let data = token.data(using: .utf8) else { return }
+        deleteToken()
+
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecValueData as String: data
+        ]
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    static func readToken() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        var item: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &item)
+        guard status == errSecSuccess,
+              let data = item as? Data,
+              let token = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return token
+    }
+
+    static func deleteToken() {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
+        ]
+        SecItemDelete(query as CFDictionary)
     }
 }

--- a/ios-app/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -7,11 +7,26 @@ final class APIClient {
     func request<T: Decodable>(
         _ path: String,
         method: String = "GET",
+        queryItems: [URLQueryItem] = [],
         token: String? = nil,
         body: Encodable? = nil,
         as: T.Type
     ) async throws -> T {
-        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        let endpoint = baseURL.appendingPathComponent(path)
+        var components = URLComponents(url: endpoint, resolvingAgainstBaseURL: false)
+        if !queryItems.isEmpty {
+            components?.queryItems = queryItems
+        }
+        guard let requestURL = components?.url else {
+            throw APIErrorEnvelope(
+                error: "Invalid request URL",
+                code: "invalid_request_url",
+                status: 500,
+                fields: nil
+            )
+        }
+
+        var request = URLRequest(url: requestURL)
         request.httpMethod = method
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         if let token {

--- a/ios-app/PyCashFlowApp/Features/Accounts/AccountsView.swift
+++ b/ios-app/PyCashFlowApp/Features/Accounts/AccountsView.swift
@@ -53,7 +53,15 @@ struct AccountsView: View {
         guard let token = session.token else { return }
         do {
             async let current: APIEnvelope<BalanceDTO> = APIClient.shared.request("balance", token: token, as: APIEnvelope<BalanceDTO>.self)
-            async let list: APIListEnvelope<BalanceDTO> = APIClient.shared.request("balance/history?limit=20&offset=0", token: token, as: APIListEnvelope<BalanceDTO>.self)
+            async let list: APIListEnvelope<BalanceDTO> = APIClient.shared.request(
+                "balance/history",
+                queryItems: [
+                    URLQueryItem(name: "limit", value: "20"),
+                    URLQueryItem(name: "offset", value: "0")
+                ],
+                token: token,
+                as: APIListEnvelope<BalanceDTO>.self
+            )
             let (currentRes, listRes) = try await (current, list)
             await MainActor.run {
                 balance = currentRes.data

--- a/ios-app/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -59,7 +59,15 @@ struct ScenariosView: View {
     private func load() async {
         guard let token = session.token else { return }
         do {
-            let response: APIListEnvelope<ScenarioDTO> = try await APIClient.shared.request("scenarios?limit=100&offset=0", token: token, as: APIListEnvelope<ScenarioDTO>.self)
+            let response: APIListEnvelope<ScenarioDTO> = try await APIClient.shared.request(
+                "scenarios",
+                queryItems: [
+                    URLQueryItem(name: "limit", value: "100"),
+                    URLQueryItem(name: "offset", value: "0")
+                ],
+                token: token,
+                as: APIListEnvelope<ScenarioDTO>.self
+            )
             await MainActor.run { scenarios = response.data }
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load scenarios" }

--- a/ios-app/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -59,7 +59,15 @@ struct SchedulesView: View {
     private func load() async {
         guard let token = session.token else { return }
         do {
-            let response: APIListEnvelope<ScheduleDTO> = try await APIClient.shared.request("schedules?limit=100&offset=0", token: token, as: APIListEnvelope<ScheduleDTO>.self)
+            let response: APIListEnvelope<ScheduleDTO> = try await APIClient.shared.request(
+                "schedules",
+                queryItems: [
+                    URLQueryItem(name: "limit", value: "100"),
+                    URLQueryItem(name: "offset", value: "0")
+                ],
+                token: token,
+                as: APIListEnvelope<ScheduleDTO>.self
+            )
             await MainActor.run { schedules = response.data }
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load schedules" }

--- a/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -90,7 +90,11 @@ struct SettingsView: View {
                 body: Payload(current_password: currentPassword, new_password: newPassword),
                 as: APIEnvelope<[String: String]>.self
             )
-            await MainActor.run { currentPassword = ""; newPassword = "" }
+            await MainActor.run {
+                currentPassword = ""
+                newPassword = ""
+                session.clear()
+            }
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to change password" }
         }


### PR DESCRIPTION
### Motivation
- Client code was embedding query strings in path arguments which caused `%3F`-encoded routes and 404s when `URL.appendingPathComponent` was used. 
- After a successful password change the backend invalidates tokens but the app kept the old bearer token, leaving the UI appearing authenticated while API calls returned 401. 
- The bearer token was persisted in `UserDefaults`, exposing long-lived credentials in plaintext.

### Description
- Added a `queryItems` parameter to `APIClient.request` and build URLs using `URLComponents` so query parameters are appended correctly instead of being embedded in the path. 
- Updated `SchedulesView`, `ScenariosView`, and `AccountsView` to pass query parameters as `URLQueryItem` instances rather than including `?limit=...&offset=...` in the path. 
- Modified the password-change flow in `SettingsView` to call `session.clear()` after a successful password update so the client does not continue using an invalidated token. 
- Replaced `UserDefaults` token storage with a small `TokenKeychainStore` helper using the `Security` API and migrated cleanup of the legacy `api_token` `UserDefaults` key in `SessionManager`.

### Testing
- Ran `python -m pytest -q` and all backend tests passed: `215 passed, 41 warnings`. 
- Ran a quick search to ensure no remaining calls embed `?` in `request` paths with `rg` and found no matches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d881221ec0832090ab42d23ac352bf)