### PR TITLE
Add secure post-purchase password setup onboarding for paid users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,3 +344,9 @@ A SwiftUI client now lives under `/ios-app` with this structure:
 - Global admins always bypass subscription checks and must remain active.
 - Guests inherit effective access from their account owner (`owner_user_id` or legacy `account_owner_id`).
 - Expired owner subscriptions disable guest access.
+- Payment-created users must never receive plaintext passwords.
+- For newly created paid users (Stripe/App Store), generate one-time password
+  setup token, store only token hash + expiry + used state, and send setup
+  email. Existing users must not receive setup email.
+- User-facing password setup links must always use `FRONTEND_BASE_URL` with
+  trailing-slash normalization and fixed route `/auth/set-password/<token>`.

--- a/MOBILE_API_REFERENCE.md
+++ b/MOBILE_API_REFERENCE.md
@@ -316,6 +316,51 @@ Sensitive fields (password, 2FA secret, backup codes) are never included.
 
 ---
 
+### POST /api/v1/auth/complete-password-setup
+
+Complete first-time password setup for payment-created users using a one-time
+setup token from onboarding email.
+
+**Auth required:** No
+
+**Request:**
+
+```json
+{
+  "token": "<setup-token>",
+  "password": "NewSecure123"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `token` | string | Yes | One-time token from email link |
+| `password` | string | Yes | Must meet password policy |
+
+**Response `200 OK`:**
+
+```json
+{
+  "data": {
+    "message": "Password setup complete"
+  }
+}
+```
+
+**Response `401 Unauthorized`:**
+
+Returned for invalid, expired, or already-used setup tokens.
+
+```json
+{
+  "error": "Invalid or expired password setup token",
+  "code": "unauthorized",
+  "status": 401
+}
+```
+
+---
+
 ### GET /api/v1/dashboard
 
 Dashboard summary for a mobile home screen.

--- a/PAYMENTS.md
+++ b/PAYMENTS.md
@@ -45,6 +45,8 @@ Default behavior in this repository is `PAYMENTS_ENABLED=false`.
   - `customer.subscription.deleted`
   - `invoice.payment_failed`
 - Auto-creates user by email when needed and sets owner + active subscription.
+- For first-time paid users only, creates a one-time password setup token and
+  sends an onboarding email. Existing users do not receive setup email.
 
 ## App Store Flow
 
@@ -52,6 +54,33 @@ Default behavior in this repository is `PAYMENTS_ENABLED=false`.
 - Public endpoint for iOS receipt or transaction payload.
 - Current implementation has **stub verification scaffold** (`verification_status=verified_stub`) for future Apple server verification integration.
 - Extracts email + expiry, creates/updates account owner, marks source `app_store`, and activates account.
+- For first-time paid users only, creates a one-time password setup token and
+  sends an onboarding email. Existing users do not receive setup email.
+
+## Paid User Onboarding Lifecycle
+
+When a subscription event creates a brand-new user:
+
+1. User is auto-created by normalized email and activated.
+2. A cryptographically random one-time password setup token is generated.
+3. Only the token hash is stored in `password_setup_tokens` (never plaintext).
+4. Token has a short TTL (default 60 minutes), is tied to a user, and is
+   invalid after first successful use.
+5. Email contains a user-facing setup link using frontend origin:
+   `{FRONTEND_BASE_URL}/auth/set-password/{token}`.
+6. User completes setup via `POST /api/v1/auth/complete-password-setup` and
+   then logs in normally with email/password.
+
+If subscription events match an existing user email, subscription state is
+updated silently and no password setup email is sent.
+
+## FRONTEND_BASE_URL Usage
+
+- `FRONTEND_BASE_URL` is used for all payment-onboarding links sent to users.
+- The configured base URL is normalized by stripping trailing slashes before
+  route concatenation.
+- Password setup route is fixed and hardcoded as `/auth/set-password`.
+- Backend/internal URLs are never used in user-facing setup email links.
 
 ## Guest Access Rules
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -31,6 +31,11 @@ def create_app():
     app.config["PASSKEY_RP_ID"] = os.environ.get("PASSKEY_RP_ID", "")
     app.config["PASSKEY_RP_NAME"] = os.environ.get("PASSKEY_RP_NAME", "PyCashFlow")
     app.config["PASSKEY_ORIGIN"] = os.environ.get("PASSKEY_ORIGIN", "")
+    app.config["FRONTEND_BASE_URL"] = os.environ.get("FRONTEND_BASE_URL", "").strip()
+    app.config["PASSWORD_SETUP_TOKEN_TTL_MINUTES"] = os.environ.get(
+        "PASSWORD_SETUP_TOKEN_TTL_MINUTES",
+        "60",
+    )
     app.config["PAYMENTS_ENABLED"] = os.environ.get("PAYMENTS_ENABLED", "false").lower() == "true"
 
     basedir = os.path.abspath(os.path.dirname(__file__))

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -10,6 +10,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 from app import limiter, db
 from app.models import User, UserToken
 from app.auth import _DUMMY_HASH
+from app.password_setup import consume_password_setup_token
 from app.totp_utils import decrypt_totp_secret, verify_totp, verify_and_consume_backup_code
 from app.subscription import enforce_user_access
 
@@ -89,6 +90,16 @@ def _verify_twofa_challenge(challenge: str) -> User | None:
     if not isinstance(user_id, int):
         return None
     return db.session.get(User, user_id)
+
+
+def _validate_new_password(password: str) -> str | None:
+    if len(password) < 8:
+        return "Password must be at least 8 characters"
+    if password.lower() == password or password.upper() == password:
+        return "Password must include uppercase and lowercase letters"
+    if not any(ch.isdigit() for ch in password):
+        return "Password must include at least one number"
+    return None
 
 
 @api.route("/auth/login", methods=["POST"])
@@ -231,3 +242,31 @@ def api_change_password():
 @api_login_required
 def api_me():
     return api_ok(serialize_user(get_api_user()))
+
+
+@api.route("/auth/complete-password-setup", methods=["POST"])
+def api_complete_password_setup():
+    body = request.get_json(silent=True) or {}
+    token = (body.get("token") or "").strip()
+    new_password = body.get("password") or ""
+
+    errors: dict = {}
+    if not token:
+        errors["token"] = "Token is required"
+    if not new_password:
+        errors["password"] = "Password is required"
+    else:
+        password_error = _validate_new_password(new_password)
+        if password_error:
+            errors["password"] = password_error
+    if errors:
+        return validation_error(errors)
+
+    user = consume_password_setup_token(token)
+    if user is None:
+        return unauthorized("Invalid or expired password setup token")
+
+    user.password = generate_password_hash(new_password, method="scrypt")
+    user.is_active = True
+    db.session.commit()
+    return api_ok({"message": "Password setup complete"})

--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -15,6 +15,12 @@ from werkzeug.security import generate_password_hash
 
 from app import db
 from app.models import User
+from app.getemail import send_password_setup_email
+from app.password_setup import (
+    build_password_setup_url,
+    create_password_setup_token,
+    get_password_setup_ttl_minutes,
+)
 from app.subscription import (
     SUB_ACTIVE,
     SUB_EXPIRED,
@@ -42,16 +48,15 @@ def _parse_unix_ts(raw) -> datetime | None:
         return None
 
 
-def _create_or_get_owner(email: str) -> User:
+def _create_or_get_owner(email: str) -> tuple[User, bool]:
     user = User.query.filter_by(email=email).first()
     if user:
-        return user
+        return user, False
 
-    generated_password = secrets.token_urlsafe(32)
     user = User(
         email=email,
         name=email.split("@")[0],
-        password=generate_password_hash(generated_password, method="scrypt"),
+        password=generate_password_hash(secrets.token_urlsafe(48), method="scrypt"),
         admin=True,
         is_account_owner=True,
         is_active=True,
@@ -61,7 +66,23 @@ def _create_or_get_owner(email: str) -> User:
     db.session.add(user)
     db.session.commit()
     logger.info("Auto-created account owner from payment flow email=%s user_id=%s", email, user.id)
-    return user
+    return user, True
+
+
+def _send_setup_email_for_new_user(user: User, created: bool) -> None:
+    if not created:
+        return
+
+    raw_token, _record = create_password_setup_token(user)
+    setup_url = build_password_setup_url(raw_token)
+    sent = send_password_setup_email(
+        user_name=user.name or user.email.split("@")[0],
+        user_email=user.email,
+        setup_url=setup_url,
+        expires_minutes=get_password_setup_ttl_minutes(),
+    )
+    if not sent:
+        logger.warning("Password setup email could not be sent for user_id=%s", user.id)
 
 
 def _verify_stripe_signature(payload: str, signature_header: str) -> bool:
@@ -99,7 +120,7 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
         email = (obj.get("customer_details") or {}).get("email") or obj.get("customer_email")
         if not email:
             return validation_error({"email": "customer email missing from checkout session"})
-        user = _create_or_get_owner(email.strip().lower())
+        user, created = _create_or_get_owner(email.strip().lower())
         expiry = _parse_unix_ts(obj.get("current_period_end"))
         apply_subscription_status(
             user,
@@ -109,6 +130,7 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
             expiry=expiry,
             activate=True,
         )
+        _send_setup_email_for_new_user(user, created)
         return api_ok({"processed": event_type, "user_id": user.id})
 
     if event_type in {"customer.subscription.created", "customer.subscription.updated"}:
@@ -119,8 +141,9 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
         user = None
         if subscription_id:
             user = User.query.filter_by(subscription_id=subscription_id).first()
+        created = False
         if user is None and email:
-            user = _create_or_get_owner(email)
+            user, created = _create_or_get_owner(email)
         if user is None:
             logger.warning(
                 "Skipping Stripe subscription event without resolvable user: type=%s sub_id=%s",
@@ -146,6 +169,7 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
             expiry=expires_at,
             activate=activate,
         )
+        _send_setup_email_for_new_user(user, created)
         return api_ok({"processed": event_type, "user_id": user.id})
 
     if event_type in {"customer.subscription.deleted", "invoice.payment_failed"}:
@@ -290,7 +314,7 @@ def api_verify_appstore():
 
     verification_status = "verified_stub"
 
-    user = _create_or_get_owner(email)
+    user, created = _create_or_get_owner(email)
     apply_subscription_status(
         user,
         status=SUB_ACTIVE,
@@ -299,6 +323,7 @@ def api_verify_appstore():
         expiry=expiry.replace(tzinfo=None),
         activate=True,
     )
+    _send_setup_email_for_new_user(user, created)
 
     return api_ok(
         {

--- a/app/getemail.py
+++ b/app/getemail.py
@@ -19,6 +19,7 @@ import re
 import imaplib
 import email
 import smtplib
+from flask import current_app
 from email.header import decode_header
 from email.utils import parseaddr
 from email.mime.text import MIMEText
@@ -517,6 +518,69 @@ The PyCashFlow Team
 
     except Exception as exc:
         logger.exception("Unexpected error sending activation notification")
+        return False
+
+
+def send_password_setup_email(user_name, user_email, setup_url, expires_minutes):
+    """Send password setup email for payment-created cloud users."""
+    try:
+        email_settings = GlobalEmailSettings.query.first()
+        if not email_settings:
+            logger.warning("No global email settings configured, skipping password setup email")
+            return False
+
+        from_email = email_settings.email
+        password = decrypt_password(email_settings.password)
+        smtp_server = email_settings.smtp_server
+        support_contact = current_app.config.get("SUPPORT_CONTACT_EMAIL") or from_email
+
+        msg = MIMEMultipart('alternative')
+        msg['From'] = from_email
+        msg['To'] = user_email
+        msg['Subject'] = 'Set Your PyCashFlow Password'
+
+        text_content = f"""
+Hello {user_name},
+
+Your PyCashFlow Cloud account was created after your subscription purchase.
+
+Please set your password using this secure one-time link:
+{setup_url}
+
+This link expires in {expires_minutes} minutes and can only be used once.
+If you did not expect this email or need help, contact {support_contact}.
+
+Best regards,
+The PyCashFlow Team
+"""
+        part1 = MIMEText(text_content, 'plain')
+        msg.attach(part1)
+
+        try:
+            server = smtplib.SMTP(smtp_server, 587, timeout=10)
+            server.starttls()
+            server.login(from_email, password)
+            server.sendmail(from_email, user_email, msg.as_string())
+            server.quit()
+            logger.info("Sent password setup email user_id_email=%s", user_email)
+            return True
+        except (smtplib.SMTPException, OSError) as exc:
+            logger.warning(
+                "Port 587 (STARTTLS) failed for password setup email, trying port 465 (SSL): %s",
+                exc,
+            )
+            try:
+                server = smtplib.SMTP_SSL(smtp_server, 465, timeout=10)
+                server.login(from_email, password)
+                server.sendmail(from_email, user_email, msg.as_string())
+                server.quit()
+                logger.info("Sent password setup email via SSL user_email=%s", user_email)
+                return True
+            except (smtplib.SMTPException, OSError) as exc2:
+                logger.error("Failed password setup email via both ports: %s", exc2)
+                return False
+    except Exception:
+        logger.exception("Unexpected error sending password setup email")
         return False
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -199,3 +199,19 @@ class UserToken(db.Model):
 
     # Relationships
     user = db.relationship('User', backref='api_tokens')
+
+
+class PasswordSetupToken(db.Model):
+    """One-time password setup tokens used for payment-created users."""
+
+    __tablename__ = 'password_setup_tokens'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
+    token_hash = db.Column(db.String(64), unique=True, nullable=False, index=True)
+    created_at = db.Column(db.DateTime, nullable=False, default=lambda: datetime.now(timezone.utc))
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used_at = db.Column(db.DateTime, nullable=True)
+
+    # Relationships
+    user = db.relationship('User', backref='password_setup_tokens')

--- a/app/password_setup.py
+++ b/app/password_setup.py
@@ -1,0 +1,72 @@
+"""Password setup token and onboarding helpers for payment-created users."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from flask import current_app
+
+from app import db
+from app.models import PasswordSetupToken, User, UserToken
+
+DEFAULT_PASSWORD_SETUP_TTL_MINUTES = 60
+PASSWORD_SETUP_ROUTE = "/auth/set-password"
+
+
+def _utc_now_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def hash_token(raw_token: str) -> str:
+    return hashlib.sha256(raw_token.encode("utf-8")).hexdigest()
+
+
+def get_password_setup_ttl_minutes() -> int:
+    configured = current_app.config.get("PASSWORD_SETUP_TOKEN_TTL_MINUTES", DEFAULT_PASSWORD_SETUP_TTL_MINUTES)
+    try:
+        ttl = int(configured)
+    except (TypeError, ValueError):
+        ttl = DEFAULT_PASSWORD_SETUP_TTL_MINUTES
+    return max(5, ttl)
+
+
+def build_password_setup_url(raw_token: str) -> str:
+    frontend_base = (current_app.config.get("FRONTEND_BASE_URL") or "").strip()
+    normalized_base = frontend_base.rstrip("/")
+    if not normalized_base:
+        normalized_base = (current_app.config.get("PREFERRED_URL_SCHEME") or "http") + "://localhost"
+    return f"{normalized_base}{PASSWORD_SETUP_ROUTE}/{raw_token}"
+
+
+def create_password_setup_token(user: User) -> tuple[str, PasswordSetupToken]:
+    raw_token = secrets.token_urlsafe(32)
+    token_record = PasswordSetupToken(
+        user_id=user.id,
+        token_hash=hash_token(raw_token),
+        expires_at=_utc_now_naive() + timedelta(minutes=get_password_setup_ttl_minutes()),
+    )
+    db.session.add(token_record)
+    db.session.commit()
+    return raw_token, token_record
+
+
+def consume_password_setup_token(raw_token: str) -> User | None:
+    token_record = PasswordSetupToken.query.filter_by(token_hash=hash_token(raw_token)).first()
+    if token_record is None:
+        return None
+
+    now = _utc_now_naive()
+    if token_record.used_at is not None or token_record.expires_at <= now:
+        return None
+
+    user = db.session.get(User, token_record.user_id)
+    if user is None:
+        return None
+
+    token_record.used_at = now
+    # Revoke active API tokens so password setup starts from clean auth state.
+    UserToken.query.filter_by(user_id=user.id).delete(synchronize_session=False)
+    db.session.commit()
+    return user

--- a/migrations/versions/f7a8b9c0d1e2_add_password_setup_tokens.py
+++ b/migrations/versions/f7a8b9c0d1e2_add_password_setup_tokens.py
@@ -1,0 +1,48 @@
+"""add password setup tokens table
+
+Revision ID: f7a8b9c0d1e2
+Revises: f6a7b8c9d0e1
+Create Date: 2026-04-11 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f7a8b9c0d1e2'
+down_revision = 'f6a7b8c9d0e1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'password_setup_tokens',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('token_hash', sa.String(length=64), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=False),
+        sa.Column('used_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_password_setup_tokens_token_hash'),
+        'password_setup_tokens',
+        ['token_hash'],
+        unique=True,
+    )
+    op.create_index(
+        op.f('ix_password_setup_tokens_user_id'),
+        'password_setup_tokens',
+        ['user_id'],
+        unique=False,
+    )
+
+
+def downgrade():
+    op.drop_index(op.f('ix_password_setup_tokens_user_id'), table_name='password_setup_tokens')
+    op.drop_index(op.f('ix_password_setup_tokens_token_hash'), table_name='password_setup_tokens')
+    op.drop_table('password_setup_tokens')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,13 @@ from app.models import (
     User as _User,
     Balance as _Balance,
     PasskeyCredential as _PasskeyCredential,
+    PasswordSetupToken as _PasswordSetupToken,
 )  # noqa: E402
+from app.password_setup import (  # noqa: E402
+    build_password_setup_url as _build_password_setup_url,
+    create_password_setup_token as _create_password_setup_token,
+)
+from app.api.routes import billing as _billing_routes  # noqa: E402
 import _helpers  # noqa: F401  – pre-load real cashflow refs before any test-module stubs
 from werkzeug.security import generate_password_hash                # noqa: E402
 
@@ -120,3 +126,24 @@ def user_model():
 def passkey_credential_model():
     """Return the real PasskeyCredential model captured before stubs are installed."""
     return _PasskeyCredential
+
+
+@pytest.fixture(scope="session")
+def password_setup_token_model():
+    """Return the real PasswordSetupToken model captured before stubs are installed."""
+    return _PasswordSetupToken
+
+
+@pytest.fixture(scope="session")
+def password_setup_helpers():
+    """Return password setup helpers captured before any module stubs are installed."""
+    return {
+        "build_url": _build_password_setup_url,
+        "create_token": _create_password_setup_token,
+    }
+
+
+@pytest.fixture(scope="session")
+def billing_routes_module():
+    """Return billing routes module captured before any module stubs are installed."""
+    return _billing_routes

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from werkzeug.security import generate_password_hash
 
 from app import db
-from app.models import User
+from app.models import PasswordSetupToken, User
 from app.api.auth_utils import create_token_for_user
 
 
@@ -138,6 +138,127 @@ def test_appstore_verification_stub_mode_can_activate_owner(flask_app, client):
         assert user.subscription_source == "app_store"
         assert user.subscription_status == "active"
         assert user.is_active is True
+
+
+def test_stripe_new_user_generates_setup_token_and_sends_email(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    sent_links = []
+    with flask_app.app_context():
+        flask_app.config["STRIPE_WEBHOOK_SECRET"] = "whsec_test_secret"
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com/"
+
+    def _fake_send_password_setup_email(user_name, user_email, setup_url, expires_minutes):
+        sent_links.append((user_email, setup_url, expires_minutes))
+        return True
+
+    monkeypatch.setattr(billing_routes_module, "send_password_setup_email", _fake_send_password_setup_email)
+
+    payload = {
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "id": "cs_test_setup_1",
+                "subscription": "sub_setup_1",
+                "customer_details": {"email": "new-stripe-setup@test.local"},
+                "current_period_end": int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp()),
+            }
+        },
+    }
+    raw = json.dumps(payload)
+    resp = client.post(
+        "/api/v1/billing/webhook/stripe",
+        data=raw,
+        headers={"Stripe-Signature": _sign(raw, "whsec_test_secret")},
+    )
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="new-stripe-setup@test.local").first()
+        assert user is not None
+        token = PasswordSetupToken.query.filter_by(user_id=user.id).first()
+        assert token is not None
+        assert token.used_at is None
+    assert len(sent_links) == 1
+    assert sent_links[0][0] == "new-stripe-setup@test.local"
+    assert sent_links[0][1].startswith("https://app.example.com/auth/set-password/")
+
+
+def test_appstore_new_user_generates_setup_token_and_sends_email(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    sent_links = []
+    with flask_app.app_context():
+        flask_app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = True
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com"
+
+    def _fake_send_password_setup_email(user_name, user_email, setup_url, expires_minutes):
+        sent_links.append((user_email, setup_url, expires_minutes))
+        return True
+
+    monkeypatch.setattr(billing_routes_module, "send_password_setup_email", _fake_send_password_setup_email)
+
+    expiry = (datetime.now(timezone.utc) + timedelta(days=20)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "new-appstore-setup@test.local",
+            "receipt_data": "dummy-receipt",
+            "expiry_date": expiry,
+            "transaction": {"original_transaction_id": "ios_txn_setup_1"},
+        },
+    )
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="new-appstore-setup@test.local").first()
+        assert user is not None
+        token = PasswordSetupToken.query.filter_by(user_id=user.id).first()
+        assert token is not None
+    assert len(sent_links) == 1
+    assert sent_links[0][1].startswith("https://app.example.com/auth/set-password/")
+
+
+def test_existing_user_does_not_get_password_setup_email(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    sent_calls = []
+    with flask_app.app_context():
+        flask_app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = True
+        existing = User(
+            email="existing-paid-user@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Existing",
+            admin=True,
+            is_account_owner=True,
+            is_active=True,
+        )
+        db.session.add(existing)
+        db.session.commit()
+
+    def _fake_send_password_setup_email(user_name, user_email, setup_url, expires_minutes):
+        sent_calls.append(user_email)
+        return True
+
+    monkeypatch.setattr(billing_routes_module, "send_password_setup_email", _fake_send_password_setup_email)
+
+    expiry = (datetime.now(timezone.utc) + timedelta(days=20)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "existing-paid-user@test.local",
+            "receipt_data": "dummy-receipt",
+            "expiry_date": expiry,
+            "transaction": {"original_transaction_id": "ios_txn_existing_1"},
+        },
+    )
+    assert resp.status_code == 200
+    assert sent_calls == []
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="existing-paid-user@test.local").first()
+        assert user is not None
+        assert PasswordSetupToken.query.filter_by(user_id=user.id).first() is None
 
 
 def test_guest_access_depends_on_owner_subscription(flask_app, client):

--- a/tests/test_password_setup_flow.py
+++ b/tests/test_password_setup_flow.py
@@ -1,0 +1,139 @@
+"""Password setup onboarding flow tests."""
+
+from datetime import datetime, timedelta, timezone
+
+from werkzeug.security import check_password_hash, generate_password_hash
+
+def _json(resp):
+    body = resp.get_json()
+    assert body is not None
+    return body
+
+
+def test_complete_password_setup_success(flask_app, client, app_ctx, user_model, password_setup_helpers):
+    create_password_setup_token = password_setup_helpers["create_token"]
+    with flask_app.app_context():
+        user = user_model(
+            email="setup-success@test.local",
+            password=generate_password_hash("TempPass123", method="scrypt"),
+            name="Setup Success",
+            admin=True,
+            is_active=True,
+        )
+        app_ctx.session.add(user)
+        app_ctx.session.commit()
+        raw_token, _record = create_password_setup_token(user)
+
+    resp = client.post(
+        "/api/v1/auth/complete-password-setup",
+        json={"token": raw_token, "password": "NewSecure123"},
+    )
+    assert resp.status_code == 200
+    assert _json(resp)["data"]["message"] == "Password setup complete"
+
+    with flask_app.app_context():
+        db_user = user_model.query.filter_by(email="setup-success@test.local").first()
+        assert db_user is not None
+        assert check_password_hash(db_user.password, "NewSecure123")
+
+
+def test_complete_password_setup_rejects_expired_token(
+    flask_app, client, app_ctx, user_model, password_setup_helpers
+):
+    create_password_setup_token = password_setup_helpers["create_token"]
+    with flask_app.app_context():
+        user = user_model(
+            email="setup-expired@test.local",
+            password=generate_password_hash("TempPass123", method="scrypt"),
+            name="Setup Expired",
+            admin=True,
+            is_active=True,
+        )
+        app_ctx.session.add(user)
+        app_ctx.session.commit()
+        raw_token, token = create_password_setup_token(user)
+        token.expires_at = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(minutes=1)
+        app_ctx.session.commit()
+
+    resp = client.post(
+        "/api/v1/auth/complete-password-setup",
+        json={"token": raw_token, "password": "NewSecure123"},
+    )
+    assert resp.status_code == 401
+
+
+def test_complete_password_setup_one_time_use(flask_app, client, app_ctx, user_model, password_setup_helpers):
+    create_password_setup_token = password_setup_helpers["create_token"]
+    with flask_app.app_context():
+        user = user_model(
+            email="setup-onetime@test.local",
+            password=generate_password_hash("TempPass123", method="scrypt"),
+            name="Setup OneTime",
+            admin=True,
+            is_active=True,
+        )
+        app_ctx.session.add(user)
+        app_ctx.session.commit()
+        raw_token, _record = create_password_setup_token(user)
+
+    first = client.post(
+        "/api/v1/auth/complete-password-setup",
+        json={"token": raw_token, "password": "NewSecure123"},
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        "/api/v1/auth/complete-password-setup",
+        json={"token": raw_token, "password": "AnotherSecure123"},
+    )
+    assert second.status_code == 401
+
+    with flask_app.app_context():
+        db_user = user_model.query.filter_by(email="setup-onetime@test.local").first()
+        assert db_user is not None
+        assert check_password_hash(db_user.password, "NewSecure123")
+
+
+def test_complete_password_setup_invalid_token(flask_app, client):
+    resp = client.post(
+        "/api/v1/auth/complete-password-setup",
+        json={"token": "definitely-not-a-valid-token", "password": "NewSecure123"},
+    )
+    assert resp.status_code == 401
+
+
+def test_password_setup_url_uses_frontend_base_url(flask_app, password_setup_helpers):
+    build_password_setup_url = password_setup_helpers["build_url"]
+    with flask_app.app_context():
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.yourdomain.com/"
+        assert (
+            build_password_setup_url("abc123")
+            == "https://app.yourdomain.com/auth/set-password/abc123"
+        )
+
+
+def test_password_setup_token_stored_hashed_only(
+    flask_app,
+    app_ctx,
+    user_model,
+    password_setup_token_model,
+    password_setup_helpers,
+):
+    create_password_setup_token = password_setup_helpers["create_token"]
+    with flask_app.app_context():
+        user = user_model(
+            email="setup-hash@test.local",
+            password=generate_password_hash("TempPass123", method="scrypt"),
+            name="Setup Hash",
+            admin=True,
+            is_active=True,
+        )
+        app_ctx.session.add(user)
+        app_ctx.session.commit()
+
+        raw_token, _record = create_password_setup_token(user)
+        stored = password_setup_token_model.query.filter_by(user_id=user.id).first()
+
+        assert stored is not None
+        assert stored.token_hash != raw_token
+        assert len(stored.token_hash) == 64


### PR DESCRIPTION
### Motivation
- Ensure paid users created via Stripe or App Store are activated and onboarded securely without emailing plaintext passwords, and surface frontend links using a configurable `FRONTEND_BASE_URL`.

### Description
- Added a new SQLAlchemy model `PasswordSetupToken` and Alembic migration to store one-time token hashes with expiry and used state.
- Implemented `app/password_setup.py` helpers to create, hash, store, consume tokens, enforce TTL and one-time use, revoke API tokens on consume, and build normalized frontend URLs using `FRONTEND_BASE_URL` plus hardcoded `/auth/set-password` route.
- Integrated onboarding into payment flows (`/api/v1/billing/webhook/stripe` and `/api/v1/billing/verify-appstore`) so newly auto-created users receive a password-setup token + email while existing users are updated silently.
- Added `send_password_setup_email` in `app/getemail.py` to send a simple, professional onboarding email using existing global SMTP settings and support contact from config.
- Added API endpoint `POST /api/v1/auth/complete-password-setup` to validate tokens, enforce password policy, set hashed password, mark user active, and invalidate token.
- Exposed `FRONTEND_BASE_URL` and `PASSWORD_SETUP_TOKEN_TTL_MINUTES` in app config (from environment) and normalized trailing slashes when building links.
- Updated docs: `PAYMENTS.md`, `AGENTS.md`, and `MOBILE_API_REFERENCE.md` describing lifecycle, security guarantees, and frontend URL usage.
- Added tests covering Stripe/App Store new-user flows (token created + email sent), existing-user no-email, token expiration, one-time use, successful password setup, invalid tokens, token-hash storage, and frontend URL correctness; adjusted `tests/conftest.py` to expose new fixtures.

### Testing
- Ran targeted tests: `python -m pytest -q tests/test_billing.py tests/test_password_setup_flow.py` — all tests passed (23 passed).
- Ran full test suite: `python -m pytest -q` — all tests passed (238 passed, 44 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b728db8483208f611416275f9417)