### PR TITLE
Add `/api/v1/billing/status` endpoint used by iOS subscription refresh

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -19,6 +19,9 @@ from app.subscription import (
     SUB_ACTIVE,
     SUB_EXPIRED,
     apply_subscription_status,
+    owner_for_user,
+    payments_enabled,
+    subscription_is_current,
 )
 
 from app.api import api
@@ -192,6 +195,41 @@ def api_create_checkout_session():
             "checkout_url": f"https://checkout.stripe.com/pay/{session_id}",
             "mode": "subscription",
             "subscription_source": "stripe",
+        }
+    )
+
+
+@api.route("/billing/status", methods=["GET"])
+@api_login_required
+def api_billing_status():
+    user = get_api_user()
+    owner = owner_for_user(user)
+    owner_id = user.owner_user_id or user.account_owner_id
+
+    effective_is_active = bool(user.is_global_admin)
+    if not effective_is_active:
+        if payments_enabled():
+            effective_is_active = subscription_is_current(owner)
+        else:
+            effective_is_active = bool(user.is_active)
+
+    subscription_subject = owner or user
+    expiry = subscription_subject.subscription_expiry
+    if expiry and expiry.tzinfo is None:
+        expiry = expiry.replace(tzinfo=timezone.utc)
+
+    return api_ok(
+        {
+            "user_id": user.id,
+            "is_active": bool(user.is_active),
+            "effective_is_active": effective_is_active,
+            "subscription_status": subscription_subject.subscription_status,
+            "subscription_source": subscription_subject.subscription_source,
+            "subscription_expiry": expiry.strftime("%Y-%m-%dT%H:%M:%SZ") if expiry else None,
+            "payments_enabled": payments_enabled(),
+            "is_global_admin": bool(user.is_global_admin),
+            "is_guest": owner_id is not None,
+            "owner_user_id": owner_id,
         }
     )
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -308,3 +308,73 @@ def test_payments_toggle_disables_subscription_enforcement(flask_app, client):
 
     with flask_app.app_context():
         flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
+def test_billing_status_endpoint_returns_subscription_snapshot(flask_app, client):
+    with flask_app.app_context():
+        user = User(
+            email="billing-status@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="BillingStatus",
+            admin=True,
+            is_active=True,
+            subscription_status="active",
+            subscription_source="stripe",
+            subscription_expiry=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=30),
+        )
+        db.session.add(user)
+        db.session.commit()
+        raw, _ = create_token_for_user(user)
+
+    resp = client.get("/api/v1/billing/status", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200
+    body = _json(resp)["data"]
+    assert body["user_id"] is not None
+    assert body["is_active"] is True
+    assert body["effective_is_active"] is True
+    assert body["subscription_status"] == "active"
+    assert body["subscription_source"] == "stripe"
+    assert isinstance(body["payments_enabled"], bool)
+    assert body["is_guest"] is False
+    assert body["owner_user_id"] is None
+
+
+def test_billing_status_endpoint_for_guest_uses_owner_subscription(flask_app, client):
+    with flask_app.app_context():
+        owner = User(
+            email="billing-owner@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Owner",
+            admin=True,
+            is_active=True,
+            subscription_status="active",
+            subscription_source="stripe",
+            subscription_expiry=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=30),
+        )
+        db.session.add(owner)
+        db.session.commit()
+
+        guest = User(
+            email="billing-guest@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Guest",
+            admin=False,
+            is_active=True,
+            is_account_owner=False,
+            owner_user_id=owner.id,
+            account_owner_id=owner.id,
+            subscription_status="inactive",
+            subscription_source="none",
+        )
+        db.session.add(guest)
+        db.session.commit()
+        raw, _ = create_token_for_user(guest)
+
+    resp = client.get("/api/v1/billing/status", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200
+    body = _json(resp)["data"]
+    assert body["effective_is_active"] is True
+    assert body["subscription_status"] == "active"
+    assert body["subscription_source"] == "stripe"
+    assert body["is_guest"] is True
+    assert body["owner_user_id"] is not None


### PR DESCRIPTION
### Motivation
- The iOS client calls `billing/status` during subscription refresh but the backend did not expose that route, causing 404s and blocking access in the mobile app.

### Description
- Add a new authenticated `GET /api/v1/billing/status` route in `app/api/routes/billing.py` that returns the snapshot shape expected by the iOS `BillingStatusDTO` (fields include `user_id`, `is_active`, `effective_is_active`, `subscription_status`, `subscription_source`, `subscription_expiry`, `payments_enabled`, `is_global_admin`, `is_guest`, and `owner_user_id`).
- Use existing subscription helpers (`owner_for_user`, `payments_enabled`, `subscription_is_current`) to compute effective access so guest users inherit their owner’s subscription state and expiry dates are emitted in ISO-8601 UTC format.
- Add tests in `tests/test_billing.py` covering owner and guest token flows for the new endpoint and adjusted an assertion to accept a boolean `payments_enabled` value.

### Testing
- Ran `python -m pytest -q tests/test_billing.py` and the billing tests passed (`11 passed`).
- Ran the full test suite `python -m pytest -q` and all tests passed (`226 passed`, `44 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d996d582bc83208a8bdd90b4b53fda)