### PR TITLE
Handle in-memory rate-limit URI variants when resolving Gunicorn workers

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -55,10 +55,15 @@ DEFAULT_GUNICORN_WORKERS=$((CPU_COUNT * 2 + 1))
 # Keep a single worker by default unless a shared rate-limit backend is configured.
 if [ -n "${GUNICORN_WORKERS:-}" ]; then
     RESOLVED_GUNICORN_WORKERS="${GUNICORN_WORKERS}"
-elif [ -z "${RATELIMIT_STORAGE_URI:-}" ] || [ "${RATELIMIT_STORAGE_URI}" = "memory://" ]; then
+elif [ -z "${RATELIMIT_STORAGE_URI:-}" ]; then
     RESOLVED_GUNICORN_WORKERS=1
 else
-    RESOLVED_GUNICORN_WORKERS="${DEFAULT_GUNICORN_WORKERS}"
+    # Treat any case/variant of memory://... as process-local storage.
+    RATELIMIT_STORAGE_URI_NORMALIZED="$(printf '%s' "${RATELIMIT_STORAGE_URI}" | tr '[:upper:]' '[:lower:]')"
+    case "${RATELIMIT_STORAGE_URI_NORMALIZED}" in
+        memory://*) RESOLVED_GUNICORN_WORKERS=1 ;;
+        *) RESOLVED_GUNICORN_WORKERS="${DEFAULT_GUNICORN_WORKERS}" ;;
+    esac
 fi
 
 GUNICORN_WORKERS="${RESOLVED_GUNICORN_WORKERS}"


### PR DESCRIPTION
### Motivation
- Flask-Limiter accepts multiple `memory://` URI variants (for example `memory:///` or mixed-case variants) which were not detected by the prior exact match, so multi-worker defaults could be chosen and effectively weaken rate limiting by creating per-worker buckets.

### Description
- Normalize `RATELIMIT_STORAGE_URI` to lowercase and match `memory://*` in `entry.sh` so any memory-based limiter URI is treated as process-local and forces a single Gunicorn worker.
- Preserve explicit `GUNICORN_WORKERS` overrides and keep the single-worker fallback behavior when `RATELIMIT_STORAGE_URI` is unset.

### Testing
- Validated shell syntax with `sh -n entry.sh` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daf545629083208e8a1d54db5ec4bb)