### PR TITLE
Replace Waitress with Gunicorn for containerized production startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ PyCashFlow is a powerful, multi-user web application designed to help individual
 - **Flask**: Lightweight Python web framework
 - **SQLAlchemy**: SQL toolkit and ORM for database management
 - **Flask-Migrate**: Database migration management
-- **Waitress**: Production-ready WSGI server
+- **Gunicorn**: Production-ready WSGI server
 - **Flask-Login**: User session management
 - **Flask-Limiter**: Rate limiting for API and auth endpoints
 
@@ -198,6 +198,22 @@ If `TZ` is not provided, the container defaults to `UTC`.
 
 Once running, access PyCashFlow at `http://localhost:5000`
 
+#### Production WSGI Server (Gunicorn)
+
+Containerized production startup uses Gunicorn (via `/entry.sh`) and keeps startup behavior unchanged: timezone setup, ownership fixes, cron startup, and `flask db upgrade` before serving requests.
+
+Supported Gunicorn environment variables:
+
+- `GUNICORN_WORKERS`: Number of worker processes (default: `2 * CPU + 1`)
+- `GUNICORN_TIMEOUT`: Worker timeout seconds (default: `120`)
+
+Example:
+
+```bash
+-e GUNICORN_WORKERS=4 \
+-e GUNICORN_TIMEOUT=180
+```
+
 ---
 
 ### Manual Installation
@@ -209,7 +225,7 @@ For advanced users or custom deployments, PyCashFlow can be installed directly o
 - Python 3.11 or higher
 - pip (Python package manager)
 - Git
-- WSGI server (Waitress, Gunicorn, or uWSGI)
+- WSGI server (Gunicorn or uWSGI)
 - (Optional) Reverse proxy (Nginx or Apache)
 
 #### Installation Steps

--- a/entry.sh
+++ b/entry.sh
@@ -44,5 +44,24 @@ chown appuser:appgroup /app/getemail.log
 # Apply checked-in migrations as appuser (never generate migrations at startup)
 su-exec appuser /usr/local/bin/flask --app app db upgrade
 
-# Run waitress as appuser (exec replaces the root shell — no root process remains)
-exec su-exec appuser waitress-serve --listen=0.0.0.0:5000 --call app:create_app
+# Derive safe Gunicorn defaults (override with env vars as needed).
+CPU_COUNT="$(getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/null || echo 1)"
+case "${CPU_COUNT}" in
+    ''|*[!0-9]*|0) CPU_COUNT=1 ;;
+esac
+DEFAULT_GUNICORN_WORKERS=$((CPU_COUNT * 2 + 1))
+GUNICORN_WORKERS="${GUNICORN_WORKERS:-${DEFAULT_GUNICORN_WORKERS}}"
+GUNICORN_TIMEOUT="${GUNICORN_TIMEOUT:-120}"
+
+echo "Starting Gunicorn: workers=${GUNICORN_WORKERS}, timeout=${GUNICORN_TIMEOUT}, bind=0.0.0.0:5000"
+
+# Run gunicorn as appuser (exec replaces the root shell — no root process remains)
+exec su-exec appuser gunicorn \
+    --bind 0.0.0.0:5000 \
+    --workers "${GUNICORN_WORKERS}" \
+    --worker-class sync \
+    --timeout "${GUNICORN_TIMEOUT}" \
+    --access-logfile - \
+    --error-logfile - \
+    --capture-output \
+    'app:create_app()'

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy
 python-dateutil
 natsort
 Flask-Migrate
-waitress
+gunicorn
 werkzeug
 webauthn
 python-dotenv


### PR DESCRIPTION
### Motivation
- Replace the container's WSGI server from Waitress to Gunicorn for a more typical production deployment while preserving all existing startup behavior.
- Keep the Flask app factory pattern (`create_app`) intact and ensure the server runs as `appuser` with logs going to Docker stdout/stderr.

### Description
- Swapped `waitress` for `gunicorn` in `requirements.txt` and left all other dependency lines unchanged (file changed: `requirements.txt`).
- Replaced the final `waitress-serve` call in `entry.sh` with a Gunicorn launch that detects CPU count and computes a safe default worker count of `2 * CPU + 1`, while supporting `GUNICORN_WORKERS` and `GUNICORN_TIMEOUT` overrides and keeping timezone setup, ownership fixes, crond startup, and `flask --app app db upgrade` intact (file changed: `entry.sh`).
- Gunicorn is invoked against the app factory using the quoted factory target `'app:create_app()'` with `--bind 0.0.0.0:5000`, `--worker-class sync`, `--access-logfile -`, `--error-logfile -`, and `--capture-output` so logs flow to stdout/stderr.
- Added a short README note documenting that the container uses Gunicorn and the supported env vars `GUNICORN_WORKERS` and `GUNICORN_TIMEOUT` with an example (file changed: `README.md`).

### Testing
- Checked shell syntax with `sh -n entry.sh` and the script is valid.
- Ran the full test suite with `python -m pytest -q` which passed (`254 passed`) in this environment.
- Attempted `pip install -r requirements.txt` but the environment could not fetch `gunicorn` due to outbound network/proxy restrictions, so package-install validation for `gunicorn` could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daeec1f20c8320a78d06e14b0d701c)