### PR TITLE
Fix Alembic heads to a single head and disable runtime migration generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,10 +216,8 @@ For advanced users or custom deployments, PyCashFlow can be installed directly o
    pip install -r requirements.txt
    ```
 
-3. **Initialize Database**
+3. **Apply Database Migrations**
    ```bash
-   flask db init
-   flask db migrate -m "Initial migration"
    flask db upgrade
    ```
 
@@ -743,7 +741,6 @@ docker rm pycashflow
 ```bash
 cd /path/to/pycashflow
 git pull origin master
-flask db migrate -m "Update migration"
 flask db upgrade
 # Restart your WSGI server
 ```
@@ -752,9 +749,17 @@ flask db upgrade
 
 PyCashFlow uses Flask-Migrate for database schema management:
 
-- Migrations are automatically generated when database models change
-- Mount `/mnt/migrations` volume (Docker) to persist migration files
-- Run `flask db upgrade` after pulling updates
+- Migrations in `migrations/versions/` are source-controlled and are the only
+  schema history used by deployments.
+- Containers/startup scripts must **never** run `flask db init` or
+  `flask db migrate` automatically.
+- Startup may run `flask db upgrade` to apply checked-in migrations.
+- For model/schema changes during development:
+  1. Update models.
+  2. Run `flask db migrate -m "<description>"`.
+  3. Review the generated migration file in `migrations/versions/`.
+  4. Run `flask db upgrade`.
+  5. Commit both model changes and migration file to Git.
 
 ---
 

--- a/entry.sh
+++ b/entry.sh
@@ -12,9 +12,7 @@ chown appuser:appgroup /app/getemail.log
 # Daemon log goes to /app/crond.log (separate from job output in getemail.log).
 /usr/sbin/crond -f -l 8 -L /app/crond.log -c /app/crontabs/ &
 
-# Flask migrations as appuser
-su-exec appuser /usr/local/bin/flask --app app db init
-su-exec appuser /usr/local/bin/flask --app app db migrate
+# Apply checked-in migrations as appuser (never generate migrations at startup)
 su-exec appuser /usr/local/bin/flask --app app db upgrade
 
 # Run waitress as appuser (exec replaces the root shell — no root process remains)

--- a/migrations/versions/3979d4be8acf_merge_alembic_heads.py
+++ b/migrations/versions/3979d4be8acf_merge_alembic_heads.py
@@ -1,0 +1,24 @@
+"""merge alembic heads
+
+Revision ID: 3979d4be8acf
+Revises: a2b3c4d5e6f7, a9b8c7d6e5f4, f7a8b9c0d1e2
+Create Date: 2026-04-11 23:30:43.030115
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '3979d4be8acf'
+down_revision = ('a2b3c4d5e6f7', 'a9b8c7d6e5f4', 'f7a8b9c0d1e2')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### Motivation
- The repository had multiple Alembic heads and the container startup was auto-generating migrations, causing divergent runtime schema histories and making the repo not the single source of truth. 
- The goal is to consolidate migration history in the repo, stop boot-time `flask db init`/`flask db migrate`, and leave non-destructive stamping of deployed DBs to operators.

### Description
- Added an empty Alembic merge migration `migrations/versions/3979d4be8acf_merge_alembic_heads.py` that merges the three live heads `a2b3c4d5e6f7`, `a9b8c7d6e5f4`, and `f7a8b9c0d1e2` into a single head `3979d4be8acf` without altering historical migrations. 
- Updated the Docker/entry script `entry.sh` to remove `flask db init` and `flask db migrate` at startup and retain only `flask --app app db upgrade` so migrations are applied from checked-in files but never generated at boot. 
- Updated `README.md` to document the developer migration workflow and explicitly prohibit containers/startup from running `flask db init` or `flask db migrate` automatically.

### Testing
- Ran `flask --app app db heads` in-repo and confirmed exactly one head is present: `3979d4be8acf` (success). 
- Generated the merge migration via `flask db merge ...` and validated the generated file `migrations/versions/3979d4be8acf_merge_alembic_heads.py` compiles (`python -m compileall -q migrations/versions`) with no syntax errors (success). 
- Executed a focused test run `python -m pytest -q tests/test_api_foundation.py` and it passed (`38 passed`) to ensure startup/app behavior remained intact. 
- After pulling the fixed repo, stamp your deployed DB to the new repo head with: `flask --app app db stamp 3979d4be8acf` (then run `flask --app app db upgrade` as needed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dad98470248320877d3faaf7e38193)