### PR TITLE
Fix TZ environment fallback consistency in entrypoint

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -18,15 +18,16 @@ if [ -z "${TZ_VALUE}" ] && [ -f "/app/app/.env" ]; then
     ' /app/app/.env)"
 fi
 TZ_VALUE="${TZ_VALUE:-UTC}"
-export TZ="${TZ_VALUE}"
 if [ -f "/usr/share/zoneinfo/${TZ_VALUE}" ]; then
     ln -snf "/usr/share/zoneinfo/${TZ_VALUE}" /etc/localtime
     echo "${TZ_VALUE}" > /etc/timezone
 else
     echo "Invalid TZ '${TZ_VALUE}', falling back to UTC."
+    TZ_VALUE="UTC"
     ln -snf /usr/share/zoneinfo/UTC /etc/localtime
     echo "UTC" > /etc/timezone
 fi
+export TZ="${TZ_VALUE}"
 
 # Running as root here — fix ownership of any bind-mounted volumes so
 # appuser can read/write them, regardless of host directory ownership.


### PR DESCRIPTION
### Motivation
- Ensure child processes inherit the validated timezone and avoid mismatch between the `TZ` environment variable and `/etc/localtime` when a provided `TZ` value is invalid.

### Description
- Export `TZ` only after validating the chosen timezone and explicitly set `TZ_VALUE="UTC"` in the invalid-timezone fallback so `export TZ="${TZ_VALUE}"` matches the `/etc/localtime` change.

### Testing
- Ran `sh -n entry.sh` to verify the script parses and has no syntax errors, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae4daf0d48320bd85e4132417fd23)