### PR TITLE
Fix owner deletion to remove guest PasswordSetupToken rows before deleting guests

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -807,6 +807,15 @@ def delete_user(id):
             # Manually delete all related data before deleting the user
             user_id = user.id
 
+            # Delete setup tokens for all guests before deleting guest rows
+            guest_ids = [
+                guest_id for (guest_id,) in db.session.query(User.id).filter_by(account_owner_id=user_id).all()
+            ]
+            if guest_ids:
+                db.session.query(PasswordSetupToken).filter(
+                    PasswordSetupToken.user_id.in_(guest_ids)
+                ).delete(synchronize_session=False)
+
             # Delete all guest users for this admin user
             db.session.query(User).filter_by(account_owner_id=user_id).delete()
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -16,6 +16,7 @@ status codes, redirects, and flash messages where they are easy to assert.
 
 import pytest
 import importlib
+from datetime import datetime, timezone
 from werkzeug.security import generate_password_hash
 
 
@@ -231,6 +232,56 @@ def test_delete_user_removes_passkey_credentials(
     assert passkey_credential_model.query.filter_by(
         credential_id="guest-credential-to-delete"
     ).first() is None
+
+
+def test_delete_owner_removes_guest_password_setup_tokens(
+    auth_client, app_ctx, user_model, password_setup_token_model
+):
+    db = app_ctx
+    acting_admin = user_model.query.filter_by(email="admin@test.local").first()
+    acting_admin.is_global_admin = True
+    db.session.flush()
+
+    owner = user_model(
+        email="owner-delete@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Owner To Delete",
+        admin=True,
+        is_active=True,
+        account_owner_id=None,
+        is_global_admin=False,
+    )
+    db.session.add(owner)
+    db.session.flush()
+
+    guest = user_model(
+        email="guest-owner-delete@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Guest Of Owner To Delete",
+        admin=False,
+        is_active=True,
+        account_owner_id=owner.id,
+        is_global_admin=False,
+    )
+    db.session.add(guest)
+    db.session.flush()
+
+    guest_id = guest.id
+    token = password_setup_token_model(
+        user_id=guest.id,
+        token_hash="a" * 64,
+        expires_at=datetime.now(timezone.utc),
+    )
+    db.session.add(token)
+    db.session.commit()
+    token_id = token.id
+
+    resp = auth_client.post(f"/delete_user/{owner.id}", follow_redirects=False)
+
+    assert resp.status_code in (301, 302)
+    assert user_model.query.filter_by(id=owner.id).first() is None
+    assert user_model.query.filter_by(id=guest_id).first() is None
+    assert password_setup_token_model.query.filter_by(id=token_id).first() is None
 
 
 class TestGuestOnboarding:


### PR DESCRIPTION
### Motivation

- Prevent foreign-key violations when deleting an account owner whose guest users have `PasswordSetupToken` rows, since the migration created a non-cascading FK for `password_setup_tokens.user_id`.

### Description

- In `delete_user` flow (`app/main.py`) query and delete `PasswordSetupToken` rows for all guest `User.id`s (`account_owner_id=user_id`) before deleting guest `User` rows to ensure FK-safe deletion.
- Retain existing cleanup for the owner’s own `PasswordSetupToken` rows so both owner and guest tokens are removed during account deletion.
- Add a regression test (`tests/test_routes.py`) `test_delete_owner_removes_guest_password_setup_tokens` that creates an owner, guest, and a guest `PasswordSetupToken`, then asserts that deleting the owner removes both the guest and its token.
- Add `datetime, timezone` import used by the new test to construct an aware expiry timestamp.

### Testing

- Ran `python -m pytest -q tests/test_routes.py -q` and the test suite completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da76b4d044832093aa9b05882a1559)