### PR TITLE
Guard paid-user onboarding when `FRONTEND_BASE_URL` is not configured

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -38,6 +38,25 @@ from app.api.responses import api_created, api_ok
 
 logger = logging.getLogger(__name__)
 
+def _frontend_base_url_configured() -> bool:
+    frontend_base = (current_app.config.get("FRONTEND_BASE_URL") or "").strip()
+    return bool(frontend_base.rstrip("/"))
+
+
+def _can_create_paid_user(email: str) -> bool:
+    if _frontend_base_url_configured():
+        return True
+
+    existing = User.query.filter_by(email=email).first()
+    if existing is not None:
+        return True
+
+    logger.error(
+        "Cannot create payment user without FRONTEND_BASE_URL: email=%s",
+        email,
+    )
+    return False
+
 
 def _parse_unix_ts(raw) -> datetime | None:
     if raw in (None, ""):
@@ -120,7 +139,12 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
         email = (obj.get("customer_details") or {}).get("email") or obj.get("customer_email")
         if not email:
             return validation_error({"email": "customer email missing from checkout session"})
-        user, created = _create_or_get_owner(email.strip().lower())
+        normalized_email = email.strip().lower()
+        if not _can_create_paid_user(normalized_email):
+            return validation_error(
+                {"frontend_base_url": "FRONTEND_BASE_URL is required to onboard new paid users"}
+            )
+        user, created = _create_or_get_owner(normalized_email)
         expiry = _parse_unix_ts(obj.get("current_period_end"))
         apply_subscription_status(
             user,
@@ -143,6 +167,10 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
             user = User.query.filter_by(subscription_id=subscription_id).first()
         created = False
         if user is None and email:
+            if not _can_create_paid_user(email):
+                return validation_error(
+                    {"frontend_base_url": "FRONTEND_BASE_URL is required to onboard new paid users"}
+                )
             user, created = _create_or_get_owner(email)
         if user is None:
             logger.warning(
@@ -313,6 +341,11 @@ def api_verify_appstore():
         )
 
     verification_status = "verified_stub"
+
+    if not _can_create_paid_user(email):
+        return validation_error(
+            {"frontend_base_url": "FRONTEND_BASE_URL is required to onboard new paid users"}
+        )
 
     user, created = _create_or_get_owner(email)
     apply_subscription_status(

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -186,6 +186,35 @@ def test_stripe_new_user_generates_setup_token_and_sends_email(
     assert sent_links[0][1].startswith("https://app.example.com/auth/set-password/")
 
 
+def test_stripe_new_user_requires_frontend_base_url(flask_app, client):
+    with flask_app.app_context():
+        flask_app.config["STRIPE_WEBHOOK_SECRET"] = "whsec_test_secret"
+        flask_app.config["FRONTEND_BASE_URL"] = ""
+
+    payload = {
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "id": "cs_test_setup_missing_frontend",
+                "subscription": "sub_setup_missing_frontend",
+                "customer_details": {"email": "missing-frontend@test.local"},
+                "current_period_end": int((datetime.now(timezone.utc) + timedelta(days=30)).timestamp()),
+            }
+        },
+    }
+    raw = json.dumps(payload)
+    resp = client.post(
+        "/api/v1/billing/webhook/stripe",
+        data=raw,
+        headers={"Stripe-Signature": _sign(raw, "whsec_test_secret")},
+    )
+    assert resp.status_code == 422
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="missing-frontend@test.local").first()
+        assert user is None
+
+
 def test_appstore_new_user_generates_setup_token_and_sends_email(
     flask_app, client, monkeypatch, billing_routes_module
 ):
@@ -219,6 +248,28 @@ def test_appstore_new_user_generates_setup_token_and_sends_email(
         assert token is not None
     assert len(sent_links) == 1
     assert sent_links[0][1].startswith("https://app.example.com/auth/set-password/")
+
+
+def test_appstore_new_user_requires_frontend_base_url(flask_app, client):
+    with flask_app.app_context():
+        flask_app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = True
+        flask_app.config["FRONTEND_BASE_URL"] = ""
+
+    expiry = (datetime.now(timezone.utc) + timedelta(days=20)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "missing-appstore-frontend@test.local",
+            "receipt_data": "dummy-receipt",
+            "expiry_date": expiry,
+            "transaction": {"original_transaction_id": "ios_txn_setup_missing_frontend"},
+        },
+    )
+    assert resp.status_code == 422
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="missing-appstore-frontend@test.local").first()
+        assert user is None
 
 
 def test_existing_user_does_not_get_password_setup_email(


### PR DESCRIPTION
### Motivation
- Prevent creating new payment-origin users when `FRONTEND_BASE_URL` is unset to avoid committing a user and password-setup token and then failing while building the setup URL, which can permanently orphan new paid users.

### Description
- Added `_frontend_base_url_configured()` and `_can_create_paid_user()` helpers to gate onboarding when the frontend base URL is missing and to allow processing existing users regardless of the config.
- Added preflight checks to Stripe webhook handling (`checkout.session.completed` and `customer.subscription.*`) to return a `validation_error` (`frontend_base_url`) instead of creating a new owner when `FRONTEND_BASE_URL` is not configured.
- Added the same preflight check to the App Store verification flow (`/billing/verify-appstore`) before creating an owner and sending setup emails.
- Added regression tests `test_stripe_new_user_requires_frontend_base_url` and `test_appstore_new_user_requires_frontend_base_url` to assert a `422` is returned and no new user is persisted when `FRONTEND_BASE_URL` is empty.

### Testing
- Ran `python -m pytest -q tests/test_billing.py tests/test_password_setup_flow.py` and observed all tests in those runs pass.
- Ran `python -m pytest -q tests/test_billing.py` after edits and observed the billing test suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9bfd17be88320b5bc29a83de1c109)