### PR TITLE
Name owner_user_id foreign key to prevent Alembic batch migration errors

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -13,7 +13,9 @@ class User(UserMixin, db.Model):
     is_active = db.Column(db.Boolean, default=False)
     account_owner_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
     is_account_owner = db.Column(db.Boolean, default=True, nullable=False, server_default=db.true())
-    owner_user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    owner_user_id = db.Column(
+        db.Integer, db.ForeignKey('user.id', name='fk_user_owner_user_id'), nullable=True
+    )
     subscription_status = db.Column(
         db.String(20), default='inactive', nullable=False, server_default='inactive'
     )


### PR DESCRIPTION
### Motivation
- Ensure Alembic batch migrations on SQLite do not fail with `ValueError: Constraint must have a name` when adding/dropping the `owner_user_id` foreign key.

### Description
- Explicitly name the `owner_user_id` foreign key on `User` as `fk_user_owner_user_id` by changing the column definition in `app/models.py` to `db.ForeignKey('user.id', name='fk_user_owner_user_id')`.

### Testing
- Ran focused API test suites with `python -m pytest -q tests/test_api_foundation.py tests/test_api_data.py` and received `100 passed` (11 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d99f0348dc8320ab143a5c1ddc211f)