### PR TITLE
Harden billing status auth for manually deactivated accounts

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -204,6 +204,13 @@ def api_create_checkout_session():
 def api_billing_status():
     user = get_api_user()
     owner = owner_for_user(user)
+
+    if not user.is_global_admin and not user.is_active:
+        # Keep manual/admin deactivation checks, but allow expired users to
+        # retrieve billing status when payments enforcement is enabled.
+        if not payments_enabled() or subscription_is_current(owner):
+            return unauthorized("Invalid credentials or account is not active")
+
     owner_id = user.owner_user_id or user.account_owner_id
 
     effective_is_active = bool(user.is_global_admin)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -380,6 +380,55 @@ def test_billing_status_endpoint_for_guest_uses_owner_subscription(flask_app, cl
     assert body["owner_user_id"] is not None
 
 
+def test_billing_status_rejects_manual_deactivated_user(flask_app, client):
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = False
+        user = User(
+            email="billing-manual-inactive@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="BillingManualInactive",
+            admin=True,
+            is_active=False,
+            subscription_status="inactive",
+            subscription_source="manual",
+        )
+        db.session.add(user)
+        db.session.commit()
+        raw, _ = create_token_for_user(user)
+
+    resp = client.get("/api/v1/billing/status", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 401
+
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
+def test_billing_status_rejects_admin_deactivated_user_with_current_subscription(flask_app, client):
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = True
+        user = User(
+            email="billing-admin-inactive@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="BillingAdminInactive",
+            admin=True,
+            is_active=False,
+            subscription_status="active",
+            subscription_source="stripe",
+            subscription_expiry=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=10),
+        )
+        db.session.add(user)
+        db.session.commit()
+        raw, _ = create_token_for_user(user)
+
+    resp = client.get("/api/v1/billing/status", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 401
+
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
 def test_billing_status_allows_inactive_users_for_refresh(flask_app, client):
     original_toggle = flask_app.config["PAYMENTS_ENABLED"]
     with flask_app.app_context():


### PR DESCRIPTION
### Motivation
- A previous change used `@api_login_required(enforce_active=False)` for the billing status endpoint which bypassed `enforce_user_access()` and allowed manually/admin-deactivated users to retrieve `/api/v1/billing/status` when presenting a valid token.  
- The intent is to keep the endpoint usable for expired subscriptions (so clients can refresh status) while restoring deactivation protections for manually/admin-deactivated accounts.

### Description
- Added a targeted guard in `app/api/routes/billing.py` inside `api_billing_status()` that denies access for non-`is_global_admin` inactive users unless `payments_enabled()` is true and the owner subscription is not current, thereby allowing only the expired-subscription refresh path.  
- This narrows the previous `enforce_active=False` exception so `enforce_user_access()` protections are preserved for manual/admin deactivations.  
- Added regression tests in `tests/test_billing.py` to assert that manually deactivated users are denied when `PAYMENTS_ENABLED=false`, admin-deactivated users with a current subscription are denied in payments mode, and the existing expired-subscription refresh behavior still returns 200.

### Testing
- Ran `python -m pytest -q tests/test_billing.py` and all tests passed: `14 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99c195518832088e6c78a17cc0835)