### PR TITLE
Add TZ env var to configure container timezone (remove host /etc/localtime mount)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY constraints.txt constraints.txt
 # install everything except greenlet
 RUN pip install --no-cache-dir -r requirements.txt -c constraints.txt
 
-RUN apk --no-cache add curl su-exec
+RUN apk --no-cache add curl su-exec tzdata
 
 # Create a dedicated non-root runtime user and group
 RUN addgroup -S appgroup && adduser -S -G appgroup appuser
@@ -37,6 +37,7 @@ RUN mkdir -p /app/app/data && \
 
 ENV PYTHONPATH=/app
 ENV DATABASE_URL=sqlite:////app/app/data/db.sqlite
+ENV TZ=UTC
 
 HEALTHCHECK CMD curl --fail http://localhost:5000
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ docker run -d \
   -p 127.0.0.1:5000:5000 \
   -v /mnt/data:/app/app/data \
   -v /mnt/migrations:/app/migrations \
-  -v /etc/localtime:/etc/localtime:ro \
+  -e TZ=America/New_York \
   -v /mnt/.env:/app/app/.env \
   --restart always \
   --pull always \
@@ -182,8 +182,17 @@ docker run -d \
 |--------------|---------|----------|
 | `/mnt/data:/app/app/data` | Persistent database storage | **Yes** |
 | `/mnt/migrations:/app/migrations` | Database migration files | Recommended |
-| `/etc/localtime:/etc/localtime:ro` | Correct timezone for calculations | Recommended |
 | `/mnt/.env:/app/app/.env` | Environment variables (.env settings, passkeys, bootstrap admin, etc.) | Optional |
+
+#### Time Zone Configuration
+
+Set the container's local time zone using the `TZ` environment variable:
+
+```bash
+-e TZ=America/New_York
+```
+
+If `TZ` is not provided, the container defaults to `UTC`.
 
 #### Access the Application
 
@@ -275,6 +284,9 @@ For advanced users or custom deployments, PyCashFlow can be installed directly o
 
    # Optional: Database URL (defaults to SQLite)
    DATABASE_URL=sqlite:///data/db.sqlite
+
+   # Optional: container/app timezone (defaults to UTC)
+   TZ=America/New_York
    ```
 
 5. **Run the Application**

--- a/entry.sh
+++ b/entry.sh
@@ -1,5 +1,16 @@
 #!/bin/sh
 
+# Configure container local timezone from TZ env var (defaults to UTC).
+TZ_VALUE="${TZ:-UTC}"
+if [ -f "/usr/share/zoneinfo/${TZ_VALUE}" ]; then
+    ln -snf "/usr/share/zoneinfo/${TZ_VALUE}" /etc/localtime
+    echo "${TZ_VALUE}" > /etc/timezone
+else
+    echo "Invalid TZ '${TZ_VALUE}', falling back to UTC."
+    ln -snf /usr/share/zoneinfo/UTC /etc/localtime
+    echo "UTC" > /etc/timezone
+fi
+
 # Running as root here — fix ownership of any bind-mounted volumes so
 # appuser can read/write them, regardless of host directory ownership.
 chown -R appuser:appgroup /app/app/data


### PR DESCRIPTION
### Motivation

- Make container timezone configuration portable by using a `TZ` environment variable instead of instructing users to mount the host `/etc/localtime` file. 
- Provide a safe default (`UTC`) and fallback behavior so invalid `TZ` values do not break startup.

### Description

- Install `tzdata` in the Docker image and add `ENV TZ=UTC` to the `Dockerfile` so timezone data is available and `TZ` has a default. 
- Update `entry.sh` to read `TZ`, write `/etc/localtime` and `/etc/timezone` from the zoneinfo files, and fall back to `UTC` when the value is invalid. 
- Replace the README Docker run guidance to recommend `-e TZ=<Zone>` instead of mounting `/etc/localtime` and add `TZ` to the `.env` example.

### Testing

- Ran the test suite with `python -m pytest -q`, which completed successfully with `249 passed, 47 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dada7a84248320a8860598f8a55d99)