### PR TITLE
Add server-rendered password setup flow for onboarding tokens

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -4,6 +4,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from .models import User, Settings, PasskeyCredential
 from app import db, limiter
 from .getemail import send_new_user_notification
+from .password_setup import consume_password_setup_token
 from .totp_utils import verify_totp, decrypt_totp_secret, verify_and_consume_backup_code
 from .subscription import enforce_user_access
 import logging
@@ -53,6 +54,16 @@ auth = Blueprint('auth', __name__)
 
 
 PASSKEY_CHALLENGE_TTL_SECONDS = 300
+
+
+def _validate_new_password(password: str) -> str | None:
+    if len(password) < 8:
+        return "Password must be at least 8 characters"
+    if password.lower() == password or password.upper() == password:
+        return "Password must include uppercase and lowercase letters"
+    if not any(ch.isdigit() for ch in password):
+        return "Password must include at least one number"
+    return None
 
 
 def _passkey_enabled() -> bool:
@@ -229,6 +240,43 @@ def logout():
     session.clear()
     logout_user()
     return redirect(url_for('main.index'))
+
+
+@auth.route('/auth/set-password/<token>', methods=['GET', 'POST'])
+def set_password(token: str):
+    setup_token = (token or "").strip()
+    if not setup_token:
+        flash("Invalid or expired password setup token")
+        return redirect(url_for('auth.login'))
+
+    if request.method == 'GET':
+        return render_template("set_password.html", token=setup_token)
+
+    password = request.form.get("password", "")
+    confirm_password = request.form.get("confirm_password", "")
+
+    if not password:
+        flash("Password is required")
+        return render_template("set_password.html", token=setup_token)
+    if password != confirm_password:
+        flash("Passwords do not match")
+        return render_template("set_password.html", token=setup_token)
+
+    password_error = _validate_new_password(password)
+    if password_error:
+        flash(password_error)
+        return render_template("set_password.html", token=setup_token)
+
+    user = consume_password_setup_token(setup_token)
+    if user is None:
+        flash("Invalid or expired password setup token")
+        return render_template("set_password.html", token=setup_token)
+
+    user.password = generate_password_hash(password, method="scrypt")
+    user.is_active = True
+    db.session.commit()
+    flash("Password setup complete. Please sign in.")
+    return redirect(url_for("auth.login"))
 
 
 def admin_required(f):

--- a/app/templates/set_password.html
+++ b/app/templates/set_password.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div style="max-width: 450px; margin: 4rem auto;">
+    <div class="metric-card" style="padding: 2rem;">
+        <h2 style="color: var(--text-primary); margin-bottom: 1rem; font-size: 1.5rem;">
+            Set your password
+        </h2>
+        <p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+            Create a new password to finish account setup.
+        </p>
+
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="alert alert-dismissible fade show" role="alert" style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid var(--danger); color: var(--text-primary); border-radius: var(--radius-md); margin-bottom: 1.5rem;">
+                <i class="fa-solid fa-circle-exclamation"></i>
+                {{ messages[0] }}
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endif %}
+        {% endwith %}
+
+        <form method="POST" action="{{ url_for('auth.set_password', token=token) }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+
+            <div class="form-group-modern">
+                <label class="form-label-modern">
+                    <i class="fa-solid fa-lock"></i> New Password
+                </label>
+                <input type="password" class="form-control-modern" name="password" required autofocus>
+            </div>
+
+            <div class="form-group-modern">
+                <label class="form-label-modern">
+                    <i class="fa-solid fa-shield"></i> Confirm Password
+                </label>
+                <input type="password" class="form-control-modern" name="confirm_password" required>
+            </div>
+
+            <button type="submit" class="btn-primary-modern btn-modern" style="width: 100%;">
+                <i class="fa-solid fa-check"></i>
+                Complete Setup
+            </button>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/tests/test_password_setup_flow.py
+++ b/tests/test_password_setup_flow.py
@@ -160,3 +160,40 @@ def test_password_setup_token_stored_hashed_only(
         assert stored is not None
         assert stored.token_hash != raw_token
         assert len(stored.token_hash) == 64
+
+
+def test_web_set_password_route_renders(client):
+    resp = client.get("/auth/set-password/example-token")
+    assert resp.status_code == 200
+    assert b"Set your password" in resp.data
+
+
+def test_web_set_password_route_completes_setup(
+    flask_app, client, app_ctx, user_model, password_setup_helpers
+):
+    create_password_setup_token = password_setup_helpers["create_token"]
+    with flask_app.app_context():
+        user = user_model(
+            email="web-setup@test.local",
+            password=generate_password_hash("TempPass123", method="scrypt"),
+            name="Web Setup",
+            admin=True,
+            is_active=False,
+        )
+        app_ctx.session.add(user)
+        app_ctx.session.commit()
+        raw_token, _record = create_password_setup_token(user)
+
+    resp = client.post(
+        f"/auth/set-password/{raw_token}",
+        data={"password": "NewSecure123", "confirm_password": "NewSecure123"},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert b"Password setup complete. Please sign in." in resp.data
+
+    with flask_app.app_context():
+        db_user = user_model.query.filter_by(email="web-setup@test.local").first()
+        assert db_user is not None
+        assert db_user.is_active is True
+        assert check_password_hash(db_user.password, "NewSecure123")


### PR DESCRIPTION
### Motivation
- Onboarding email links pointing at `/auth/set-password/<token>` were returning 404 when the frontend route was not available, preventing users from completing password setup.
- The change provides a server-rendered fallback so emailed setup links work directly against the Flask app domain and preserve the existing API-based completion flow.

### Description
- Added a new GET/POST route `@auth.route('/auth/set-password/<token>')` in `app/auth.py` that renders a password form, validates input, consumes the one-time token via `consume_password_setup_token`, hashes and stores the password, activates the user, and redirects to login.
- Introduced a `_validate_new_password` helper in `app/auth.py` to enforce password rules (min length, mixed case, number) consistent with API validation.
- Added a server-rendered template `app/templates/set_password.html` for the password setup UI and flash messaging.
- Extended `tests/test_password_setup_flow.py` with route-level tests `test_web_set_password_route_renders` and `test_web_set_password_route_completes_setup` to cover rendering and successful form completion.

### Testing
- Ran the focused tests with `python -m pytest -q tests/test_password_setup_flow.py` where all new and related tests passed (`10 passed`).
- Ran the full test suite with `python -m pytest -q` and observed all tests passing (`247 passed, 47 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da799b736083208883faf75419ad92)