### PR TITLE
Allow billing status checks for inactive subscriptions

### DIFF
--- a/app/api/auth_utils.py
+++ b/app/api/auth_utils.py
@@ -132,7 +132,7 @@ def get_api_user():
 
 # ── Decorator ─────────────────────────────────────────────────────────────────
 
-def api_login_required(f=None, *, require_bearer: bool = False):
+def api_login_required(f=None, *, require_bearer: bool = False, enforce_active: bool = True):
     """Require authentication via Bearer token or active Flask-Login session.
 
     On success, the authenticated user is available via ``get_api_user()``.
@@ -144,7 +144,7 @@ def api_login_required(f=None, *, require_bearer: bool = False):
             # 1. Bearer token takes precedence
             user = _load_user_from_bearer()
             if user is not None:
-                if not enforce_user_access(user):
+                if enforce_active and not enforce_user_access(user):
                     return unauthorized("Invalid credentials or account is not active")
                 g.api_user = user
                 return func(*args, **kwargs)
@@ -152,7 +152,7 @@ def api_login_required(f=None, *, require_bearer: bool = False):
             # 2. Optional session cookie fallback (Flask-Login)
             if not require_bearer and current_user.is_authenticated:
                 session_user = current_user._get_current_object()
-                if not enforce_user_access(session_user):
+                if enforce_active and not enforce_user_access(session_user):
                     return unauthorized("Invalid credentials or account is not active")
                 g.api_user = session_user
                 return func(*args, **kwargs)
@@ -163,7 +163,7 @@ def api_login_required(f=None, *, require_bearer: bool = False):
 
         return decorated
 
-    # Supports both @api_login_required and @api_login_required(require_bearer=True)
+    # Supports both @api_login_required and keyword-argument variants.
     if f is None:
         return _decorate
     return _decorate(f)

--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -200,7 +200,7 @@ def api_create_checkout_session():
 
 
 @api.route("/billing/status", methods=["GET"])
-@api_login_required
+@api_login_required(enforce_active=False)
 def api_billing_status():
     user = get_api_user()
     owner = owner_for_user(user)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -378,3 +378,32 @@ def test_billing_status_endpoint_for_guest_uses_owner_subscription(flask_app, cl
     assert body["subscription_source"] == "stripe"
     assert body["is_guest"] is True
     assert body["owner_user_id"] is not None
+
+
+def test_billing_status_allows_inactive_users_for_refresh(flask_app, client):
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = True
+        user = User(
+            email="billing-expired@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="BillingExpired",
+            admin=True,
+            is_active=False,
+            subscription_status="expired",
+            subscription_source="stripe",
+            subscription_expiry=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1),
+        )
+        db.session.add(user)
+        db.session.commit()
+        raw, _ = create_token_for_user(user)
+
+    resp = client.get("/api/v1/billing/status", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200
+    body = _json(resp)["data"]
+    assert body["is_active"] is False
+    assert body["effective_is_active"] is False
+    assert body["subscription_status"] == "expired"
+
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle


### PR DESCRIPTION
### Motivation
- The billing status endpoint needs to return a subscription snapshot even for users whose subscriptions are expired so clients can show paywall/refresh UI instead of treating the request as an auth failure. 
- The existing `@api_login_required` decorator enforced `enforce_user_access()` for all routes which caused 401s for expired/inactive users on this endpoint.

### Description
- Added an `enforce_active: bool = True` keyword argument to `api_login_required` and made the decorator skip the `enforce_user_access()` check when `enforce_active` is `False` to allow identity-only authentication without subscription gating. 
- Updated `GET /api/v1/billing/status` to use `@api_login_required(enforce_active=False)` so expired or inactive users can still retrieve the billing snapshot. 
- Added a test `test_billing_status_allows_inactive_users_for_refresh` to verify expired/inactive users receive `200` with `effective_is_active == False` and preserved the existing tests for billing status and guest-owner behavior.

### Testing
- Ran `python -m pytest -q tests/test_billing.py` and all tests in that file passed (`12 passed`).
- Ran `python -m pytest -q tests/test_api_foundation.py` and the suite passed (`38 passed`, with expected SQLAlchemy deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99a50f710832090aa7372c5cb26b5)