### PR TITLE
Fix SQLite batch-mode FK naming in user subscription migration

### DIFF
--- a/migrations/versions/a9b8c7d6e5f4_add_subscription_fields_to_user.py
+++ b/migrations/versions/a9b8c7d6e5f4_add_subscription_fields_to_user.py
@@ -33,7 +33,7 @@ def upgrade():
         batch_op.add_column(sa.Column('subscription_source', sa.String(length=20), nullable=False, server_default='none'))
         batch_op.add_column(sa.Column('subscription_id', sa.String(length=255), nullable=True))
         batch_op.add_column(sa.Column('subscription_expiry', sa.DateTime(), nullable=True))
-        batch_op.create_foreign_key('fk_user_owner_user_id', 'user', ['owner_user_id'], ['id'])
+        batch_op.create_foreign_key('fk_user_owner_user_id_user', 'user', ['owner_user_id'], ['id'])
 
 
 def downgrade():
@@ -47,7 +47,7 @@ def downgrade():
             "pk": "pk_%(table_name)s",
         },
     ) as batch_op:
-        batch_op.drop_constraint('fk_user_owner_user_id', type_='foreignkey')
+        batch_op.drop_constraint('fk_user_owner_user_id_user', type_='foreignkey')
         batch_op.drop_column('subscription_expiry')
         batch_op.drop_column('subscription_id')
         batch_op.drop_column('subscription_source')


### PR DESCRIPTION
### Motivation
- Ensure the Alembic batch-mode alteration of the `user` table is SQLite-safe by providing a deterministic explicit name for the foreign-key constraint added by the migration to avoid batch constraint naming errors.

### Description
- In `migrations/versions/a9b8c7d6e5f4_add_subscription_fields_to_user.py` changed the batch `create_foreign_key` call to use the explicit name `fk_user_owner_user_id_user` and updated the matching `drop_constraint` in `downgrade()` to drop the same name.

### Testing
- Ran `flask db upgrade heads`, `flask db upgrade a9b8c7d6e5f4`, and `flask db downgrade f6a7b8c9d0e1` against a fresh SQLite DB and inspected `sqlite_master` and `PRAGMA foreign_key_list('user')` to confirm the migration and downgrade completed and the `owner_user_id -> user.id` FK is present; all commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9a556e8f08320a29f5d728ec66348)