### PR TITLE
Enforce external sign-up redirect for direct POST /signup

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -246,6 +246,10 @@ def signup():
 @auth.route('/signup', methods=['POST'])
 @limiter.limit("5 per minute")
 def signup_post():
+    external_signup_url = _external_signup_url()
+    if external_signup_url:
+        return redirect(external_signup_url)
+
     # code to validate and add user to database goes here
     email = (request.form.get('email') or '').strip().lower()
     name = request.form.get('name')

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -117,6 +117,32 @@ class TestSignupLinkBehavior:
         text_settings_model.query.filter_by(name="external_signup_url").delete()
         db.session.commit()
 
+    def test_signup_post_redirects_to_external_url_when_configured(
+        self, client, app_ctx, text_settings_model, user_model
+    ):
+        db = app_ctx
+        text_settings_model.query.filter_by(name="external_signup_url").delete()
+        db.session.add(
+            text_settings_model(name="external_signup_url", value="https://example.com/app-signup")
+        )
+        db.session.commit()
+
+        email = "external-signup-post@test.local"
+        user_model.query.filter_by(email=email).delete()
+        db.session.commit()
+
+        resp = client.post(
+            "/signup",
+            data={"email": email, "name": "External Post", "password": "TestPass123"},
+            follow_redirects=False,
+        )
+        assert resp.status_code in (301, 302)
+        assert resp.headers.get("Location") == "https://example.com/app-signup"
+        assert user_model.query.filter_by(email=email).first() is None
+
+        text_settings_model.query.filter_by(name="external_signup_url").delete()
+        db.session.commit()
+
     def test_signups_post_rejects_invalid_external_signup_url(
         self, auth_client, app_ctx, user_model, settings_model, text_settings_model
     ):


### PR DESCRIPTION
### Motivation

- The GET `/signup` route already redirected to an externally configured sign-up URL, but `POST /signup` still allowed direct form submissions which could bypass the external sign-up policy and create local accounts.

### Description

- Added an early guard in `signup_post` to call `_external_signup_url()` and return a redirect when an external sign-up URL is configured, before any local user creation logic runs (`app/auth.py`).
- Added a regression test `test_signup_post_redirects_to_external_url_when_configured` in `tests/test_routes.py` to verify that a direct `POST /signup` redirects to the configured external URL and does not create a local user.

### Testing

- Ran `python -m pytest -q tests/test_routes.py -k "signup"`, which passed (`5 passed`).
- Ran the full suite with `python -m pytest -q`, which completed successfully (`254 passed`, with warnings)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daec96fd6c8320a382521ecd86d5d0)