### PR TITLE
Add configurable external sign-up URL (TextSettings), UI, validation and tests

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash, session, jsonify, current_app
 from flask_login import login_user, login_required, logout_user, current_user
 from werkzeug.security import generate_password_hash, check_password_hash
-from .models import User, Settings, PasskeyCredential
+from .models import User, Settings, PasskeyCredential, TextSettings
 from app import db, limiter
 from .getemail import send_new_user_notification, send_password_setup_email
 from .password_setup import consume_password_setup_token, create_password_setup_link
@@ -11,6 +11,7 @@ import logging
 from datetime import datetime, timezone
 from functools import wraps
 import json
+from urllib.parse import urlparse
 
 try:
     from webauthn import (
@@ -75,9 +76,25 @@ def _passkey_enabled() -> bool:
     )
 
 
+def _external_signup_url() -> str | None:
+    setting = TextSettings.query.filter_by(name='external_signup_url').first()
+    if not setting or not setting.value:
+        return None
+
+    candidate = setting.value.strip()
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ('http', 'https') or not parsed.netloc:
+        return None
+    return candidate
+
+
 @auth.route('/login')
 def login():
-    return render_template('login.html', passkey_enabled=_passkey_enabled())
+    return render_template(
+        'login.html',
+        passkey_enabled=_passkey_enabled(),
+        external_signup_url=_external_signup_url(),
+    )
 
 
 @auth.route('/forgot-password', methods=['GET', 'POST'])
@@ -212,6 +229,10 @@ def login_2fa_post():
 
 @auth.route('/signup')
 def signup():
+    external_signup_url = _external_signup_url()
+    if external_signup_url:
+        return redirect(external_signup_url)
+
     try:
         setting = Settings.query.filter_by(name='signup').first()
         if setting and setting.value == 1:

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from flask import (
 from flask_login import login_required, current_user
 from flask import Blueprint, render_template
 from .models import (
-    Schedule, Scenario, Balance, User, Settings, Email, Hold, Skip,
+    Schedule, Scenario, Balance, User, Settings, TextSettings, Email, Hold, Skip,
     GlobalEmailSettings, AISettings, PasskeyCredential, UserToken, PasswordSetupToken,
 )
 from app import db, limiter
@@ -13,6 +13,7 @@ import os
 import secrets
 import json
 import logging
+from urllib.parse import urlparse
 from sqlalchemy import desc, extract, asc
 from werkzeug.security import generate_password_hash, check_password_hash
 from .cashflow import update_cash, plot_cash, calculate_cash_risk_score
@@ -148,15 +149,18 @@ def settings():
         email_config = Email.query.filter_by(user_id=user_id).first()
         global_email_config = GlobalEmailSettings.query.first()
         signup_setting = Settings.query.filter_by(name='signup').first()
+        signup_link_setting = TextSettings.query.filter_by(name='external_signup_url').first()
         return render_template('settings.html', about=about, app_version=app_version, py_version=py_version,
                              ai_configured=ai_configured, ai_model=ai_model,
                              email_config=email_config, global_email_config=global_email_config,
-                             signup_setting=signup_setting)
+                             signup_setting=signup_setting, signup_link_setting=signup_link_setting)
     else:
         email_config = Email.query.filter_by(user_id=user_id).first()
         signup_setting = Settings.query.filter_by(name='signup').first()
+        signup_link_setting = TextSettings.query.filter_by(name='external_signup_url').first()
         return render_template('settings_guest.html', about=about, app_version=app_version, py_version=py_version,
-                             email_config=email_config, signup_setting=signup_setting)
+                             email_config=email_config, signup_setting=signup_setting,
+                             signup_link_setting=signup_link_setting)
 
 
 @main.route('/schedule')
@@ -611,7 +615,15 @@ def changepw():
 def signups():
     # set the settings options, in this case disable signups, from the profile page
     if request.method == 'POST':
+        external_signup_url = (request.form.get('external_signup_url') or '').strip()
+        if external_signup_url:
+            parsed_url = urlparse(external_signup_url)
+            if parsed_url.scheme not in ('http', 'https') or not parsed_url.netloc:
+                flash('External sign-up URL must be a valid http(s) URL')
+                return redirect(url_for('main.settings'))
+
         signupsettingname = Settings.query.filter_by(name='signup').first()
+        signup_link_setting = TextSettings.query.filter_by(name='external_signup_url').first()
 
         if signupsettingname:
             if request.form['signupvalue'] == "True":
@@ -619,6 +631,12 @@ def signups():
             else:
                 signupvalue = False
             signupsettingname.value = signupvalue
