### PR TITLE
Harden billing verification and subscription entitlement handling

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -84,6 +84,13 @@ def _verify_stripe_signature(payload: str, signature_header: str) -> bool:
     return hmac.compare_digest(expected, provided_sig)
 
 
+def _appstore_stub_verification_enabled() -> bool:
+    configured = current_app.config.get("APPSTORE_ALLOW_STUB_VERIFICATION")
+    if configured is None:
+        configured = os.environ.get("APPSTORE_ALLOW_STUB_VERIFICATION", "")
+    return str(configured).strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
     if event_type == "checkout.session.completed":
         email = (obj.get("customer_details") or {}).get("email") or obj.get("customer_email")
@@ -105,10 +112,20 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
         email = ((obj.get("customer_email") or "").strip().lower())
         if not email and obj.get("metadata"):
             email = (obj.get("metadata", {}).get("email") or "").strip().lower()
-        if not email:
-            return validation_error({"email": "subscription email missing"})
+        subscription_id = obj.get("id")
+        user = None
+        if subscription_id:
+            user = User.query.filter_by(subscription_id=subscription_id).first()
+        if user is None and email:
+            user = _create_or_get_owner(email)
+        if user is None:
+            logger.warning(
+                "Skipping Stripe subscription event without resolvable user: type=%s sub_id=%s",
+                event_type,
+                subscription_id,
+            )
+            return api_ok({"processed": event_type, "ignored": True})
 
-        user = _create_or_get_owner(email)
         status = obj.get("status")
         expires_at = _parse_unix_ts(obj.get("current_period_end"))
         if status in {"active", "trialing"}:
@@ -122,7 +139,7 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
             user,
             status=next_status,
             source="stripe",
-            subscription_id=obj.get("id"),
+            subscription_id=subscription_id,
             expiry=expires_at,
             activate=activate,
         )
@@ -219,7 +236,13 @@ def api_verify_appstore():
     except ValueError:
         return validation_error({"expiry_date": "expiry_date must be ISO-8601"})
 
-    # Stub verification hook for future Apple server-side validation integration.
+    verification_status = "verification_unavailable"
+    if not _appstore_stub_verification_enabled():
+        logger.warning("Rejected App Store verification: server-side verification is not configured")
+        return unauthorized(
+            "App Store verification is not configured on this server"
+        )
+
     verification_status = "verified_stub"
 
     user = _create_or_get_owner(email)

--- a/app/subscription.py
+++ b/app/subscription.py
@@ -129,17 +129,23 @@ def enforce_user_access(user: User | None) -> bool:
             db.session.commit()
         return True
 
-    if not user.is_active:
-        return False
-
     if not payments_enabled():
-        return True
+        return bool(user.is_active)
 
     owner = owner_for_user(user)
     if owner is None:
         return False
 
     if subscription_is_current(owner):
+        changed = False
+        if not owner.is_global_admin and not owner.is_active:
+            owner.is_active = True
+            changed = True
+        if not user.is_active:
+            user.is_active = True
+            changed = True
+        if changed:
+            db.session.commit()
         return True
 
     changed = _expire_user(owner)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -107,12 +107,33 @@ def test_appstore_verification_creates_or_updates_owner(flask_app, client):
             "transaction": {"original_transaction_id": "ios_txn_1"},
         },
     )
+    assert resp.status_code == 401
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="ios-user@test.local").first()
+        assert user is None
+
+
+def test_appstore_verification_stub_mode_can_activate_owner(flask_app, client):
+    with flask_app.app_context():
+        flask_app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = True
+
+    expiry = (datetime.now(timezone.utc) + timedelta(days=20)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-stub@test.local",
+            "receipt_data": "dummy-receipt",
+            "expiry_date": expiry,
+            "transaction": {"original_transaction_id": "ios_txn_1"},
+        },
+    )
     assert resp.status_code == 200
     body = _json(resp)["data"]
     assert body["verification_status"] == "verified_stub"
 
     with flask_app.app_context():
