### PR TITLE
iOS: enforce backend-driven App Store subscription access

### DIFF
--- a/ios-app/PyCashFlowApp/App/PyCashFlowApp.swift
+++ b/ios-app/PyCashFlowApp/App/PyCashFlowApp.swift
@@ -3,11 +3,18 @@ import SwiftUI
 @main
 struct PyCashFlowApp: App {
     @StateObject private var session = SessionManager()
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some Scene {
         WindowGroup {
             RootView()
                 .environmentObject(session)
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            guard newPhase == .active, session.isAuthenticated else { return }
+            Task {
+                await session.refreshSubscriptionState(forceProfileRefresh: false)
+            }
         }
     }
 }

--- a/ios-app/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/PyCashFlowApp/App/RootView.swift
@@ -5,11 +5,22 @@ struct RootView: View {
 
     var body: some View {
         NavigationStack {
-            if session.isAuthenticated {
-                DashboardView()
-            } else {
+            if !session.isAuthenticated {
                 LoginView()
+            } else {
+                switch session.accessState {
+                case .unknown, .checking:
+                    ProgressView("Checking account status...")
+                        .foregroundStyle(AppTheme.textPrimary)
+                case .allowed:
+                    DashboardView()
+                case .blocked(let message):
+                    SubscriptionPaywallView(message: message)
+                }
             }
+        }
+        .task {
+            await session.bootstrap()
         }
         .preferredColorScheme(.dark)
     }

--- a/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -1,11 +1,29 @@
 import Foundation
 import Security
 
+@MainActor
 final class SessionManager: ObservableObject {
+    enum AccessState: Equatable {
+        case unknown
+        case checking
+        case allowed
+        case blocked(message: String)
+    }
+
     @Published var token: String? = TokenKeychainStore.readTokenMigratingLegacy()
     @Published var user: UserDTO?
+    @Published var billingStatus: BillingStatusDTO?
+    @Published var accessState: AccessState = .unknown
 
     var isAuthenticated: Bool { token != nil }
+
+    func bootstrap() async {
+        guard token != nil else {
+            accessState = .unknown
+            return
+        }
+        await refreshSubscriptionState(forceProfileRefresh: true)
+    }
 
     func setSession(token: String, user: UserDTO) {
         self.token = token
@@ -17,9 +35,51 @@ final class SessionManager: ObservableObject {
         }
     }
 
+    func establishSession(token: String, user: UserDTO) async {
+        setSession(token: token, user: user)
+        await refreshSubscriptionState(forceProfileRefresh: true)
+    }
+
+    func refreshSubscriptionState(forceProfileRefresh: Bool = false) async {
+        guard let token else {
+            accessState = .unknown
+            return
+        }
+
+        accessState = .checking
+
+        do {
+            if forceProfileRefresh || user == nil {
+                let me: APIEnvelope<UserDTO> = try await APIClient.shared.request(
+                    "auth/me",
+                    token: token,
+                    as: APIEnvelope<UserDTO>.self
+                )
+                user = me.data
+            }
+
+            let status = try await BillingAPI.fetchBillingStatus(token: token)
+            billingStatus = status
+            accessState = status.effectiveAccessAllowed
+                ? .allowed
+                : .blocked(message: status.accessMessage)
+        } catch let apiError as APIErrorEnvelope {
+            if apiError.status == 401 {
+                clear()
+                accessState = .unknown
+                return
+            }
+            accessState = .blocked(message: apiError.error)
+        } catch {
+            accessState = .blocked(message: "Unable to refresh account status. Please try again.")
+        }
+    }
+
     func clear() {
         token = nil
         user = nil
+        billingStatus = nil
+        accessState = .unknown
         TokenKeychainStore.deleteToken()
         UserDefaults.standard.removeObject(forKey: "api_token")
     }

--- a/ios-app/PyCashFlowApp/Core/Billing/BillingAPI.swift
+++ b/ios-app/PyCashFlowApp/Core/Billing/BillingAPI.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+struct AppStoreVerificationPayload: Encodable {
+    struct TransactionPayload: Encodable {
+        let id: String
+        let original_id: String
+        let product_id: String
+        let purchase_date: String
+        let expiry_date: String?
+        let signed_transaction_info: String?
+    }
+
+    let email: String
+    let receipt_data: String
+    let expiry_date: String?
+    let transaction: TransactionPayload
+}
+
+enum BillingAPI {
+    static func fetchBillingStatus(token: String) async throws -> BillingStatusDTO {
+        let response: APIEnvelope<BillingStatusDTO> = try await APIClient.shared.request(
+            "billing/status",
+            token: token,
+            as: APIEnvelope<BillingStatusDTO>.self
+        )
+        return response.data
+    }
+
+    static func verifyAppStorePurchase(token: String?, payload: AppStoreVerificationPayload) async throws -> AppStoreVerificationResponseDTO {
+        let response: APIEnvelope<AppStoreVerificationResponseDTO> = try await APIClient.shared.request(
+            "billing/verify-appstore",
+            method: "POST",
+            token: token,
+            body: payload,
+            as: APIEnvelope<AppStoreVerificationResponseDTO>.self
+        )
+        return response.data
+    }
+}

--- a/ios-app/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -1,0 +1,142 @@
+import Foundation
+import StoreKit
+
+@MainActor
+final class StoreKitSubscriptionManager: ObservableObject {
+    @Published var availableProducts: [Product] = []
+    @Published var isBusy = false
+    @Published var errorMessage: String?
+    @Published var statusMessage: String?
+
+    func loadProducts() async {
+        guard !AppEnvironment.appStoreProductIDs.isEmpty else {
+            errorMessage = "Subscription products are not configured for this build."
+            return
+        }
+
+        do {
+            availableProducts = try await Product.products(for: AppEnvironment.appStoreProductIDs)
+                .sorted { $0.displayPrice < $1.displayPrice }
+            if availableProducts.isEmpty {
+                errorMessage = "No App Store products are currently available."
+            } else {
+                errorMessage = nil
+            }
+        } catch {
+            errorMessage = "Unable to load App Store products."
+        }
+    }
+
+    func purchase(_ product: Product, session: SessionManager) async {
+        guard let user = session.user else {
+            errorMessage = "Sign in again before purchasing."
+            return
+        }
+
+        isBusy = true
+        errorMessage = nil
+        statusMessage = "Completing purchase..."
+
+        do {
+            let result = try await product.purchase()
+            switch result {
+            case .success(let verification):
+                let transaction = try checkVerified(verification)
+                try await submit(transaction: transaction, email: user.email, token: session.token)
+                await transaction.finish()
+                statusMessage = "Purchase verified. Refreshing account status..."
+                await session.refreshSubscriptionState(forceProfileRefresh: true)
+            case .pending:
+                statusMessage = "Purchase pending approval."
+            case .userCancelled:
+                statusMessage = "Purchase cancelled."
+            @unknown default:
+                errorMessage = "Purchase failed due to an unknown StoreKit result."
+            }
+        } catch {
+            errorMessage = "Purchase could not be verified with backend."
+        }
+
+        isBusy = false
+    }
+
+    func restorePurchases(session: SessionManager) async {
+        guard let user = session.user else {
+            errorMessage = "Sign in again before restoring purchases."
+            return
+        }
+
+        isBusy = true
+        errorMessage = nil
+        statusMessage = "Restoring App Store purchases..."
+
+        do {
+            try await AppStore.sync()
+            let transactions = try await currentVerifiedTransactions()
+            guard let latest = transactions.max(by: { $0.purchaseDate < $1.purchaseDate }) else {
+                errorMessage = "No active App Store purchases were found to restore."
+                isBusy = false
+                return
+            }
+
+            try await submit(transaction: latest, email: user.email, token: session.token)
+            statusMessage = "Restore verified. Refreshing account status..."
+            await session.refreshSubscriptionState(forceProfileRefresh: true)
+        } catch {
+            errorMessage = "Restore failed. Please try again."
+        }
+
+        isBusy = false
+    }
+
+    private func submit(transaction: StoreKit.Transaction, email: String, token: String?) async throws {
+        let receiptData: String
+        if let receiptURL = Bundle.main.appStoreReceiptURL,
+           let data = try? Data(contentsOf: receiptURL) {
+            receiptData = data.base64EncodedString()
+        } else {
+            receiptData = ""
+        }
+
+        let expiryISO = transaction.expirationDate.map(Self.isoDate)
+        let payload = AppStoreVerificationPayload(
+            email: email,
+            receipt_data: receiptData,
+            expiry_date: expiryISO,
+            transaction: .init(
+                id: String(transaction.id),
+                original_id: String(transaction.originalID),
+                product_id: transaction.productID,
+                purchase_date: Self.isoDate(transaction.purchaseDate),
+                expiry_date: expiryISO,
+                signed_transaction_info: transaction.jwsRepresentation
+            )
+        )
+
+        _ = try await BillingAPI.verifyAppStorePurchase(token: token, payload: payload)
+    }
+
+    private func currentVerifiedTransactions() async throws -> [StoreKit.Transaction] {
+        var items: [StoreKit.Transaction] = []
+        for await entitlement in StoreKit.Transaction.currentEntitlements {
+            let transaction = try checkVerified(entitlement)
+            items.append(transaction)
+        }
+        return items
+    }
+
+    private func checkVerified<T>(_ result: VerificationResult<T>) throws -> T {
+        switch result {
+        case .unverified:
+            throw APIErrorEnvelope(error: "Unverified App Store transaction", code: "storekit_unverified", status: 422, fields: nil)
+        case .verified(let safe):
+            return safe
+        }
+    }
+
+    private static func isoDate(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+}

--- a/ios-app/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/PyCashFlowApp/Core/Models/APIModels.swift
@@ -21,6 +21,9 @@ struct UserDTO: Decodable {
     let is_global_admin: Bool?
     let twofa_enabled: Bool?
     let is_guest: Bool
+    let subscription_status: String?
+    let subscription_source: String?
+    let subscription_expiry: String?
 }
 
 struct LoginResponseDTO: Decodable {
@@ -28,6 +31,47 @@ struct LoginResponseDTO: Decodable {
     let twofa_required: Bool?
     let challenge: String?
     let user: UserDTO
+}
+
+struct BillingStatusDTO: Decodable {
+    let user_id: Int?
+    let is_active: Bool?
+    let effective_is_active: Bool?
+    let subscription_status: String?
+    let subscription_source: String?
+    let subscription_expiry: String?
+    let payments_enabled: Bool?
+    let is_global_admin: Bool?
+    let is_guest: Bool?
+    let owner_user_id: Int?
+
+    var effectiveAccessAllowed: Bool {
+        if is_global_admin == true {
+            return true
+        }
+        if let effective_is_active {
+            return effective_is_active
+        }
+        return is_active ?? false
+    }
+
+    var accessMessage: String {
+        let status = subscription_status ?? "inactive"
+        if status == "expired" {
+            return "Subscription expired. Renew to continue using owner-only features."
+        }
+        if is_guest == true {
+            return "Guest access depends on your account owner's active subscription."
+        }
+        return "An active subscription is required to continue."
+    }
+}
+
+struct AppStoreVerificationResponseDTO: Decodable {
+    let verification_status: String
+    let user_id: Int?
+    let subscription_status: String?
+    let subscription_source: String?
 }
 
 struct DashboardDTO: Decodable {

--- a/ios-app/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -2,7 +2,8 @@ import Foundation
 
 final class APIClient {
     static let shared = APIClient()
-    var baseURL = URL(string: "http://localhost:5000/api/v1")!
+
+    var baseURL: URL = AppEnvironment.apiBaseURL
 
     func request<T: Decodable>(
         _ path: String,
@@ -62,4 +63,56 @@ private struct AnyEncodable: Encodable {
     func encode(to encoder: Encoder) throws {
         try encodeFn(encoder)
     }
+}
+
+enum AppEnvironment {
+    static let apiBaseURL: URL = {
+        let key = "API_BASE_URL"
+
+        if let plistValue = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+           let url = URL(string: plistValue),
+           !plistValue.isEmpty {
+            return url
+        }
+
+        if let defaultsValue = UserDefaults.standard.string(forKey: key),
+           let url = URL(string: defaultsValue),
+           !defaultsValue.isEmpty {
+            return url
+        }
+
+        if let envValue = ProcessInfo.processInfo.environment[key],
+           let url = URL(string: envValue),
+           !envValue.isEmpty {
+            return url
+        }
+
+        return URL(string: "https://example.com/api/v1")!
+    }()
+
+    static let appStoreProductIDs: [String] = {
+        let key = "APP_STORE_PRODUCT_IDS"
+
+        if let plistValue = Bundle.main.object(forInfoDictionaryKey: key) as? String {
+            let ids = plistValue
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            if !ids.isEmpty {
+                return ids
+            }
+        }
+
+        if let envValue = ProcessInfo.processInfo.environment[key] {
+            let ids = envValue
+                .split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            if !ids.isEmpty {
+                return ids
+            }
+        }
+
+        return []
+    }()
 }

--- a/ios-app/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/PyCashFlowApp/Features/Login/LoginView.swift
@@ -91,7 +91,7 @@ struct LoginView: View {
                 await MainActor.run { errorText = "Login token missing" }
                 return
             }
-            await MainActor.run { session.setSession(token: token, user: response.data.user) }
+            await session.establishSession(token: token, user: response.data.user)
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Login failed" }
         }
@@ -111,7 +111,7 @@ struct LoginView: View {
                 await MainActor.run { errorText = "2FA login token missing" }
                 return
             }
-            await MainActor.run { session.setSession(token: token, user: response.data.user) }
+            await session.establishSession(token: token, user: response.data.user)
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "2FA failed" }
         }

--- a/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -21,6 +21,14 @@ struct SettingsView: View {
                     Text("AI Configured: \(settings.ai.configured ? "Yes" : "No")").surfaceCard()
                 }
 
+                if let billing = session.billingStatus {
+                    Text("Subscription: \(billing.subscription_status ?? "inactive") via \(billing.subscription_source ?? "none")")
+                        .surfaceCard()
+                    if let expiry = billing.subscription_expiry {
+                        Text("Subscription expiry: \(expiry)").surfaceCard()
+                    }
+                }
+
                 if let insights {
                     Text("Insights: \((insights.insights ?? []).joined(separator: "\n• "))")
                         .surfaceCard()
@@ -37,6 +45,9 @@ struct SettingsView: View {
                         .buttonStyle(PrimaryButtonStyle())
                 }
                 .surfaceCard()
+
+                Button("Refresh Subscription Status") { Task { await session.refreshSubscriptionState(forceProfileRefresh: true) } }
+                    .buttonStyle(PrimaryButtonStyle())
 
                 Button("Logout", role: .destructive) { Task { await logout() } }
                     .buttonStyle(PrimaryButtonStyle())

--- a/ios-app/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+import StoreKit
+
+struct SubscriptionPaywallView: View {
+    @EnvironmentObject var session: SessionManager
+    @StateObject private var manager = StoreKitSubscriptionManager()
+
+    let message: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 14) {
+                Text("Subscription Required")
+                    .font(.title.bold())
+                    .foregroundStyle(AppTheme.textPrimary)
+
+                Text(message)
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .surfaceCard()
+
+                if let status = session.billingStatus {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Text("Status: \(status.subscription_status ?? "inactive")")
+                        Text("Source: \(status.subscription_source ?? "none")")
+                        if let expiry = status.subscription_expiry {
+                            Text("Expires: \(expiry)")
+                        }
+                    }
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .surfaceCard()
+                }
+
+                if manager.availableProducts.isEmpty {
+                    Text("No App Store products available.")
+                        .foregroundStyle(AppTheme.textMuted)
+                        .surfaceCard()
+                } else {
+                    ForEach(manager.availableProducts, id: \.id) { product in
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text(product.displayName)
+                                .foregroundStyle(AppTheme.textPrimary)
+                            Text(product.description)
+                                .foregroundStyle(AppTheme.textSecondary)
+                            Button("Subscribe • \(product.displayPrice)") {
+                                Task { await manager.purchase(product, session: session) }
+                            }
+                            .buttonStyle(PrimaryButtonStyle())
+                            .disabled(manager.isBusy)
+                        }
+                        .surfaceCard()
+                    }
+                }
+
+                Button("Restore Purchases") {
+                    Task { await manager.restorePurchases(session: session) }
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(manager.isBusy)
+
+                Button("Re-check Account Status") {
+                    Task { await session.refreshSubscriptionState(forceProfileRefresh: true) }
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(manager.isBusy)
+
+                if let statusMessage = manager.statusMessage {
+                    Text(statusMessage)
+                        .foregroundStyle(AppTheme.textSecondary)
+                }
+
+                if let errorMessage = manager.errorMessage {
+                    Text(errorMessage)
+                        .foregroundStyle(AppTheme.danger)
+                }
+
+                Button("Logout", role: .destructive) {
+                    session.clear()
+                }
+                .buttonStyle(PrimaryButtonStyle())
+            }
+            .padding(20)
+        }
+        .appBackground()
+        .task {
+            await manager.loadProducts()
+        }
+        .navigationTitle("Subscription")
+    }
+}

--- a/ios-app/PyCashFlowAppTests/BillingStatusTests.swift
+++ b/ios-app/PyCashFlowAppTests/BillingStatusTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import PyCashFlowApp
+
+final class BillingStatusTests: XCTestCase {
+    func testGlobalAdminAlwaysAllowed() {
+        let status = BillingStatusDTO(
+            user_id: 1,
+            is_active: false,
+            effective_is_active: false,
+            subscription_status: "expired",
+            subscription_source: "app_store",
+            subscription_expiry: nil,
+            payments_enabled: true,
+            is_global_admin: true,
+            is_guest: false,
+            owner_user_id: nil
+        )
+
+        XCTAssertTrue(status.effectiveAccessAllowed)
+    }
+
+    func testGuestMessageWhenInactive() {
+        let status = BillingStatusDTO(
+            user_id: 22,
+            is_active: false,
+            effective_is_active: false,
+            subscription_status: "expired",
+            subscription_source: "app_store",
+            subscription_expiry: nil,
+            payments_enabled: true,
+            is_global_admin: false,
+            is_guest: true,
+            owner_user_id: 7
+        )
+
+        XCTAssertEqual(
+            status.accessMessage,
+            "Guest access depends on your account owner's active subscription."
+        )
+    }
+}

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -4,8 +4,44 @@ SwiftUI client for PyCashFlow backed by `/api/v1` endpoints.
 
 ## Architecture
 - `Core/Networking`: `APIClient`, endpoint construction, envelope decoding.
-- `Core/Auth`: session/token state and persistence.
+- `Core/Auth`: session/token state, secure token persistence, and launch-time access enforcement.
+- `Core/Billing`: StoreKit purchase + restore integration and backend billing API adapters.
 - `Core/Models`: DTOs aligned to backend response shapes.
 - `Features/*`: screen-level view models and views.
 
-The app uses real backend APIs only; no mock-only business flows are implemented.
+## Payments & Subscription Enforcement (App Store only)
+
+The iOS app supports **Apple App Store** purchase flow only. Stripe is intentionally not implemented on iOS.
+
+### Launch/session flow
+1. App restores bearer token from Keychain.
+2. `SessionManager.bootstrap()` refreshes `/auth/me` and `/billing/status`.
+3. Backend billing status decides UI access:
+   - active/effective active => app content unlocked
+   - expired/inactive => paywall screen
+
+### Purchase flow
+1. `SubscriptionPaywallView` loads StoreKit products from `APP_STORE_PRODUCT_IDS`.
+2. User taps Subscribe.
+3. StoreKit purchase completes and returns verified transaction.
+4. App sends receipt + signed transaction metadata to `POST /api/v1/billing/verify-appstore`.
+5. App refreshes `GET /api/v1/billing/status` and unlocks only if backend confirms active.
+
+### Restore flow
+1. User taps Restore Purchases.
+2. App runs `AppStore.sync()` and reads current entitlements.
+3. App submits latest verified entitlement to `POST /api/v1/billing/verify-appstore`.
+4. App refreshes backend billing status and updates lock/unlock UI.
+
+### Authority model
+- Backend is source of truth for activation.
+- Guests follow backend effective account status (owner-based access).
+- Global-admin bypass is backend-driven and respected by client state.
+
+## Runtime configuration
+Set these values via Info.plist (or environment for debug tooling):
+
+- `API_BASE_URL` => e.g. `https://api.example.com/api/v1`
+- `APP_STORE_PRODUCT_IDS` => comma-separated product IDs, e.g. `com.pycashflow.premium.monthly`
+
+`APIClient` will not default to localhost.


### PR DESCRIPTION
### Motivation
- Ensure the iOS client uses App Store purchases only and defers subscription truth to the backend so account access is consistently enforced across web and mobile.
- Provide a simple StoreKit-based purchase/restore flow that posts receipts/transaction metadata to the backend verification endpoint and refreshes effective account state.
- Make session bootstrap/foreground checks consult backend billing status so expired/inactive accounts and guest/global-admin rules are honored by the app.

### Description
- Add `Core/Billing` with `BillingAPI` adapters for `GET billing/status` and `POST billing/verify-appstore` and an `AppStoreVerificationPayload` model to send receipt + transaction data to the server.
- Implement `StoreKitSubscriptionManager` to load products from `APP_STORE_PRODUCT_IDS`, run purchases/restores, verify StoreKit transactions locally, submit payloads to the backend, and refresh account state on success.
- Extend `SessionManager` to perform launch/session bootstrap and `refreshSubscriptionState()` which fetches `auth/me` and `billing/status`, stores billing info, and exposes an `AccessState` (unknown/checking/allowed/blocked) used to gate the UI.
- Add `SubscriptionPaywallView` UI with subscribe, restore, re-check status, and logout actions, and wire Root/Scene lifecycle to present paywall vs dashboard based on backend-reported effective access.
- Update API models to include billing fields (`BillingStatusDTO`, subscription fields on `UserDTO`, and verification response DTO), and make `APIClient` environment-driven via `API_BASE_URL` and `APP_STORE_PRODUCT_IDS` (no hardcoded localhost).
- Add a small XCTest (`BillingStatusTests`) for billing access logic and update iOS README documenting StoreKit flows and configuration.

### Testing
- Ran the backend automated test suite with `python -m pytest -q`, which completed successfully: `221 passed, 44 warnings`.
- Added Swift `XCTest` cases under `ios-app/PyCashFlowAppTests` for billing state behavior; these tests were added to the repo but were not executed by the Python test runner in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9902b0e2c8320bdfb6e83add69ebd)