+            if signup_link_setting:
+                signup_link_setting.value = external_signup_url or None
+            else:
+                db.session.add(
+                    TextSettings(name='external_signup_url', value=external_signup_url or None)
+                )
             db.session.commit()
 
             return redirect(url_for('main.settings'))
@@ -630,6 +648,12 @@ def signups():
             signupvalue = False
         settings = Settings(name="signup", value=signupvalue)
         db.session.add(settings)
+        if signup_link_setting:
+            signup_link_setting.value = external_signup_url or None
+        else:
+            db.session.add(
+                TextSettings(name='external_signup_url', value=external_signup_url or None)
+            )
         db.session.commit()
 
         return redirect(url_for('main.settings'))

--- a/app/models.py
+++ b/app/models.py
@@ -119,6 +119,17 @@ class Settings(db.Model):
     )
 
 
+class TextSettings(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(100))
+    value = db.Column(db.String(500))
+
+    # Constraints
+    __table_args__ = (
+        db.UniqueConstraint('name', name='uq_text_settings_name'),
+    )
+
+
 class Email(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -74,7 +74,7 @@
         <!-- Sign up link -->
         <div style="margin-top: 1.5rem; text-align: center; padding-top: 1.5rem; border-top: 1px solid var(--border);">
             <p style="color: var(--text-secondary); margin-bottom: 0.5rem;">Don't have an account?</p>
-            <a href="{{url_for('auth.signup')}}" style="color: var(--accent); text-decoration: none; font-weight: 600;">
+            <a href="{{ external_signup_url or url_for('auth.signup') }}" style="color: var(--accent); text-decoration: none; font-weight: 600;">
                 <i class="fa-solid fa-user-plus"></i>
                 Create Account
             </a>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -356,6 +356,21 @@
                             <option value="True" {% if signup_setting and signup_setting.value %}selected{% endif %}>Disabled (Block sign-ups)</option>
                         </select>
                     </div>
+                    <div class="form-group-modern">
+                        <label class="form-label-modern">
+                            <i class="fa-solid fa-arrow-up-right-from-square"></i> External Sign-Up URL
+                        </label>
+                        <input
+                            class="form-control-modern"
+                            type="url"
+                            name="external_signup_url"
+                            placeholder="https://apps.apple.com/..."
+                            value="{{ signup_link_setting.value if signup_link_setting and signup_link_setting.value else '' }}"
+                        >
+                        <small style="color: var(--text-secondary); font-size: 0.75rem; margin-top: 0.25rem; display: block;">
+                            When set, Create Account redirects users to this URL.
+                        </small>
+                    </div>
 
                     <div style="display: flex; gap: 0.5rem; margin-top: 1.5rem;">
                         <button class="btn-primary-modern btn-modern" type="submit" style="flex: 1;">

--- a/app/templates/settings_guest.html
+++ b/app/templates/settings_guest.html
@@ -210,6 +210,21 @@
                             <option value="True" {% if signup_setting and signup_setting.value %}selected{% endif %}>Disabled (Block sign-ups)</option>
                         </select>
                     </div>
+                    <div class="form-group-modern">
+                        <label class="form-label-modern">
+                            <i class="fa-solid fa-arrow-up-right-from-square"></i> External Sign-Up URL
+                        </label>
+                        <input
+                            class="form-control-modern"
+                            type="url"
+                            name="external_signup_url"
+                            placeholder="https://apps.apple.com/..."
+                            value="{{ signup_link_setting.value if signup_link_setting and signup_link_setting.value else '' }}"
+                        >
+                        <small style="color: var(--text-secondary); font-size: 0.75rem; margin-top: 0.25rem; display: block;">
+                            When set, Create Account redirects users to this URL.
+                        </small>
+                    </div>
 
                     <div style="display: flex; gap: 0.5rem; margin-top: 1.5rem;">
                         <button class="btn-primary-modern btn-modern" type="submit" style="flex: 1;">

--- a/migrations/versions/a8c9d0e1f2a3_add_text_settings_table.py
+++ b/migrations/versions/a8c9d0e1f2a3_add_text_settings_table.py
@@ -1,0 +1,31 @@
+"""add text settings table
+
+Revision ID: a8c9d0e1f2a3
+Revises: 3979d4be8acf
+Create Date: 2026-04-12 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a8c9d0e1f2a3'
+down_revision = '3979d4be8acf'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'text_settings',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('name', sa.String(length=100), nullable=True),
+        sa.Column('value', sa.String(length=500), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name', name='uq_text_settings_name'),
+    )
+
+
+def downgrade():
+    op.drop_table('text_settings')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,8 @@ from app import create_app as _create_app, db as _db               # noqa: E402
 from app.models import (
     User as _User,
     Balance as _Balance,
+    Settings as _Settings,
+    TextSettings as _TextSettings,
     PasskeyCredential as _PasskeyCredential,
     PasswordSetupToken as _PasswordSetupToken,
 )  # noqa: E402
@@ -132,6 +134,18 @@ def passkey_credential_model():
 def password_setup_token_model():
     """Return the real PasswordSetupToken model captured before stubs are installed."""
     return _PasswordSetupToken
+
+
+@pytest.fixture(scope="session")
+def settings_model():
+    """Return the real Settings model captured before any module stubs are installed."""
+    return _Settings
+
+
+@pytest.fixture(scope="session")
+def text_settings_model():
+    """Return the real TextSettings model captured before any module stubs are installed."""
+    return _TextSettings
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -81,6 +81,64 @@ class TestAuthenticatedGetRoutes:
         assert "/" in resp.headers.get("Location", "")
 
 
+class TestSignupLinkBehavior:
+    def test_login_create_account_defaults_to_builtin_signup(self, client):
+        resp = client.get("/login", follow_redirects=True)
+        assert resp.status_code == 200
+        assert b'href="/signup"' in resp.data
+
+    def test_login_create_account_uses_external_signup_url(self, client, app_ctx, text_settings_model):
+        db = app_ctx
+        text_settings_model.query.filter_by(name="external_signup_url").delete()
+        db.session.add(
+            text_settings_model(name="external_signup_url", value="https://example.com/app-signup")
+        )
+        db.session.commit()
+
+        resp = client.get("/login", follow_redirects=True)
+        assert resp.status_code == 200
+        assert b'href="https://example.com/app-signup"' in resp.data
+
+        text_settings_model.query.filter_by(name="external_signup_url").delete()
+        db.session.commit()
+
+    def test_signup_route_redirects_to_external_url_when_configured(self, client, app_ctx, text_settings_model):
+        db = app_ctx
+        text_settings_model.query.filter_by(name="external_signup_url").delete()
+        db.session.add(
+            text_settings_model(name="external_signup_url", value="https://example.com/app-signup")
+        )
+        db.session.commit()
+
+        resp = client.get("/signup", follow_redirects=False)
+        assert resp.status_code in (301, 302)
+        assert resp.headers.get("Location") == "https://example.com/app-signup"
+
+        text_settings_model.query.filter_by(name="external_signup_url").delete()
+        db.session.commit()
+
+    def test_signups_post_rejects_invalid_external_signup_url(
+        self, auth_client, app_ctx, user_model, settings_model, text_settings_model
+    ):
+        db = app_ctx
+        admin = user_model.query.filter_by(email="admin@test.local").first()
+        admin.is_global_admin = True
+        db.session.commit()
+
+        settings_model.query.filter_by(name="signup").delete()
+        text_settings_model.query.filter_by(name="external_signup_url").delete()
+        db.session.commit()
+
+        resp = auth_client.post(
+            "/signups",
+            data={"signupvalue": "False", "external_signup_url": "javascript:alert(1)"},
+            follow_redirects=True,
+        )
+        assert resp.status_code == 200
+        assert _flashed(resp.data, "valid http")
+        assert text_settings_model.query.filter_by(name="external_signup_url").first() is None
+
+
 # ── Tests: schedule creation (POST /create) ───────────────────────────────────
 
 


### PR DESCRIPTION
### Motivation

- Allow administrators to configure an external sign-up URL so the Create Account flow can redirect to an external app/store instead of the built-in signup page.

### Description

- Introduced a new `TextSettings` model and Alembic migration to persist string configuration values (table `text_settings`).
- Added `_external_signup_url` helper and wiring in `auth.login` and `auth.signup` so the login page uses the external URL for the Create Account link and `/signup` redirects to it when configured.
- Added admin UI in `settings.html` and `settings_guest.html` to set the External Sign-Up URL and persisted the value in `TextSettings` from the `/signups` POST handler with `urlparse`-based validation enforcing `http`/`https` and a hostname.
- Updated templates (`login.html`, settings modals) and route imports to include `TextSettings`, plus small guards and input validation to prevent unsafe URLs.
- Extended test fixtures to expose `TextSettings` in `tests/conftest.py` and added `TestSignupLinkBehavior` tests in `tests/test_routes.py` to cover the link rendering, redirect behavior, and invalid-URL rejection.

### Testing

- Ran the new test class `tests/test_routes.py::TestSignupLinkBehavior` with `pytest` and the tests for the signup link rendering, redirect, and invalid URL validation passed.
- Ran the affected route tests (settings and login-related route tests) via `pytest` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dae87918608320955833810d95b121)