### PR TITLE
Fix iOS session token fallback when keychain persistence fails

### DIFF
--- a/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -12,6 +12,8 @@ final class SessionManager: ObservableObject {
         self.user = user
         if TokenKeychainStore.saveToken(token) {
             UserDefaults.standard.removeObject(forKey: "api_token")
+        } else {
+            UserDefaults.standard.set(token, forKey: "api_token")
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent a stale legacy `api_token` in `UserDefaults` from being reloaded on next launch after a login when keychain persistence fails, which could cause repeated unauthorized or wrong-session behavior.

### Description
- Update `SessionManager.setSession` in `ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift` to write the freshly issued token into legacy `UserDefaults` (`api_token`) when `TokenKeychainStore.saveToken` returns `false`, while retaining the existing removal of the legacy key when keychain save succeeds.

### Testing
- Ran the full test suite with `python -m pytest -q` and all tests passed (`215 passed`, `41 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d887c9cd2883208e189808d2cccde6)