### PR TITLE
Add forgot-password flow using existing password-setup tokens

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -3,8 +3,8 @@ from flask_login import login_user, login_required, logout_user, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
 from .models import User, Settings, PasskeyCredential
 from app import db, limiter
-from .getemail import send_new_user_notification
-from .password_setup import consume_password_setup_token
+from .getemail import send_new_user_notification, send_password_setup_email
+from .password_setup import consume_password_setup_token, create_password_setup_link
 from .totp_utils import verify_totp, decrypt_totp_secret, verify_and_consume_backup_code
 from .subscription import enforce_user_access
 import logging
@@ -78,6 +78,41 @@ def _passkey_enabled() -> bool:
 @auth.route('/login')
 def login():
     return render_template('login.html', passkey_enabled=_passkey_enabled())
+
+
+@auth.route('/forgot-password', methods=['GET', 'POST'])
+@limiter.limit("5 per minute")
+def forgot_password():
+    if request.method == 'GET':
+        return render_template('forgot_password.html')
+
+    email = (request.form.get('email') or '').strip().lower()
+    success_message = (
+        "If an account exists for that email, a password reset link has been sent."
+    )
+    if not email:
+        flash("Email address is required")
+        return render_template('forgot_password.html')
+
+    user = User.query.filter_by(email=email).first()
+    if user is not None:
+        try:
+            setup_url, expires_minutes = create_password_setup_link(user)
+            sent = send_password_setup_email(
+                user_name=user.name or user.email.split('@')[0],
+                user_email=user.email,
+                setup_url=setup_url,
+                expires_minutes=expires_minutes,
+            )
+            if not sent:
+                logger.warning("Password reset email could not be sent for user_id=%s", user.id)
+        except RuntimeError:
+            logger.exception("Forgot-password flow unavailable; FRONTEND_BASE_URL missing")
+            flash("Password reset is currently unavailable. Please contact support.")
+            return render_template('forgot_password.html')
+
+    flash(success_message)
+    return redirect(url_for('auth.login'))
 
 
 @auth.route('/login', methods=['POST'])

--- a/app/templates/forgot_password.html
+++ b/app/templates/forgot_password.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div style="max-width: 450px; margin: 4rem auto;">
+    <div class="metric-card" style="padding: 2rem;">
+        <h2 style="color: var(--text-primary); margin-bottom: 1.5rem; font-size: 1.5rem;">
+            Forgot Password
+        </h2>
+
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+            <div class="alert alert-dismissible fade show" role="alert" style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid var(--danger); color: var(--text-primary); border-radius: var(--radius-md); margin-bottom: 1.5rem;">
+                <i class="fa-solid fa-circle-exclamation"></i>
+                {{ messages[0] }}
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+        {% endif %}
+        {% endwith %}
+
+        <p style="color: var(--text-secondary); margin-bottom: 1.5rem;">
+            Enter your account email and we will send you a one-time password reset link.
+        </p>
+
+        <form method="POST" action="{{ url_for('auth.forgot_password') }}">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <div class="form-group-modern">
+                <label class="form-label-modern">
+                    <i class="fa-solid fa-envelope"></i> Email Address
+                </label>
+                <input type="email" class="form-control-modern" name="email" placeholder="your@email.com" required autofocus>
+            </div>
+
+            <button type="submit" class="btn-primary-modern btn-modern" style="width: 100%; margin-bottom: 1rem;">
+                <i class="fa-solid fa-paper-plane"></i>
+                Send Reset Link
+            </button>
+        </form>
+
+        <div style="margin-top: 1rem; text-align: center;">
+            <a href="{{ url_for('auth.login') }}" style="color: var(--accent); text-decoration: none; font-weight: 600;">
+                <i class="fa-solid fa-arrow-left"></i>
+                Back to Sign In
+            </a>
+        </div>
+    </div>
+</div>
+
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -52,6 +52,12 @@
                 </label>
             </div>
 
