### PR TITLE
Fix Alembic ValueError in SQLite batch migration by adding naming convention

### DIFF
--- a/migrations/versions/a9b8c7d6e5f4_add_subscription_fields_to_user.py
+++ b/migrations/versions/a9b8c7d6e5f4_add_subscription_fields_to_user.py
@@ -17,7 +17,16 @@ depends_on = None
 
 
 def upgrade():
-    with op.batch_alter_table('user') as batch_op:
+    with op.batch_alter_table(
+        'user',
+        naming_convention={
+            "ix": "ix_%(table_name)s_%(column_0_name)s",
+            "uq": "uq_%(table_name)s_%(column_0_name)s",
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "pk": "pk_%(table_name)s",
+        },
+    ) as batch_op:
         batch_op.add_column(sa.Column('is_account_owner', sa.Boolean(), nullable=False, server_default=sa.true()))
         batch_op.add_column(sa.Column('owner_user_id', sa.Integer(), nullable=True))
         batch_op.add_column(sa.Column('subscription_status', sa.String(length=20), nullable=False, server_default='inactive'))
@@ -28,7 +37,16 @@ def upgrade():
 
 
 def downgrade():
-    with op.batch_alter_table('user') as batch_op:
+    with op.batch_alter_table(
+        'user',
+        naming_convention={
+            "ix": "ix_%(table_name)s_%(column_0_name)s",
+            "uq": "uq_%(table_name)s_%(column_0_name)s",
+            "ck": "ck_%(table_name)s_%(constraint_name)s",
+            "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+            "pk": "pk_%(table_name)s",
+        },
+    ) as batch_op:
         batch_op.drop_constraint('fk_user_owner_user_id', type_='foreignkey')
         batch_op.drop_column('subscription_expiry')
         batch_op.drop_column('subscription_id')


### PR DESCRIPTION
### Motivation
- Running `flask db upgrade` failed with `ValueError: Constraint must have a name` when Alembic used SQLite batch mode to alter the `user` table.  
- The initial migration created a self-referential foreign key on `user` without a stable name and the app does not set a global SQLAlchemy naming convention, so reflected unnamed constraints caused Alembic to raise while recreating the table.  
- The smallest safe fix is to provide a deterministic `naming_convention` for the specific `batch_alter_table()` that triggers the recreate/copy path, avoiding migration history changes.  

### Description
- Added an explicit `naming_convention` dict to both `upgrade()` and `downgrade()` `op.batch_alter_table('user', ...)` calls in `migrations/versions/a9b8c7d6e5f4_add_subscription_fields_to_user.py` so Alembic can synthesize stable names for reflected constraints during SQLite batch operations.  
- This change is local to the migration file and preserves existing migration history and revision IDs.  
- No model files or global metadata initialization were changed to keep churn minimal and avoid touching runtime behaviour.  

### Testing
- Ran `flask db heads` and observed the two heads present before/after (`a2b3c4d5e6f7` and `a9b8c7d6e5f4`).  
- Executed a full migration against a fresh SQLite database with `flask db upgrade heads` which completed all revision steps successfully.  
- Verified `flask db current` after upgrade to confirm the database reached the head revisions.  
- Confirmed the previous `ValueError: Constraint must have a name` no longer occurs when running the migration commands above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a2d409648320a6180e8d80b5c5d3)