-        user = User.query.filter_by(email="ios-user@test.local").first()
+        user = User.query.filter_by(email="ios-stub@test.local").first()
         assert user is not None
         assert user.subscription_source == "app_store"
         assert user.subscription_status == "active"
@@ -159,6 +180,90 @@ def test_guest_access_depends_on_owner_subscription(flask_app, client):
         guest_db = User.query.filter_by(email="guest-expired@test.local").first()
         assert guest_db.is_active is False
         flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
+def test_inactive_guest_is_reactivated_when_owner_subscription_is_current(flask_app, client):
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = True
+        owner = User(
+            email="owner-active@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Owner",
+            admin=True,
+            is_active=True,
+            subscription_status="active",
+            subscription_source="stripe",
+            subscription_expiry=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=30),
+        )
+        db.session.add(owner)
+        db.session.commit()
+
+        guest = User(
+            email="guest-inactive@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Guest",
+            admin=False,
+            is_active=False,
+            account_owner_id=owner.id,
+            owner_user_id=owner.id,
+            is_account_owner=False,
+            subscription_status="inactive",
+            subscription_source="none",
+        )
+        db.session.add(guest)
+        db.session.commit()
+
+        raw, _ = create_token_for_user(guest)
+
+    resp = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        guest_db = User.query.filter_by(email="guest-inactive@test.local").first()
+        assert guest_db.is_active is True
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
+def test_subscription_webhook_update_without_email_uses_existing_subscription_id(flask_app, client):
+    with flask_app.app_context():
+        flask_app.config["STRIPE_WEBHOOK_SECRET"] = "whsec_test_secret"
+        user = User(
+            email="sub-update@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="SubUpdate",
+            admin=True,
+            is_account_owner=True,
+            is_active=False,
+            subscription_status="expired",
+            subscription_source="stripe",
+            subscription_id="sub_existing_123",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+    payload = {
+        "type": "customer.subscription.updated",
+        "data": {
+            "object": {
+                "id": "sub_existing_123",
+                "status": "active",
+                "current_period_end": int((datetime.now(timezone.utc) + timedelta(days=45)).timestamp()),
+            }
+        },
+    }
+    raw = json.dumps(payload)
+    resp = client.post(
+        "/api/v1/billing/webhook/stripe",
+        data=raw,
+        headers={"Stripe-Signature": _sign(raw, "whsec_test_secret")},
+    )
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="sub-update@test.local").first()
+        assert user.subscription_status == "active"
+        assert user.is_active is True
 
 
 def test_global_admin_is_subscription_exempt(flask_app, client):


### PR DESCRIPTION
### Motivation

- Prevent public App Store verification payloads from granting active subscriptions by default since the endpoint previously applied entitlements without server-side verification.
- Allow Stripe webhook subscription events that omit `customer_email` to be reconciled when a `subscription_id` already exists, avoiding dropped updates.
- Ensure guest access correctly follows owner subscription state so guests are reactivated when their owner is currently entitled.

### Description

- Added `_appstore_stub_verification_enabled()` and require the `APPSTORE_ALLOW_STUB_VERIFICATION` flag (or env var) before treating App Store payloads as verified, and return `unauthorized` otherwise; updated `api_verify_appstore` to reflect this change (`app/api/routes/billing.py`).
- Updated Stripe webhook handling in `_apply_stripe_event` to resolve users by `subscription_id` first, create or update by email only when necessary, and safely ignore events that cannot be resolved (`app/api/routes/billing.py`).
- Changed `enforce_user_access` to avoid an early-return that blocked reactivation, to reactivate owner/guest when the owner's subscription is current, and to respect `PAYMENTS_ENABLED` while preserving `is_active` semantics (`app/subscription.py`).
- Expanded and adjusted tests in `tests/test_billing.py` to cover default App Store rejection, stub-mode activation, missing-email Stripe updates reconciled by subscription id, and guest reactivation behavior.

### Testing

- Ran `python -m pytest -q tests/test_billing.py` and observed all billing tests passed (`9 passed`).
- Ran the full test suite with `python -m pytest -q` and observed all tests passed (`224 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d993a15b98832083fe5cd2e8cbe4fc)