### PR TITLE
Make cron startup configurable via ENABLE_CRON

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ docker run -d \
   -v /mnt/data:/app/app/data \
   -v /mnt/migrations:/app/migrations \
   -e TZ=America/New_York \
+  -e ENABLE_CRON=true \
   -v /mnt/.env:/app/app/.env \
   --restart always \
   --pull always \
@@ -200,16 +201,35 @@ Once running, access PyCashFlow at `http://localhost:5000`
 
 #### Production WSGI Server (Gunicorn)
 
-Containerized production startup uses Gunicorn (via `/entry.sh`) and keeps startup behavior unchanged: timezone setup, ownership fixes, cron startup, and `flask db upgrade` before serving requests.
+Containerized production startup uses Gunicorn (via `/entry.sh`) and keeps startup behavior unchanged: timezone setup, ownership fixes, optional cron startup, and `flask db upgrade` before serving requests.
+
+#### Cron Startup Control
+
+Use `ENABLE_CRON` to control whether container startup launches `crond`:
+
+- `ENABLE_CRON=true` (default): start cron inside the container
+- `ENABLE_CRON=false`: skip cron startup
+- If unset, startup defaults to `true`
+
+`ENABLE_CRON` can be provided either as a Docker environment variable (`-e ENABLE_CRON=...`) or in your mounted `.env` file at `/app/app/.env`.
+
+For platforms like **DigitalOcean App Platform** where you run scheduled jobs separately, set:
+
+```bash
+-e ENABLE_CRON=false
+```
 
 Supported Gunicorn environment variables:
 
-- `GUNICORN_WORKERS`: Number of worker processes (default: `2 * CPU + 1`)
+- `GUNICORN_WORKERS`: Number of worker processes. If unset, startup chooses:
+  - `1` when `RATELIMIT_STORAGE_URI` is unset or uses `memory://` (process-local rate-limit storage)
+  - otherwise `2 * CPU + 1`
 - `GUNICORN_TIMEOUT`: Worker timeout seconds (default: `120`)
 
 Example:
 
 ```bash
+-e ENABLE_CRON=false \
 -e GUNICORN_WORKERS=4 \
 -e GUNICORN_TIMEOUT=180
 ```

--- a/app/.env_example
+++ b/app/.env_example
@@ -1,6 +1,14 @@
 # Optional: runtime environment
 # FLASK_ENV=production
 
+# Optional: container timezone (defaults to UTC when unset).
+# TZ=UTC
+
+# Optional: container cron toggle.
+# true (default): start crond for scheduled jobs
+# false: skip crond startup (use external scheduler/platform jobs)
+ENABLE_CRON=true
+
 # Optional: Database URL (defaults to SQLite at app/data/db.sqlite)
 # DATABASE_URL=sqlite:///data/db.sqlite
 
@@ -24,6 +32,13 @@ SESSION_COOKIE_SECURE=true
 # For multi-process/multi-server deployments, use a Redis URL, e.g.:
 #   RATELIMIT_STORAGE_URI=redis://localhost:6379/0
 RATELIMIT_STORAGE_URI=
+
+# Optional: Gunicorn worker process count.
+# If unset, startup auto-selects workers based on CPU and rate-limit backend.
+GUNICORN_WORKERS=
+
+# Optional: Gunicorn worker timeout in seconds (defaults to 120).
+GUNICORN_TIMEOUT=120
 
 # Optional: create the initial global admin on first startup instead of relying
 # on the signup form. Remove or leave blank after the account is created.

--- a/entry.sh
+++ b/entry.sh
@@ -1,23 +1,44 @@
 #!/bin/sh
 
+DOTENV_FILE="/app/app/.env"
+
+# Resolve a variable from runtime environment first, then from /app/app/.env.
+# Usage: get_env_or_dotenv "VAR_NAME" "default_value"
+get_env_or_dotenv() {
+    var_name="$1"
+    default_value="$2"
+
+    eval "runtime_value=\${${var_name}:-}"
+    if [ -n "${runtime_value}" ]; then
+        printf '%s' "${runtime_value}"
+        return 0
+    fi
+
+    if [ -f "${DOTENV_FILE}" ]; then
+        dotenv_value="$(awk -F= -v key="${var_name}" '
+            $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+                sub(/^[[:space:]]*[^=]+=[[:space:]]*/, "", $0)
+                gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
+                gsub(/^["'"'"']|["'"'"']$/, "", $0)
+                print $0
+                exit
+            }
+        ' "${DOTENV_FILE}")"
+        if [ -n "${dotenv_value}" ]; then
+            printf '%s' "${dotenv_value}"
+            return 0
+        fi
+    fi
+
+    printf '%s' "${default_value}"
+}
+
 # Configure container local timezone from TZ env var, or /app/app/.env (defaults to UTC).
 #
 # Runtime env var takes precedence. If it is missing, attempt to read TZ from
 # the mounted .env file so timezone configuration works even when users only
 # set TZ there.
