### PR TITLE
Scope App Store subscriptions to PyCashFlow Cloud; add Self‑Hosted mode and remove global paywall

### DIFF
--- a/ios-app/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/PyCashFlowApp/App/RootView.swift
@@ -15,7 +15,11 @@ struct RootView: View {
                 case .allowed:
                     DashboardView()
                 case .blocked(let message):
-                    SubscriptionPaywallView(message: message)
+                    if session.appMode == .cloud {
+                        SubscriptionPaywallView(message: message)
+                    } else {
+                        DashboardView()
+                    }
                 }
             }
         }

--- a/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -3,6 +3,19 @@ import Security
 
 @MainActor
 final class SessionManager: ObservableObject {
+    enum AppMode: String, CaseIterable, Identifiable {
+        case cloud
+        case selfHosted
+
+        var id: String { rawValue }
+        var label: String {
+            switch self {
+            case .cloud: return "PyCashFlow Cloud"
+            case .selfHosted: return "Self-Hosted"
+            }
+        }
+    }
+
     enum AccessState: Equatable {
         case unknown
         case checking
@@ -14,8 +27,15 @@ final class SessionManager: ObservableObject {
     @Published var user: UserDTO?
     @Published var billingStatus: BillingStatusDTO?
     @Published var accessState: AccessState = .unknown
+    @Published var appMode: AppMode = Self.loadMode()
+    @Published var selfHostedBaseURLText: String = Self.loadSelfHostedURL().absoluteString
 
     var isAuthenticated: Bool { token != nil }
+    var currentBaseURL: URL { APIClient.shared.baseURL }
+
+    init() {
+        applyBaseURLForMode()
+    }
 
     func bootstrap() async {
         guard token != nil else {
@@ -82,6 +102,55 @@ final class SessionManager: ObservableObject {
         accessState = .unknown
         TokenKeychainStore.deleteToken()
         UserDefaults.standard.removeObject(forKey: "api_token")
+    }
+
+    func switchMode(_ newMode: AppMode) {
+        guard newMode != appMode else { return }
+        appMode = newMode
+        UserDefaults.standard.set(newMode.rawValue, forKey: Self.modeKey)
+        applyBaseURLForMode()
+        clear()
+    }
+
+    @discardableResult
+    func updateSelfHostedBaseURL(_ value: String) -> Bool {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let parsed = URL(string: trimmed), parsed.scheme != nil, parsed.host != nil else {
+            return false
+        }
+        selfHostedBaseURLText = parsed.absoluteString
+        UserDefaults.standard.set(parsed.absoluteString, forKey: Self.selfHostedURLKey)
+        if appMode == .selfHosted {
+            APIClient.shared.baseURL = parsed
+        }
+        return true
+    }
+
+    private func applyBaseURLForMode() {
+        switch appMode {
+        case .cloud:
+            APIClient.shared.baseURL = AppEnvironment.cloudAPIBaseURL
+        case .selfHosted:
+            APIClient.shared.baseURL = Self.loadSelfHostedURL()
+        }
+    }
+
+    private static let modeKey = "APP_MODE"
+    private static let selfHostedURLKey = "SELF_HOSTED_API_BASE_URL"
+
+    private static func loadMode() -> AppMode {
+        let raw = UserDefaults.standard.string(forKey: modeKey)
+        return AppMode(rawValue: raw ?? "") ?? .cloud
+    }
+
+    private static func loadSelfHostedURL() -> URL {
+        if let raw = UserDefaults.standard.string(forKey: selfHostedURLKey),
+           let url = URL(string: raw),
+           url.scheme != nil,
+           url.host != nil {
+            return url
+        }
+        return AppEnvironment.defaultSelfHostedAPIBaseURL
     }
 }
 

--- a/ios-app/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -27,9 +27,9 @@ final class StoreKitSubscriptionManager: ObservableObject {
         }
     }
 
-    func purchase(_ product: Product, session: SessionManager) async {
-        guard let user = session.user else {
-            errorMessage = "Sign in again before purchasing."
+    func purchase(_ product: Product, email: String, token: String?) async {
+        guard !email.isEmpty else {
+            errorMessage = "Email is required to activate a hosted cloud account."
             return
         }
 
@@ -42,10 +42,9 @@ final class StoreKitSubscriptionManager: ObservableObject {
             switch result {
             case .success(let verification):
                 let transaction = try checkVerified(verification)
-                try await submit(transaction: transaction, email: user.email, token: session.token)
+                try await submit(transaction: transaction, email: email, token: token)
                 await transaction.finish()
-                statusMessage = "Purchase verified. Refreshing account status..."
-                await session.refreshSubscriptionState(forceProfileRefresh: true)
+                statusMessage = "Purchase verified with backend."
             case .pending:
                 statusMessage = "Purchase pending approval."
             case .userCancelled:
@@ -60,9 +59,9 @@ final class StoreKitSubscriptionManager: ObservableObject {
         isBusy = false
     }
 
-    func restorePurchases(session: SessionManager) async {
-        guard let user = session.user else {
-            errorMessage = "Sign in again before restoring purchases."
+    func restorePurchases(email: String, token: String?) async {
+        guard !email.isEmpty else {
+            errorMessage = "Email is required to restore a hosted cloud account."
             return
         }
 
@@ -79,9 +78,8 @@ final class StoreKitSubscriptionManager: ObservableObject {
                 return
             }
 
-            try await submit(transaction: latest, email: user.email, token: session.token)
-            statusMessage = "Restore verified. Refreshing account status..."
-            await session.refreshSubscriptionState(forceProfileRefresh: true)
+            try await submit(transaction: latest, email: email, token: token)
+            statusMessage = "Restore verified with backend."
         } catch {
             errorMessage = "Restore failed. Please try again."
         }

--- a/ios-app/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -3,7 +3,7 @@ import Foundation
 final class APIClient {
     static let shared = APIClient()
 
-    var baseURL: URL = AppEnvironment.apiBaseURL
+    var baseURL: URL = AppEnvironment.cloudAPIBaseURL
 
     func request<T: Decodable>(
         _ path: String,
@@ -66,7 +66,7 @@ private struct AnyEncodable: Encodable {
 }
 
 enum AppEnvironment {
-    static let apiBaseURL: URL = {
+    static let cloudAPIBaseURL: URL = {
         let key = "API_BASE_URL"
 
         if let plistValue = Bundle.main.object(forInfoDictionaryKey: key) as? String,
@@ -88,6 +88,24 @@ enum AppEnvironment {
         }
 
         return URL(string: "https://example.com/api/v1")!
+    }()
+
+    static let defaultSelfHostedAPIBaseURL: URL = {
+        let key = "SELF_HOSTED_API_BASE_URL"
+
+        if let plistValue = Bundle.main.object(forInfoDictionaryKey: key) as? String,
+           let url = URL(string: plistValue),
+           !plistValue.isEmpty {
+            return url
+        }
+
+        if let defaultsValue = UserDefaults.standard.string(forKey: key),
+           let url = URL(string: defaultsValue),
+           !defaultsValue.isEmpty {
+            return url
+        }
+
+        return URL(string: "http://localhost:5000/api/v1")!
     }()
 
     static let appStoreProductIDs: [String] = {

--- a/ios-app/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/PyCashFlowApp/Features/Login/LoginView.swift
@@ -6,6 +6,7 @@ struct LoginView: View {
     @State private var password = ""
     @State private var challenge: String?
     @State private var twoFACode = ""
+    @State private var selfHostedURL = ""
     @State private var errorText: String?
     @State private var isLoading = false
 
@@ -20,6 +21,48 @@ struct LoginView: View {
                         .foregroundStyle(AppTheme.textSecondary)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
+
+                Picker("App Mode", selection: $session.appMode) {
+                    ForEach(SessionManager.AppMode.allCases) { mode in
+                        Text(mode.label).tag(mode)
+                    }
+                }
+                .onChange(of: session.appMode) { _, newValue in
+                    session.switchMode(newValue)
+                }
+                .surfaceCard()
+
+                if session.appMode == .selfHosted {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Self-Hosted API Base URL")
+                            .foregroundStyle(AppTheme.textPrimary)
+                        TextField("https://your-server.example.com/api/v1", text: $selfHostedURL)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .padding(12)
+                            .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+                            .foregroundStyle(AppTheme.textPrimary)
+                        Button("Save Server URL") {
+                            if !session.updateSelfHostedBaseURL(selfHostedURL) {
+                                errorText = "Please enter a valid URL, including /api/v1."
+                            } else {
+                                errorText = nil
+                            }
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                    }
+                    .surfaceCard()
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Using PyCashFlow Cloud hosted service.")
+                            .foregroundStyle(AppTheme.textSecondary)
+                        NavigationLink("Activate or Restore Cloud Subscription") {
+                            SubscriptionPaywallView(message: "Use App Store subscription to activate or restore your hosted PyCashFlow Cloud account.")
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                    }
+                    .surfaceCard()
+                }
 
                 VStack(spacing: 12) {
                     if challenge == nil {
@@ -61,6 +104,9 @@ struct LoginView: View {
         }
         .appBackground()
         .navigationTitle("Login")
+        .onAppear {
+            selfHostedURL = session.selfHostedBaseURLText
+        }
     }
 
     private func submit() async {

--- a/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -21,6 +21,9 @@ struct SettingsView: View {
                     Text("AI Configured: \(settings.ai.configured ? "Yes" : "No")").surfaceCard()
                 }
 
+                Text("Mode: \(session.appMode.label)").surfaceCard()
+                Text("API: \(session.currentBaseURL.absoluteString)").surfaceCard()
+
                 if let billing = session.billingStatus {
                     Text("Subscription: \(billing.subscription_status ?? "inactive") via \(billing.subscription_source ?? "none")")
                         .surfaceCard()
@@ -48,6 +51,11 @@ struct SettingsView: View {
 
                 Button("Refresh Subscription Status") { Task { await session.refreshSubscriptionState(forceProfileRefresh: true) } }
                     .buttonStyle(PrimaryButtonStyle())
+
+                Button("Switch to Self-Hosted Mode") {
+                    session.switchMode(.selfHosted)
+                }
+                .buttonStyle(PrimaryButtonStyle())
 
                 Button("Logout", role: .destructive) { Task { await logout() } }
                     .buttonStyle(PrimaryButtonStyle())

--- a/ios-app/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -4,6 +4,7 @@ import StoreKit
 struct SubscriptionPaywallView: View {
     @EnvironmentObject var session: SessionManager
     @StateObject private var manager = StoreKitSubscriptionManager()
+    @State private var cloudEmail = ""
 
     let message: String
 
@@ -14,9 +15,20 @@ struct SubscriptionPaywallView: View {
                     .font(.title.bold())
                     .foregroundStyle(AppTheme.textPrimary)
 
+                Text("App Store subscription is only for PyCashFlow Cloud account activation and maintenance.")
+                    .foregroundStyle(AppTheme.textSecondary)
+                    .surfaceCard()
+
                 Text(message)
                     .foregroundStyle(AppTheme.textSecondary)
                     .surfaceCard()
+
+                TextField("Cloud account email", text: $cloudEmail)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding(12)
+                    .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+                    .foregroundStyle(AppTheme.textPrimary)
 
                 if let status = session.billingStatus {
                     VStack(alignment: .leading, spacing: 6) {
@@ -42,7 +54,16 @@ struct SubscriptionPaywallView: View {
                             Text(product.description)
                                 .foregroundStyle(AppTheme.textSecondary)
                             Button("Subscribe • \(product.displayPrice)") {
-                                Task { await manager.purchase(product, session: session) }
+                                Task {
+                                    await manager.purchase(
+                                        product,
+                                        email: resolvedEmail,
+                                        token: session.token
+                                    )
+                                    if session.isAuthenticated {
+                                        await session.refreshSubscriptionState(forceProfileRefresh: true)
+                                    }
+                                }
                             }
                             .buttonStyle(PrimaryButtonStyle())
                             .disabled(manager.isBusy)
@@ -52,7 +73,12 @@ struct SubscriptionPaywallView: View {
                 }
 
                 Button("Restore Purchases") {
-                    Task { await manager.restorePurchases(session: session) }
+                    Task {
+                        await manager.restorePurchases(email: resolvedEmail, token: session.token)
+                        if session.isAuthenticated {
+                            await session.refreshSubscriptionState(forceProfileRefresh: true)
+                        }
+                    }
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .disabled(manager.isBusy)
@@ -77,13 +103,25 @@ struct SubscriptionPaywallView: View {
                     session.clear()
                 }
                 .buttonStyle(PrimaryButtonStyle())
+
+                Button("Switch to Self-Hosted Mode") {
+                    session.switchMode(.selfHosted)
+                }
+                .buttonStyle(PrimaryButtonStyle())
             }
             .padding(20)
         }
         .appBackground()
         .task {
             await manager.loadProducts()
+            if cloudEmail.isEmpty {
+                cloudEmail = session.user?.email ?? ""
+            }
         }
         .navigationTitle("Subscription")
+    }
+
+    private var resolvedEmail: String {
+        cloudEmail.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/ios-app/PyCashFlowAppTests/SessionManagerModeTests.swift
+++ b/ios-app/PyCashFlowAppTests/SessionManagerModeTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import PyCashFlowApp
+
+@MainActor
+final class SessionManagerModeTests: XCTestCase {
+    override func tearDown() {
+        super.tearDown()
+        UserDefaults.standard.removeObject(forKey: "APP_MODE")
+        UserDefaults.standard.removeObject(forKey: "SELF_HOSTED_API_BASE_URL")
+        UserDefaults.standard.removeObject(forKey: "api_token")
+    }
+
+    func testSwitchToSelfHostedUpdatesBaseURLAndClearsSession() async {
+        let session = SessionManager()
+        _ = session.updateSelfHostedBaseURL("https://self-hosted.example.com/api/v1")
+        session.setSession(
+            token: "token123",
+            user: UserDTO(
+                id: 1,
+                email: "user@example.com",
+                name: "User",
+                is_admin: true,
+                is_global_admin: false,
+                twofa_enabled: false,
+                is_guest: false,
+                subscription_status: nil,
+                subscription_source: nil,
+                subscription_expiry: nil
+            )
+        )
+
+        session.switchMode(.selfHosted)
+
+        XCTAssertEqual(session.appMode, .selfHosted)
+        XCTAssertEqual(session.currentBaseURL.absoluteString, "https://self-hosted.example.com/api/v1")
+        XCTAssertFalse(session.isAuthenticated)
+    }
+
+    func testInvalidSelfHostedURLRejected() async {
+        let session = SessionManager()
+        let ok = session.updateSelfHostedBaseURL("not-a-url")
+        XCTAssertFalse(ok)
+    }
+}

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -4,44 +4,48 @@ SwiftUI client for PyCashFlow backed by `/api/v1` endpoints.
 
 ## Architecture
 - `Core/Networking`: `APIClient`, endpoint construction, envelope decoding.
-- `Core/Auth`: session/token state, secure token persistence, and launch-time access enforcement.
+- `Core/Auth`: session/token state, app mode (Cloud vs Self-Hosted), and secure token persistence.
 - `Core/Billing`: StoreKit purchase + restore integration and backend billing API adapters.
 - `Core/Models`: DTOs aligned to backend response shapes.
 - `Features/*`: screen-level view models and views.
 
-## Payments & Subscription Enforcement (App Store only)
+## Product Model
+
+The iOS app is free to download and use. It supports two modes:
+
+1. **PyCashFlow Cloud mode**
+   - Uses the managed hosted backend URL.
+   - App Store subscriptions are used only to create/activate/restore hosted cloud access.
+   - Backend `/billing/status` remains the source of truth for hosted account activation.
+
+2. **Self-Hosted mode**
+   - User configures a custom API base URL (for example, their own server).
+   - No App Store subscription is required by the app.
+   - Server-side access rules are determined by the connected backend configuration.
+
+There is **no global app paywall** on launch. Subscription prompts appear in hosted-cloud activation and restore contexts only.
+
+## Payments & Subscription Scope (Cloud only)
 
 The iOS app supports **Apple App Store** purchase flow only. Stripe is intentionally not implemented on iOS.
 
-### Launch/session flow
-1. App restores bearer token from Keychain.
-2. `SessionManager.bootstrap()` refreshes `/auth/me` and `/billing/status`.
-3. Backend billing status decides UI access:
-   - active/effective active => app content unlocked
-   - expired/inactive => paywall screen
-
-### Purchase flow
+### Hosted cloud purchase/restore flow
 1. `SubscriptionPaywallView` loads StoreKit products from `APP_STORE_PRODUCT_IDS`.
-2. User taps Subscribe.
-3. StoreKit purchase completes and returns verified transaction.
-4. App sends receipt + signed transaction metadata to `POST /api/v1/billing/verify-appstore`.
-5. App refreshes `GET /api/v1/billing/status` and unlocks only if backend confirms active.
-
-### Restore flow
-1. User taps Restore Purchases.
-2. App runs `AppStore.sync()` and reads current entitlements.
-3. App submits latest verified entitlement to `POST /api/v1/billing/verify-appstore`.
-4. App refreshes backend billing status and updates lock/unlock UI.
+2. User subscribes or restores.
+3. App sends receipt + signed transaction metadata to `POST /api/v1/billing/verify-appstore`.
+4. If authenticated, app refreshes `GET /api/v1/billing/status`.
 
 ### Authority model
 - Backend is source of truth for activation.
 - Guests follow backend effective account status (owner-based access).
 - Global-admin bypass is backend-driven and respected by client state.
+- App Store status is not treated as a universal entitlement for all app usage.
 
 ## Runtime configuration
 Set these values via Info.plist (or environment for debug tooling):
 
-- `API_BASE_URL` => e.g. `https://api.example.com/api/v1`
+- `API_BASE_URL` => hosted cloud API URL, e.g. `https://cloud.pycashflow.com/api/v1`
+- `SELF_HOSTED_API_BASE_URL` => default self-hosted API URL shown in app config
 - `APP_STORE_PRODUCT_IDS` => comma-separated product IDs, e.g. `com.pycashflow.premium.monthly`
 
 `APIClient` will not default to localhost.


### PR DESCRIPTION
### Motivation
- Prevent the app from being globally paywalled by App Store subscription state and ensure subscriptions apply only to hosted PyCashFlow Cloud account lifecycle.
- Allow full, free usage of the app for self‑hosted users and provide a clear mode separation between Self‑Hosted and Cloud workflows.
- Preserve backend-as-source-of-truth for hosted activation while keeping the iOS subscription flow scoped to account activation/restore only.

### Description
- Added an `AppMode` model to `SessionManager` with persisted mode selection, self‑hosted base URL persistence, validation, and a `switchMode(_:)` flow that resets session state and applies the appropriate API base URL (`ios-app/PyCashFlowApp/Core/Auth/SessionManager.swift`).
- Introduced separate environment URL handling with `cloudAPIBaseURL` and `defaultSelfHostedAPIBaseURL`, and switched `APIClient.shared.baseURL` to use cloud by default (`ios-app/PyCashFlowApp/Core/Networking/APIClient.swift`).
- Updated root routing so the subscription paywall (`SubscriptionPaywallView`) is only shown when the app is in Cloud mode and not when in Self‑Hosted mode (`ios-app/PyCashFlowApp/App/RootView.swift`).
- Modified the login UI to let users choose mode on first launch, configure a self‑hosted server URL, and access a hosted activation/restore entry point without forcing a subscription for self‑hosted usage (`ios-app/PyCashFlowApp/Features/Login/LoginView.swift`).
- Scoped StoreKit purchase and restore flows to hosted activation by requiring a cloud email and passing email/token to the backend verification endpoint, and added a switch-to-self-hosted escape from the paywall (`ios-app/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift`, `ios-app/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift`).
- Surface current mode and active API URL in `SettingsView`, and added a quick switch to Self‑Hosted mode (`ios-app/PyCashFlowApp/Features/Settings/SettingsView.swift`).
- Updated iOS documentation to describe the free app model, the two modes, and the scope of App Store subscriptions so they apply only to hosted cloud account lifecycle (`ios-app/README.md`).
- Added unit tests for mode switching and self‑hosted URL validation (`ios-app/PyCashFlowAppTests/SessionManagerModeTests.swift`).

### Testing
- Added `SessionManagerModeTests` to validate that switching to Self‑Hosted updates the base URL and clears an authenticated session, and that invalid self‑hosted URLs are rejected (tests added but not executed in this environment). 
- Attempted to run iOS test tooling with `xcodebuild` but `xcodebuild` is not available in this Linux/container environment so XCTest could not be executed here. 
- Attempted `swift test` but there is no `Package.swift` (the app is an Xcode project), therefore SwiftPM tests could not be executed in this environment.
- Verified non‑blocking local checks (e.g., `swift --version`) and committed changes; full iOS test execution and UI verification should be run in an environment with Xcode (macOS) and the project opened in Xcode to run the new XCTest and validate StoreKit flows and UI behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99880399c8320b2e50929d0324b44)