### PR TITLE
Harden password-setup input validation and require FRONTEND_BASE_URL for setup links

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -247,13 +247,19 @@ def api_me():
 @api.route("/auth/complete-password-setup", methods=["POST"])
 def api_complete_password_setup():
     body = request.get_json(silent=True) or {}
-    token = (body.get("token") or "").strip()
-    new_password = body.get("password") or ""
+    token_raw = body.get("token")
+    token = token_raw.strip() if isinstance(token_raw, str) else ""
+    password_raw = body.get("password")
+    new_password = password_raw if isinstance(password_raw, str) else ""
 
     errors: dict = {}
-    if not token:
+    if token_raw is not None and not isinstance(token_raw, str):
+        errors["token"] = "Token must be a string"
+    elif not token:
         errors["token"] = "Token is required"
-    if not new_password:
+    if password_raw is not None and not isinstance(password_raw, str):
+        errors["password"] = "Password must be a string"
+    elif not new_password:
         errors["password"] = "Password is required"
     else:
         password_error = _validate_new_password(new_password)

--- a/app/password_setup.py
+++ b/app/password_setup.py
@@ -36,7 +36,7 @@ def build_password_setup_url(raw_token: str) -> str:
     frontend_base = (current_app.config.get("FRONTEND_BASE_URL") or "").strip()
     normalized_base = frontend_base.rstrip("/")
     if not normalized_base:
-        normalized_base = (current_app.config.get("PREFERRED_URL_SCHEME") or "http") + "://localhost"
+        raise RuntimeError("FRONTEND_BASE_URL must be configured for password setup links")
     return f"{normalized_base}{PASSWORD_SETUP_ROUTE}/{raw_token}"
 
 

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -27,6 +27,7 @@ def _json(resp):
 def test_stripe_webhook_checkout_activation_flow(flask_app, client):
     with flask_app.app_context():
         flask_app.config["STRIPE_WEBHOOK_SECRET"] = "whsec_test_secret"
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com"
 
     payload = {
         "type": "checkout.session.completed",
@@ -117,6 +118,7 @@ def test_appstore_verification_creates_or_updates_owner(flask_app, client):
 def test_appstore_verification_stub_mode_can_activate_owner(flask_app, client):
     with flask_app.app_context():
         flask_app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = True
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com"
 
     expiry = (datetime.now(timezone.utc) + timedelta(days=20)).strftime("%Y-%m-%dT%H:%M:%SZ")
     resp = client.post(

--- a/tests/test_password_setup_flow.py
+++ b/tests/test_password_setup_flow.py
@@ -102,6 +102,17 @@ def test_complete_password_setup_invalid_token(flask_app, client):
     assert resp.status_code == 401
 
 
+def test_complete_password_setup_rejects_non_string_fields(client):
+    resp = client.post(
+        "/api/v1/auth/complete-password-setup",
+        json={"token": 123, "password": ["not-a-string"]},
+    )
+    assert resp.status_code == 422
+    fields = _json(resp)["fields"]
+    assert fields["token"] == "Token must be a string"
+    assert fields["password"] == "Password must be a string"
+
+
 def test_password_setup_url_uses_frontend_base_url(flask_app, password_setup_helpers):
     build_password_setup_url = password_setup_helpers["build_url"]
     with flask_app.app_context():
@@ -110,6 +121,18 @@ def test_password_setup_url_uses_frontend_base_url(flask_app, password_setup_hel
             build_password_setup_url("abc123")
             == "https://app.yourdomain.com/auth/set-password/abc123"
         )
+
+
+def test_password_setup_url_requires_frontend_base_url(flask_app, password_setup_helpers):
+    build_password_setup_url = password_setup_helpers["build_url"]
+    with flask_app.app_context():
+        flask_app.config["FRONTEND_BASE_URL"] = ""
+        try:
+            build_password_setup_url("abc123")
+        except RuntimeError as exc:
+            assert "FRONTEND_BASE_URL must be configured" in str(exc)
+        else:
+            raise AssertionError("Expected RuntimeError when FRONTEND_BASE_URL is unset")
 
 
 def test_password_setup_token_stored_hashed_only(


### PR DESCRIPTION
### Motivation
- Prevent runtime 500s from malformed client JSON by validating types for the password-setup endpoint before string operations. 
- Avoid sending unusable activation links by failing fast when `FRONTEND_BASE_URL` is not configured instead of silently falling back to `http://localhost`.

### Description
- Validate `token` and `password` payloads in `POST /api/v1/auth/complete-password-setup` by checking for string types and returning validation errors for non-strings, avoiding `.strip()` on non-string values (`app/api/routes/auth.py`).
- Change `build_password_setup_url` to raise a `RuntimeError` when `FRONTEND_BASE_URL` is unset so onboarding emails cannot include a localhost fallback (`app/password_setup.py`).
- Add a test asserting non-string `token`/`password` are rejected with a 422 and that `build_password_setup_url` requires `FRONTEND_BASE_URL` (`tests/test_password_setup_flow.py`).
- Update billing tests that generate setup links to explicitly provide `FRONTEND_BASE_URL` so they remain compatible with the new fail-fast behavior (`tests/test_billing.py`).

### Testing
- Ran `python -m pytest -q tests/test_password_setup_flow.py tests/test_billing.py` and all tests in those files passed (`25 passed`).
- New and updated tests exercise the non-string input validation and required `FRONTEND_BASE_URL` behaviors and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ba665c108320b56794d55a5dcbc0)