-TZ_VALUE="${TZ:-}"
-if [ -z "${TZ_VALUE}" ] && [ -f "/app/app/.env" ]; then
-    TZ_VALUE="$(awk -F= '
-        /^[[:space:]]*TZ[[:space:]]*=/ {
-            sub(/^[[:space:]]*TZ[[:space:]]*=[[:space:]]*/, "", $0)
-            gsub(/^[[:space:]]+|[[:space:]]+$/, "", $0)
-            gsub(/^["'"'"']|["'"'"']$/, "", $0)
-            print $0
-            exit
-        }
-    ' /app/app/.env)"
-fi
-TZ_VALUE="${TZ_VALUE:-UTC}"
+TZ_VALUE="$(get_env_or_dotenv "TZ" "UTC")"
 if [ -f "/usr/share/zoneinfo/${TZ_VALUE}" ]; then
     ln -snf "/usr/share/zoneinfo/${TZ_VALUE}" /etc/localtime
     echo "${TZ_VALUE}" > /etc/timezone
@@ -36,10 +57,24 @@ chown -R appuser:appgroup /app/migrations
 chown appuser:appgroup /app/getemail.log
 # crond.log is written by root crond — leave as root:root
 
-# Run crond in foreground mode (-f) so it doesn't double-fork into an
-# unreachable daemon; & sends it to the background so this script continues.
-# Daemon log goes to /app/crond.log (separate from job output in getemail.log).
-/usr/sbin/crond -f -l 8 -L /app/crond.log -c /app/crontabs/ &
+ENABLE_CRON_RESOLVED="$(get_env_or_dotenv "ENABLE_CRON" "true")"
+ENABLE_CRON_NORMALIZED="$(printf '%s' "${ENABLE_CRON_RESOLVED}" | tr '[:upper:]' '[:lower:]')"
+case "${ENABLE_CRON_NORMALIZED}" in
+    true|1|yes|on)
+        START_CRON=true
+        ;;
+    *)
+        START_CRON=false
+        ;;
+esac
+
+echo "ENABLE_CRON resolved to '${ENABLE_CRON_RESOLVED}' (from env/.env); cron startup: ${START_CRON}"
+if [ "${START_CRON}" = "true" ]; then
+    # Run crond in foreground mode (-f) so it doesn't double-fork into an
+    # unreachable daemon; & sends it to the background so this script continues.
+    # Daemon log goes to /app/crond.log (separate from job output in getemail.log).
+    /usr/sbin/crond -f -l 8 -L /app/crond.log -c /app/crontabs/ &
+fi
 
 # Apply checked-in migrations as appuser (never generate migrations at startup)
 su-exec appuser /usr/local/bin/flask --app app db upgrade


### PR DESCRIPTION
### Motivation
- Provide an easy way to disable in-container cron for platforms that run scheduled jobs externally while keeping current behavior for most users. 
- Ensure `ENABLE_CRON` can be supplied from Docker env vars or a mounted `.env` so typical container and mounted-config workflows both work. 

### Description
- Added `get_env_or_dotenv()` to `entry.sh` to resolve runtime env vars first, then `/app/app/.env`, and used it to read `ENABLE_CRON` (defaulting to `true`).
- Normalized common truthy values and only start `crond` when `ENABLE_CRON` resolves to a truthy value, while preserving existing startup steps (`TZ` handling, ownership fixes, `flask db upgrade`, and Gunicorn execution). 
- Updated `app/.env_example` to include `ENABLE_CRON`, `GUNICORN_WORKERS`, and `GUNICORN_TIMEOUT` with sensible defaults/comments. 
- Updated `README.md` to document `ENABLE_CRON` (default enabled), how to disable it for platforms like DigitalOcean App Platform, and the supported Gunicorn environment variables and selection behavior. 

Files changed: `entry.sh`, `app/.env_example`, `README.md`.

### Testing
- Verified `entry.sh` syntax with `sh -n entry.sh` and it returned successfully. 
- Ran the full test suite with `python -m pytest -q` and all tests passed (`254 passed`, `48 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db12f59b5c8320bdc709b527b19211)