+            <div style="margin: -0.25rem 0 1rem; text-align: right;">
+                <a href="{{ url_for('auth.forgot_password') }}" style="color: var(--accent); text-decoration: none; font-weight: 600;">
+                    Forgot password?
+                </a>
+            </div>
+
             <button type="submit" class="btn-primary-modern btn-modern" style="width: 100%; margin-bottom: 1rem;">
                 <i class="fa-solid fa-right-to-bracket"></i>
                 Sign In

--- a/tests/test_password_setup_flow.py
+++ b/tests/test_password_setup_flow.py
@@ -1,5 +1,6 @@
 """Password setup onboarding flow tests."""
 
+import importlib
 from datetime import datetime, timedelta, timezone
 
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -197,3 +198,55 @@ def test_web_set_password_route_completes_setup(
         assert db_user is not None
         assert db_user.is_active is True
         assert check_password_hash(db_user.password, "NewSecure123")
+
+
+def test_forgot_password_route_sends_setup_email(
+    flask_app, client, app_ctx, user_model, password_setup_token_model, monkeypatch
+):
+    with flask_app.app_context():
+        user = user_model(
+            email="forgot-password@test.local",
+            password=generate_password_hash("TempPass123", method="scrypt"),
+            name="Forgot Password User",
+            admin=True,
+            is_active=True,
+        )
+        app_ctx.session.add(user)
+        app_ctx.session.commit()
+
+    flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com/"
+    sent = {}
+
+    def _fake_send_password_setup_email(user_name, user_email, setup_url, expires_minutes):
+        sent["user_name"] = user_name
+        sent["user_email"] = user_email
+        sent["setup_url"] = setup_url
+        sent["expires_minutes"] = expires_minutes
+        return True
+
+    auth_module = importlib.import_module("app.auth")
+    monkeypatch.setattr(auth_module, "send_password_setup_email", _fake_send_password_setup_email)
+
+    resp = client.post(
+        "/forgot-password",
+        data={"email": "forgot-password@test.local"},
+        follow_redirects=True,
+    )
+
+    assert resp.status_code == 200
+    assert b"password reset link has been sent" in resp.data
+    assert sent["user_name"] == "Forgot Password User"
+    assert sent["user_email"] == "forgot-password@test.local"
+    assert sent["setup_url"].startswith("https://app.example.com/auth/set-password/")
+    assert isinstance(sent["expires_minutes"], int)
+
+    with flask_app.app_context():
+        db_user = user_model.query.filter_by(email="forgot-password@test.local").first()
+        token = password_setup_token_model.query.filter_by(user_id=db_user.id).first()
+        assert token is not None
+
+
+def test_login_page_includes_forgot_password_link(client):
+    resp = client.get("/login")
+    assert resp.status_code == 200
+    assert b"Forgot password?" in resp.data


### PR DESCRIPTION
### Motivation
- Provide a web-accessible password reset that reuses the same one-time token/link and email mechanism already used by guest invites and paid-user onboarding.
- Avoid duplicating token/email logic and preserve existing `FRONTEND_BASE_URL` behavior and one-time token semantics.

### Description
- Add a rate-limited `GET`/`POST` route at `'/forgot-password'` in `app/auth.py` that validates the email, creates a one-time setup token using `create_password_setup_link`, and sends the reset link via `send_password_setup_email`.
- Return a generic success flash message to mitigate account enumeration and surface a friendly error if `FRONTEND_BASE_URL` is not configured.
- Add a `Forgot password?` link to the login page (`app/templates/login.html`) and a new template `app/templates/forgot_password.html` for the email form.
- Add tests in `tests/test_password_setup_flow.py` to verify the forgot-password email is sent, a token is created, and the login page renders the link.

### Testing
- Ran `python -m pytest -q tests/test_password_setup_flow.py` and observed the new tests pass (`12 passed`).
- Ran the full test suite `python -m pytest -q` and observed all tests passed (`249 passed`) with existing SQLAlchemy deprecation warnings (non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da7d6720e48320b9ea073e9571c70b)