### PR TITLE
Default Gunicorn worker count to 1 when rate limiting uses memory storage

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -50,7 +50,18 @@ case "${CPU_COUNT}" in
     ''|*[!0-9]*|0) CPU_COUNT=1 ;;
 esac
 DEFAULT_GUNICORN_WORKERS=$((CPU_COUNT * 2 + 1))
-GUNICORN_WORKERS="${GUNICORN_WORKERS:-${DEFAULT_GUNICORN_WORKERS}}"
+
+# Flask-Limiter defaults to in-memory storage (memory://), which is process-local.
+# Keep a single worker by default unless a shared rate-limit backend is configured.
+if [ -n "${GUNICORN_WORKERS:-}" ]; then
+    RESOLVED_GUNICORN_WORKERS="${GUNICORN_WORKERS}"
+elif [ -z "${RATELIMIT_STORAGE_URI:-}" ] || [ "${RATELIMIT_STORAGE_URI}" = "memory://" ]; then
+    RESOLVED_GUNICORN_WORKERS=1
+else
+    RESOLVED_GUNICORN_WORKERS="${DEFAULT_GUNICORN_WORKERS}"
+fi
+
+GUNICORN_WORKERS="${RESOLVED_GUNICORN_WORKERS}"
 GUNICORN_TIMEOUT="${GUNICORN_TIMEOUT:-120}"
 
 echo "Starting Gunicorn: workers=${GUNICORN_WORKERS}, timeout=${GUNICORN_TIMEOUT}, bind=0.0.0.0:5000"


### PR DESCRIPTION
### Motivation
- Prevent accidental weakening of application rate limits by avoiding multiple Gunicorn workers when Flask-Limiter is using the process-local `memory://` backend.

### Description
- Update `entry.sh` to resolve `GUNICORN_WORKERS` so an explicit `GUNICORN_WORKERS` value still wins, otherwise default to `1` if `RATELIMIT_STORAGE_URI` is unset or `memory://`, and fall back to the previous `2 * CPU + 1` default only when a shared rate-limit backend is configured.

### Testing
- Ran the full test suite with `python -m pytest -q`, which completed successfully with `254 passed, 48 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf2d12a1c8320850841ac0157b94f)