### PR TITLE
Honor TZ from mounted .env when initializing container timezone

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ RUN mkdir -p /app/app/data && \
 
 ENV PYTHONPATH=/app
 ENV DATABASE_URL=sqlite:////app/app/data/db.sqlite
-ENV TZ=UTC
 
 HEALTHCHECK CMD curl --fail http://localhost:5000
 

--- a/entry.sh
+++ b/entry.sh
@@ -1,7 +1,24 @@
 #!/bin/sh
 
-# Configure container local timezone from TZ env var (defaults to UTC).
-TZ_VALUE="${TZ:-UTC}"
+# Configure container local timezone from TZ env var, or /app/app/.env (defaults to UTC).
+#
+# Runtime env var takes precedence. If it is missing, attempt to read TZ from
+# the mounted .env file so timezone configuration works even when users only
+# set TZ there.
+TZ_VALUE="${TZ:-}"
+if [ -z "${TZ_VALUE}" ] && [ -f "/app/app/.env" ]; then
+    TZ_VALUE="$(awk -F= '
+        /^[[:space:]]*TZ[[:space:]]*=/ {
+            sub(/^[[:space:]]*TZ[[:space:]]*=[[:space:]]*/, "", $0)
+            gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+            gsub(/^["'"'"']|["'"'"']$/, "", $0)
+            print $0
+            exit
+        }
+    ' /app/app/.env)"
+fi
+TZ_VALUE="${TZ_VALUE:-UTC}"
+export TZ="${TZ_VALUE}"
 if [ -f "/usr/share/zoneinfo/${TZ_VALUE}" ]; then
     ln -snf "/usr/share/zoneinfo/${TZ_VALUE}" /etc/localtime
     echo "${TZ_VALUE}" > /etc/timezone


### PR DESCRIPTION
### Motivation
- Container startup always used the image `ENV TZ=UTC` or the runtime `TZ`, which prevented a mounted `.env` file from influencing the system timezone at boot. 
- `python-dotenv` is loaded inside `create_app()` (Python/Flask startup), so reading the `.env` there happens after container timezone setup in `entry.sh` and could not affect `/etc/localtime`. 
- The intent is to allow customers who mount `/app/app/.env` containing `TZ=...` to set the container timezone when they do not provide a runtime `-e TZ=...`.

### Description
- Update `entry.sh` to resolve timezone in this precedence: runtime `TZ` env var, `TZ` parsed from `/app/app/.env`, then `UTC` fallback. 
- The `.env` parsing uses `awk` and trims surrounding quotes/whitespace for a robust `TZ` value extraction. 
- The resolved value is `export`ed as `TZ` before applying `/usr/share/zoneinfo/...` so child processes inherit it. 
- Remove the image-level `ENV TZ=UTC` from the `Dockerfile` so an image default does not block `.env`-based configuration.

### Testing
- Ran `bash -n entry.sh` to validate shell syntax and it completed successfully. 
- Executed the parsing snippet against a temporary `.env` containing `TZ="America/New_York"` and it returned `America/New_York` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae19d546c8320acc95c63aed0c946)