### PR TITLE
Use onboarding token emails for guest user invites

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -17,9 +17,7 @@ from app import db
 from app.models import User
 from app.getemail import send_password_setup_email
 from app.password_setup import (
-    build_password_setup_url,
-    create_password_setup_token,
-    get_password_setup_ttl_minutes,
+    create_password_setup_link,
 )
 from app.subscription import (
     SUB_ACTIVE,
@@ -92,13 +90,12 @@ def _send_setup_email_for_new_user(user: User, created: bool) -> None:
     if not created:
         return
 
-    raw_token, _record = create_password_setup_token(user)
-    setup_url = build_password_setup_url(raw_token)
+    setup_url, expires_minutes = create_password_setup_link(user)
     sent = send_password_setup_email(
         user_name=user.name or user.email.split("@")[0],
         user_email=user.email,
         setup_url=setup_url,
-        expires_minutes=get_password_setup_ttl_minutes(),
+        expires_minutes=expires_minutes,
     )
     if not sent:
         logger.warning("Password setup email could not be sent for user_id=%s", user.id)

--- a/app/main.py
+++ b/app/main.py
@@ -1,13 +1,16 @@
-from flask import request, redirect, url_for, send_from_directory, flash, send_file, Response, session
+from flask import (
+    request, redirect, url_for, send_from_directory, flash, send_file, Response, session, current_app
+)
 from flask_login import login_required, current_user
 from flask import Blueprint, render_template
 from .models import (
     Schedule, Scenario, Balance, User, Settings, Email, Hold, Skip,
-    GlobalEmailSettings, AISettings, PasskeyCredential, UserToken,
+    GlobalEmailSettings, AISettings, PasskeyCredential, UserToken, PasswordSetupToken,
 )
 from app import db, limiter
 from datetime import datetime, timezone
 import os
+import secrets
 import json
 import logging
 from sqlalchemy import desc, extract, asc
@@ -16,8 +19,10 @@ from .cashflow import update_cash, plot_cash, calculate_cash_risk_score
 from .auth import admin_required, global_admin_required, account_owner_required
 from .files import export, upload, version
 from .getemail import send_account_activation_notification
+from .getemail import send_password_setup_email
 from .crypto_utils import encrypt_password, decrypt_password
 from .ai_insights import fetch_insights, validate_model
+from .password_setup import create_password_setup_link
 from .totp_utils import (
     generate_totp_secret, encrypt_totp_secret, decrypt_totp_secret,
     generate_qr_code_b64, verify_totp,
@@ -828,6 +833,7 @@ def delete_user(id):
 
             # Delete all API tokens for this user
             db.session.query(UserToken).filter_by(user_id=user_id).delete()
+            db.session.query(PasswordSetupToken).filter_by(user_id=user_id).delete()
 
             # Now delete the user
             db.session.delete(user)
@@ -1049,14 +1055,15 @@ def add_guest():
         flash('A user with this email already exists')
         return redirect(url_for('main.manage_guests'))
 
-    # Generate a random password for guest (they can change it later)
-    import secrets
-    temp_password = secrets.token_urlsafe(16)
+    frontend_base = (current_app.config.get("FRONTEND_BASE_URL") or "").strip().rstrip("/")
+    if not frontend_base:
+        flash("FRONTEND_BASE_URL must be configured before inviting guest users")
+        return redirect(url_for('main.manage_guests'))
 
     new_guest = User(
         email=email,
         name=name,
-        password=generate_password_hash(temp_password, method='scrypt'),
+        password=generate_password_hash(secrets.token_urlsafe(48), method='scrypt'),
         admin=False,  # Guests are not admins
         is_global_admin=False,
         is_active=True,
@@ -1067,9 +1074,21 @@ def add_guest():
     db.session.add(new_guest)
     db.session.commit()
 
-    # Return template directly so the plaintext password is never stored in the session cookie.
-    # The password is only held in this request's local scope and rendered once.
-    return render_template('guest_password.html', temp_password=temp_password, name=name, email=email)
+    setup_url, expires_minutes = create_password_setup_link(new_guest)
+    sent = send_password_setup_email(
+        user_name=name,
+        user_email=email,
+        setup_url=setup_url,
+        expires_minutes=expires_minutes,
+    )
+    if sent:
+        flash(f"Guest invited. A password setup email was sent to {email}.")
+    else:
+        flash(
+            "Guest created, but setup email could not be sent. "
+            "Check global email settings and try again."
+        )
+    return redirect(url_for('main.manage_guests'))
 
 
 @main.route('/guest_password')
@@ -1088,6 +1107,7 @@ def remove_guest(guest_id):
     guest = User.query.filter_by(id=int(guest_id), account_owner_id=current_user.id).first()
 
     if guest:
+        db.session.query(PasswordSetupToken).filter_by(user_id=guest.id).delete()
         db.session.delete(guest)
         db.session.commit()
         flash('Guest user removed successfully')

--- a/app/password_setup.py
+++ b/app/password_setup.py
@@ -52,6 +52,12 @@ def create_password_setup_token(user: User) -> tuple[str, PasswordSetupToken]:
     return raw_token, token_record
 
 
+def create_password_setup_link(user: User) -> tuple[str, int]:
+    """Create a one-time setup token for ``user`` and return URL + expiry minutes."""
+    raw_token, _record = create_password_setup_token(user)
+    return build_password_setup_url(raw_token), get_password_setup_ttl_minutes()
+
+
 def consume_password_setup_token(raw_token: str) -> User | None:
     token_record = PasswordSetupToken.query.filter_by(token_hash=hash_token(raw_token)).first()
     if token_record is None:

--- a/app/templates/manage_guests.html
+++ b/app/templates/manage_guests.html
@@ -110,7 +110,7 @@
                         </label>
                         <input type="email" class="form-control-modern" name="email" placeholder="guest@email.com" required>
                         <small style="color: var(--text-secondary); display: block; margin-top: 0.5rem;">
-                            A temporary password will be generated and displayed after creation.
+                            A one-time password setup email will be sent after creation.
                         </small>
                     </div>
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,6 +15,7 @@ status codes, redirects, and flash messages where they are easy to assert.
 """
 
 import pytest
+import importlib
 from werkzeug.security import generate_password_hash
 
 
@@ -230,3 +231,55 @@ def test_delete_user_removes_passkey_credentials(
     assert passkey_credential_model.query.filter_by(
         credential_id="guest-credential-to-delete"
     ).first() is None
+
+
+class TestGuestOnboarding:
+    def test_add_guest_sends_password_setup_email(
+        self, auth_client, flask_app, app_ctx, user_model, password_setup_token_model, monkeypatch
+    ):
+        monkeypatch.setitem(flask_app.config, "FRONTEND_BASE_URL", "https://app.example.com/")
+        sent = {}
+
+        def _fake_send_password_setup_email(user_name, user_email, setup_url, expires_minutes):
+            sent["user_name"] = user_name
+            sent["user_email"] = user_email
+            sent["setup_url"] = setup_url
+            sent["expires_minutes"] = expires_minutes
+            return True
+
+        main_module = importlib.import_module("app.main")
+        monkeypatch.setattr(main_module, "send_password_setup_email", _fake_send_password_setup_email)
+        resp = auth_client.post(
+            "/add_guest",
+            data={"name": "Guest Invite", "email": "guest-invite@test.local"},
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert _flashed(resp.data, "password setup email was sent")
+        assert sent["user_name"] == "Guest Invite"
+        assert sent["user_email"] == "guest-invite@test.local"
+        assert sent["setup_url"].startswith("https://app.example.com/auth/set-password/")
+        assert isinstance(sent["expires_minutes"], int)
+
+        guest = user_model.query.filter_by(email="guest-invite@test.local").first()
+        assert guest is not None
+        assert guest.account_owner_id is not None
+
+        app_ctx.session.query(password_setup_token_model).filter_by(user_id=guest.id).delete()
+        app_ctx.session.delete(guest)
+        app_ctx.session.commit()
+
+    def test_add_guest_requires_frontend_base_url(
+        self, auth_client, flask_app, app_ctx, user_model, monkeypatch
+    ):
+        monkeypatch.setitem(flask_app.config, "FRONTEND_BASE_URL", "")
+        resp = auth_client.post(
+            "/add_guest",
+            data={"name": "No Frontend", "email": "guest-no-front@test.local"},
+            follow_redirects=True,
+        )
+
+        assert resp.status_code == 200
+        assert _flashed(resp.data, "frontend_base_url must be configured")
+        assert user_model.query.filter_by(email="guest-no-front@test.local").first() is None


### PR DESCRIPTION
### Motivation
- Replace the legacy flow that generated and displayed a one-time plaintext temporary password for newly created guest users with a safer email-based onboarding flow using one-time password-setup tokens, and reuse the same mechanics used for payments onboarding.
- Ensure guest onboarding is compatible with the cloud/payment onboarding flow and does not leak plaintext credentials or rely on session-local rendering.

### Description
- Added `create_password_setup_link(user)` to `app/password_setup.py` to return a one-time setup URL and TTL by reusing the existing token creation logic.
- Updated billing onboarding in `app/api/routes/billing.py` to call the shared helper so payment-created users and guests share the same token/link generation path.
- Reworked guest creation in `app/main.py` (`/add_guest`) to require `FRONTEND_BASE_URL`, create the guest account with a random hashed password, generate a password-setup token/link, send the setup email via `send_password_setup_email`, and surface clear flash messages for success/failure; removed the temporary-password display path.
- Cleaned up `PasswordSetupToken` records when deleting users or removing guests, and updated the guest-management template copy to reflect email-based onboarding; added route tests for the invite email flow and missing-`FRONTEND_BASE_URL` behavior.

### Testing
- Ran targeted tests `python -m pytest -q tests/test_routes.py tests/test_billing.py tests/test_password_setup_flow.py` and they passed.
- Ran the full test suite `python -m pytest -q` and all tests passed (244 passed, with expected deprecation warnings reported).
- New/updated route tests assert that the invite email is sent with a valid setup URL and that guest creation is blocked when `FRONTEND_BASE_URL` is not configured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da73c48ac08320afc2324b5e4f1b54)