### PR TITLE
Add App Store Server API verification and billing flow for iOS subscriptions

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,42 @@
+# Required: Flask session/app secrets
+SECRET_KEY=replace-with-generated-secret
+APP_SECRET=replace-with-fernet-key
+
+# Optional: database + runtime
+DATABASE_URL=sqlite:///app/data/db.sqlite
+SESSION_COOKIE_SECURE=false
+RATELIMIT_STORAGE_URI=memory://
+
+# Optional: passkeys
+PASSKEY_RP_ID=localhost
+PASSKEY_RP_NAME=PyCashFlow
+PASSKEY_ORIGIN=http://localhost:5000
+
+# Optional: bootstrap first global admin
+BOOTSTRAP_ADMIN_EMAIL=admin@example.com
+BOOTSTRAP_ADMIN_PASSWORD=changeme
+
+# Payments toggle
+PAYMENTS_ENABLED=false
+
+# Required for payment-created user onboarding links
+FRONTEND_BASE_URL=
+PASSWORD_SETUP_TOKEN_TTL_MINUTES=60
+
+# Stripe (web checkout)
+STRIPE_WEBHOOK_SECRET=
+
+# App Store verification
+# Use stub only for local/dev testing
+APPSTORE_ALLOW_STUB_VERIFICATION=false
+
+# Required for real App Store Server API verification
+APPLE_ISSUER_ID=
+APPLE_KEY_ID=
+# Provide either inline key or a file path
+APPLE_PRIVATE_KEY=
+APPLE_PRIVATE_KEY_PATH=
+# Recommended verification guard
+APPLE_BUNDLE_ID=
+# production | sandbox | auto
+APPLE_ENVIRONMENT=production

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -339,7 +339,10 @@ A SwiftUI client now lives under `/ios-app` with this structure:
 - `PAYMENTS_ENABLED=false` bypasses subscription enforcement for self-hosted/manual operation.
 - Subscription truth sources:
   - Stripe webhook events (`/api/v1/billing/webhook/stripe`)
-  - App Store verification endpoint (`/api/v1/billing/verify-appstore`)
+  - App Store verification endpoint (`/api/v1/billing/verify-appstore`) using
+    App Store Server API JWT auth (`APPLE_ISSUER_ID`, `APPLE_KEY_ID`,
+    `APPLE_PRIVATE_KEY`/`APPLE_PRIVATE_KEY_PATH`, optional `APPLE_BUNDLE_ID`,
+    and `APPLE_ENVIRONMENT=production|sandbox|auto`)
 - Do not trust client-side purchase state for activation.
 - Global admins always bypass subscription checks and must remain active.
 - Guests inherit effective access from their account owner (`owner_user_id` or legacy `account_owner_id`).

--- a/MOBILE_API_REFERENCE.md
+++ b/MOBILE_API_REFERENCE.md
@@ -896,7 +896,18 @@ Stripe webhook receiver. Verifies `Stripe-Signature` using server-side
 
 #### POST /api/v1/billing/verify-appstore
 
-Server endpoint for iOS subscription verification.
+Server endpoint for iOS subscription verification against Apple App Store Server API.
+
+
+### App Store verification notes
+
+- Real verification requires backend App Store Connect credentials (`APPLE_ISSUER_ID`,
+  `APPLE_KEY_ID`, `APPLE_PRIVATE_KEY` or `APPLE_PRIVATE_KEY_PATH`).
+- `transaction.original_transaction_id` is required for real verification.
+- `APPLE_ENVIRONMENT=auto` enables production-first with sandbox fallback.
+- Response `data.environment` indicates which environment resolved the transaction.
+- If verification fails, backend returns `401 unauthorized` and no account activation occurs.
+- Local development may opt into `APPSTORE_ALLOW_STUB_VERIFICATION=true` (non-production).
 
 **Auth required:** No
 
@@ -917,7 +928,7 @@ Server endpoint for iOS subscription verification.
 ```json
 {
   "data": {
-    "verification_status": "verified_stub",
+    "verification_status": "verified",
     "user_id": 123,
     "subscription_status": "active",
     "subscription_source": "app_store"

--- a/PAYMENTS.md
+++ b/PAYMENTS.md
@@ -5,7 +5,7 @@
 PyCashFlow supports three activation sources:
 
 1. **Stripe subscriptions** (web checkout + webhook truth source)
-2. **Apple App Store subscriptions** (server-side verification endpoint; currently stubbed verifier)
+2. **Apple App Store subscriptions** (server-side verification via App Store Server API JWT auth)
 3. **Self-hosted/manual** activation when `PAYMENTS_ENABLED=false`
 
 All subscription state is stored on `User` and enforced centrally for both web and API auth paths.
@@ -51,11 +51,19 @@ Default behavior in this repository is `PAYMENTS_ENABLED=false`.
 ## App Store Flow
 
 ### `POST /api/v1/billing/verify-appstore`
-- Public endpoint for iOS receipt or transaction payload.
-- Current implementation has **stub verification scaffold** (`verification_status=verified_stub`) for future Apple server verification integration.
-- Extracts email + expiry, creates/updates account owner, marks source `app_store`, and activates account.
+- Public endpoint for iOS receipt/transaction payload.
+- Uses Apple App Store Server API (`/inApps/v1/subscriptions/{originalTransactionId}`)
+  with ES256 JWT bearer auth generated from App Store Connect credentials.
+- Supports `APPLE_ENVIRONMENT=production|sandbox|auto` (`auto` tries production then sandbox).
+- Optionally validates `APPLE_BUNDLE_ID` against Apple-signed transaction payload.
+- Applies subscription lifecycle transitions from Apple truth source:
+  - Active statuses (`1`, `3`, `4`) => `subscription_status=active`, `is_active=true`
+  - Non-active statuses => `subscription_status=expired`, `is_active=false`
+- Creates/updates account owner by email and stores source `app_store`.
 - For first-time paid users only, creates a one-time password setup token and
   sends an onboarding email. Existing users do not receive setup email.
+- Optional local/dev stub mode remains available with
+  `APPSTORE_ALLOW_STUB_VERIFICATION=true` (returns `verification_status=verified_stub`).
 
 ## Paid User Onboarding Lifecycle
 
@@ -96,3 +104,16 @@ Global admins always remain active and bypass subscription checks.
 - Client-provided payment status is never trusted for final access control.
 - Stripe webhooks must pass signature verification.
 - Subscription transitions are logged with user id, source, status changes, and expiry.
+
+
+## App Store Server Credentials
+
+Set these environment variables for real App Store verification:
+
+- `APPLE_ISSUER_ID`
+- `APPLE_KEY_ID`
+- `APPLE_PRIVATE_KEY` **or** `APPLE_PRIVATE_KEY_PATH`
+- `APPLE_ENVIRONMENT` (`production`, `sandbox`, or `auto`)
+- `APPLE_BUNDLE_ID` (recommended for payload binding)
+
+If credentials are missing and stub mode is disabled, verification requests are rejected.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -37,6 +37,15 @@ def create_app():
         "60",
     )
     app.config["PAYMENTS_ENABLED"] = os.environ.get("PAYMENTS_ENABLED", "false").lower() == "true"
+    app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = (
+        os.environ.get("APPSTORE_ALLOW_STUB_VERIFICATION", "false").lower() == "true"
+    )
+    app.config["APPLE_ISSUER_ID"] = os.environ.get("APPLE_ISSUER_ID", "")
+    app.config["APPLE_KEY_ID"] = os.environ.get("APPLE_KEY_ID", "")
+    app.config["APPLE_PRIVATE_KEY"] = os.environ.get("APPLE_PRIVATE_KEY", "")
+    app.config["APPLE_PRIVATE_KEY_PATH"] = os.environ.get("APPLE_PRIVATE_KEY_PATH", "")
+    app.config["APPLE_BUNDLE_ID"] = os.environ.get("APPLE_BUNDLE_ID", "")
+    app.config["APPLE_ENVIRONMENT"] = os.environ.get("APPLE_ENVIRONMENT", "production")
 
     basedir = os.path.abspath(os.path.dirname(__file__))
 

--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -19,6 +19,10 @@ from app.getemail import send_password_setup_email
 from app.password_setup import (
     create_password_setup_link,
 )
+from app.appstore import (
+    AppStoreVerificationError,
+    verify_app_store_subscription,
+)
 from app.subscription import (
     SUB_ACTIVE,
     SUB_EXPIRED,
@@ -129,6 +133,80 @@ def _appstore_stub_verification_enabled() -> bool:
     if configured is None:
         configured = os.environ.get("APPSTORE_ALLOW_STUB_VERIFICATION", "")
     return str(configured).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _verify_appstore_purchase(transaction_info: dict, receipt_data: str | None):
+    """Verify App Store purchase data against Apple APIs.
+
+    Stub verification can be enabled for local development/testing only.
+    """
+    original_transaction_id = (
+        (transaction_info.get("original_transaction_id") or "").strip()
+        or (transaction_info.get("originalTransactionId") or "").strip()
+    )
+
+    if _appstore_stub_verification_enabled():
+        if not original_transaction_id:
+            original_transaction_id = (
+                (transaction_info.get("id") or "").strip()
+                or (receipt_data or "stub-receipt").strip()
+            )
+        if not original_transaction_id:
+            raise AppStoreVerificationError("missing original transaction id")
+        return {
+            "verification_status": "verified_stub",
+            "is_active": True,
+            "expiry": None,
+            "subscription_id": original_transaction_id,
+            "environment": "stub",
+        }
+
+    if not original_transaction_id:
+        raise AppStoreVerificationError(
+            "transaction.original_transaction_id is required when stub verification is disabled"
+        )
+
+    issuer_id = (current_app.config.get("APPLE_ISSUER_ID") or os.environ.get("APPLE_ISSUER_ID") or "").strip()
+    key_id = (current_app.config.get("APPLE_KEY_ID") or os.environ.get("APPLE_KEY_ID") or "").strip()
+    private_key = current_app.config.get("APPLE_PRIVATE_KEY") or os.environ.get("APPLE_PRIVATE_KEY")
+    private_key_path = current_app.config.get("APPLE_PRIVATE_KEY_PATH") or os.environ.get("APPLE_PRIVATE_KEY_PATH")
+    environment = (
+        current_app.config.get("APPLE_ENVIRONMENT")
+        or os.environ.get("APPLE_ENVIRONMENT")
+        or "production"
+    )
+    expected_bundle_id = (
+        current_app.config.get("APPLE_BUNDLE_ID")
+        or os.environ.get("APPLE_BUNDLE_ID")
+        or ""
+    ).strip()
+
+    if not issuer_id or not key_id:
+        raise AppStoreVerificationError(
+            "Apple credentials are incomplete: APPLE_ISSUER_ID and APPLE_KEY_ID are required"
+        )
+
+    verification = verify_app_store_subscription(
+        original_transaction_id=original_transaction_id,
+        issuer_id=issuer_id,
+        key_id=key_id,
+        private_key=private_key,
+        private_key_path=private_key_path,
+        environment=environment,
+    )
+
+    if expected_bundle_id and verification.bundle_id and verification.bundle_id != expected_bundle_id:
+        raise AppStoreVerificationError("App Store bundle identifier mismatch")
+
+    return {
+        "verification_status": "verified",
+        "is_active": verification.is_active,
+        "expiry": verification.expiry,
+        "subscription_id": verification.original_transaction_id,
+        "environment": verification.environment,
+        "status_code": verification.status_code,
+        "bundle_id": verification.bundle_id,
+    }
 
 
 def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
@@ -313,31 +391,23 @@ def api_verify_appstore():
     receipt_data = body.get("receipt_data")
     transaction_info = body.get("transaction") or {}
     email = (body.get("email") or "").strip().lower()
-    expiry_iso = body.get("expiry_date") or transaction_info.get("expires_date")
-
     errors = {}
     if not email:
         errors["email"] = "email is required"
     if not receipt_data and not transaction_info:
         errors["receipt_data"] = "receipt_data or transaction is required"
-    if not expiry_iso:
-        errors["expiry_date"] = "expiry_date is required"
     if errors:
         return validation_error(errors)
 
     try:
-        expiry = datetime.fromisoformat(str(expiry_iso).replace("Z", "+00:00")).astimezone(timezone.utc)
-    except ValueError:
-        return validation_error({"expiry_date": "expiry_date must be ISO-8601"})
+        verification = _verify_appstore_purchase(transaction_info, receipt_data)
+    except AppStoreVerificationError as exc:
+        logger.warning("App Store verification failed: %s", exc)
+        return unauthorized("App Store verification failed")
 
-    verification_status = "verification_unavailable"
-    if not _appstore_stub_verification_enabled():
-        logger.warning("Rejected App Store verification: server-side verification is not configured")
-        return unauthorized(
-            "App Store verification is not configured on this server"
-        )
-
-    verification_status = "verified_stub"
+    expiry = verification.get("expiry")
+    is_active = bool(verification.get("is_active"))
+    subscription_status = SUB_ACTIVE if is_active else SUB_EXPIRED
 
     if not _can_create_paid_user(email):
         return validation_error(
@@ -347,19 +417,20 @@ def api_verify_appstore():
     user, created = _create_or_get_owner(email)
     apply_subscription_status(
         user,
-        status=SUB_ACTIVE,
+        status=subscription_status,
         source="app_store",
-        subscription_id=transaction_info.get("original_transaction_id") or transaction_info.get("id"),
-        expiry=expiry.replace(tzinfo=None),
-        activate=True,
+        subscription_id=verification.get("subscription_id"),
+        expiry=expiry,
+        activate=is_active,
     )
     _send_setup_email_for_new_user(user, created)
 
     return api_ok(
         {
-            "verification_status": verification_status,
+            "verification_status": verification.get("verification_status"),
             "user_id": user.id,
             "subscription_status": user.subscription_status,
             "subscription_source": user.subscription_source,
+            "environment": verification.get("environment"),
         }
     )

--- a/app/appstore.py
+++ b/app/appstore.py
@@ -1,0 +1,191 @@
+"""App Store subscription verification helpers.
+
+Implements Apple App Store Server API authentication (ES256 JWT) and
+subscription-state retrieval.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from urllib import error, request
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+APPSTORE_PRODUCTION_URL = "https://api.storekit.itunes.apple.com"
+APPSTORE_SANDBOX_URL = "https://api.storekit-sandbox.itunes.apple.com"
+
+_ACTIVE_STATUSES = {1, 3, 4}
+
+
+class AppStoreVerificationError(Exception):
+    """Raised when App Store verification cannot be completed."""
+
+
+@dataclass
+class AppStoreVerificationResult:
+    is_active: bool
+    status_code: int | None
+    environment: str
+    original_transaction_id: str | None
+    transaction_id: str | None
+    expiry: datetime | None
+    raw_status: str
+    bundle_id: str | None
+
+
+def _b64url(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _jwt_es256(issuer_id: str, key_id: str, private_key_pem: str, audience: str) -> str:
+    now = int(time.time())
+    header = {"alg": "ES256", "kid": key_id, "typ": "JWT"}
+    payload = {
+        "iss": issuer_id,
+        "iat": now,
+        "exp": now + 300,
+        "aud": audience,
+        "nonce": str(uuid.uuid4()),
+    }
+    signing_input = f"{_b64url(json.dumps(header, separators=(',', ':')).encode())}.{_b64url(json.dumps(payload, separators=(',', ':')).encode())}".encode()
+
+    private_key = serialization.load_pem_private_key(private_key_pem.encode("utf-8"), password=None)
+    if not isinstance(private_key, ec.EllipticCurvePrivateKey):
+        raise AppStoreVerificationError("APPLE_PRIVATE_KEY must be an EC private key")
+
+    signature_der = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))
+    # Convert DER ECDSA signature into raw R||S format required by JWT ES256.
+    r, s = _decode_dss_signature(signature_der)
+    raw_sig = r.to_bytes(32, "big") + s.to_bytes(32, "big")
+    return f"{signing_input.decode()}.{_b64url(raw_sig)}"
+
+
+def _decode_dss_signature(signature_der: bytes) -> tuple[int, int]:
+    from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+
+    return decode_dss_signature(signature_der)
+
+
+def _read_private_key(private_key: str | None, private_key_path: str | None) -> str:
+    if private_key and private_key.strip():
+        return private_key.replace("\\n", "\n")
+    if private_key_path and private_key_path.strip():
+        with open(private_key_path, "r", encoding="utf-8") as f:
+            return f.read()
+    raise AppStoreVerificationError("APPLE_PRIVATE_KEY or APPLE_PRIVATE_KEY_PATH is required")
+
+
+def _decode_jws_payload(jws: str) -> dict[str, Any]:
+    parts = jws.split(".")
+    if len(parts) != 3:
+        return {}
+    payload = parts[1]
+    payload += "=" * (-len(payload) % 4)
+    try:
+        return json.loads(base64.urlsafe_b64decode(payload.encode("ascii")).decode("utf-8"))
+    except Exception:
+        return {}
+
+
+def _ms_to_dt(raw_ms: Any) -> datetime | None:
+    if raw_ms in (None, ""):
+        return None
+    try:
+        return datetime.fromtimestamp(int(raw_ms) / 1000, tz=timezone.utc).replace(tzinfo=None)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _apple_api_get(base_url: str, path: str, bearer_token: str) -> dict[str, Any]:
+    req = request.Request(
+        url=f"{base_url}{path}",
+        headers={"Authorization": f"Bearer {bearer_token}", "Accept": "application/json"},
+        method="GET",
+    )
+    try:
+        with request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="ignore") if exc.fp else ""
+        details: dict[str, Any] = {}
+        try:
+            details = json.loads(body) if body else {}
+        except json.JSONDecodeError:
+            details = {"raw": body}
+        details["http_status"] = exc.code
+        raise AppStoreVerificationError(f"Apple API error: {json.dumps(details)}") from exc
+    except error.URLError as exc:
+        raise AppStoreVerificationError(f"Apple API request failed: {exc.reason}") from exc
+
+
+def verify_app_store_subscription(
+    *,
+    original_transaction_id: str,
+    issuer_id: str,
+    key_id: str,
+    private_key: str | None,
+    private_key_path: str | None,
+    environment: str,
+) -> AppStoreVerificationResult:
+    """Verify a subscription using Apple's App Store Server API."""
+    private_key_pem = _read_private_key(private_key, private_key_path)
+    token = _jwt_es256(issuer_id, key_id, private_key_pem, audience="appstoreconnect-v1")
+
+    env = (environment or "production").strip().lower()
+    if env not in {"production", "sandbox", "auto"}:
+        raise AppStoreVerificationError("APPLE_ENVIRONMENT must be production, sandbox, or auto")
+
+    urls = [APPSTORE_PRODUCTION_URL]
+    if env == "sandbox":
+        urls = [APPSTORE_SANDBOX_URL]
+    elif env == "auto":
+        urls = [APPSTORE_PRODUCTION_URL, APPSTORE_SANDBOX_URL]
+
+    path = f"/inApps/v1/subscriptions/{original_transaction_id}"
+    last_error: Exception | None = None
+    for base_url in urls:
+        try:
+            payload = _apple_api_get(base_url, path, token)
+        except AppStoreVerificationError as exc:
+            last_error = exc
+            continue
+
+        data = payload.get("data") or []
+        for group in data:
+            for txn in group.get("lastTransactions") or []:
+                status_code = txn.get("status")
+                signed_info = txn.get("signedTransactionInfo") or ""
+                decoded = _decode_jws_payload(signed_info)
+                expiry = _ms_to_dt(decoded.get("expiresDate"))
+                return AppStoreVerificationResult(
+                    is_active=status_code in _ACTIVE_STATUSES,
+                    status_code=status_code,
+                    environment=(payload.get("environment") or base_url).lower(),
+                    original_transaction_id=decoded.get("originalTransactionId") or original_transaction_id,
+                    transaction_id=decoded.get("transactionId"),
+                    expiry=expiry,
+                    raw_status=str(status_code),
+                    bundle_id=decoded.get("bundleId"),
+                )
+
+        return AppStoreVerificationResult(
+            is_active=False,
+            status_code=None,
+            environment=(payload.get("environment") or base_url).lower(),
+            original_transaction_id=original_transaction_id,
+            transaction_id=None,
+            expiry=None,
+            raw_status="not_found",
+            bundle_id=None,
+        )
+
+    assert last_error is not None
+    raise last_error

--- a/tests/test_appstore_verification.py
+++ b/tests/test_appstore_verification.py
@@ -1,0 +1,87 @@
+"""Unit tests for App Store verification boundary."""
+
+from datetime import datetime, timezone
+
+import app.appstore as appstore
+
+
+def test_verify_app_store_subscription_auto_falls_back_to_sandbox(monkeypatch):
+    calls = []
+
+    def _fake_get(base_url, path, bearer_token):
+        calls.append(base_url)
+        if "sandbox" not in base_url:
+            raise appstore.AppStoreVerificationError("not found in production")
+        return {
+            "environment": "Sandbox",
+            "data": [
+                {
+                    "lastTransactions": [
+                        {
+                            "status": 1,
+                            "signedTransactionInfo": (
+                                "eyJhbGciOiJFUzI1NiJ9."
+                                "eyJvcmlnaW5hbFRyYW5zYWN0aW9uSWQiOiJvcmlnXzEiLCJ0cmFuc2FjdGlvbklkIjoidHhuXzEiLCJleHBpcmVzRGF0ZSI6MTkwMDAwMDAwMDAwMCwiYnVuZGxlSWQiOiJjb20uZXhhbXBsZS5weWNhc2hmbG93In0"
+                                ".sig"
+                            ),
+                        }
+                    ]
+                }
+            ],
+        }
+
+    monkeypatch.setattr(appstore, "_apple_api_get", _fake_get)
+    monkeypatch.setattr(appstore, "_jwt_es256", lambda *args, **kwargs: "token")
+    monkeypatch.setattr(appstore, "_read_private_key", lambda *args, **kwargs: "pem")
+
+    result = appstore.verify_app_store_subscription(
+        original_transaction_id="orig_1",
+        issuer_id="issuer",
+        key_id="kid",
+        private_key="pem",
+        private_key_path=None,
+        environment="auto",
+    )
+
+    assert result.is_active is True
+    assert result.original_transaction_id == "orig_1"
+    assert result.transaction_id == "txn_1"
+    assert result.bundle_id == "com.example.pycashflow"
+    assert isinstance(result.expiry, datetime)
+    assert result.expiry.tzinfo is None
+    assert len(calls) == 2
+
+
+def test_verify_app_store_subscription_expired_status(monkeypatch):
+    def _fake_get(base_url, path, bearer_token):
+        return {
+            "environment": "Production",
+            "data": [
+                {
+                    "lastTransactions": [
+                        {
+                            "status": 2,
+                            "signedTransactionInfo": "eyJhbGciOiJFUzI1NiJ9.eyJvcmlnaW5hbFRyYW5zYWN0aW9uSWQiOiJvcmlnX2V4cCIsImV4cGlyZXNEYXRlIjoxNjAwMDAwMDAwMDAwfQ.sig",
+                        }
+                    ]
+                }
+            ],
+        }
+
+    monkeypatch.setattr(appstore, "_apple_api_get", _fake_get)
+    monkeypatch.setattr(appstore, "_jwt_es256", lambda *args, **kwargs: "token")
+    monkeypatch.setattr(appstore, "_read_private_key", lambda *args, **kwargs: "pem")
+
+    result = appstore.verify_app_store_subscription(
+        original_transaction_id="orig_exp",
+        issuer_id="issuer",
+        key_id="kid",
+        private_key="pem",
+        private_key_path=None,
+        environment="production",
+    )
+
+    assert result.is_active is False
+    assert result.status_code == 2
+    assert result.expiry is not None
+    assert result.expiry < datetime.now(timezone.utc).replace(tzinfo=None)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -142,6 +142,219 @@ def test_appstore_verification_stub_mode_can_activate_owner(flask_app, client):
         assert user.is_active is True
 
 
+def test_appstore_existing_user_subscription_update_no_duplicate(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    with flask_app.app_context():
+        existing = User(
+            email="ios-existing@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Existing iOS",
+            admin=True,
+            is_account_owner=True,
+            is_active=False,
+            subscription_status="expired",
+            subscription_source="app_store",
+            subscription_id="orig_old",
+        )
+        db.session.add(existing)
+        db.session.commit()
+        existing_id = existing.id
+
+    monkeypatch.setattr(
+        billing_routes_module,
+        "_verify_appstore_purchase",
+        lambda transaction_info, receipt_data: {
+            "verification_status": "verified",
+            "is_active": True,
+            "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=40),
+            "subscription_id": "orig_txn_renewed",
+            "environment": "production",
+        },
+    )
+
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-existing@test.local",
+            "receipt_data": "receipt",
+            "transaction": {"original_transaction_id": "orig_txn_renewed"},
+        },
+    )
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        users = User.query.filter_by(email="ios-existing@test.local").all()
+        assert len(users) == 1
+        user = users[0]
+        assert user.id == existing_id
+        assert user.subscription_status == "active"
+        assert user.subscription_source == "app_store"
+        assert user.subscription_id == "orig_txn_renewed"
+        assert user.is_active is True
+
+
+def test_appstore_expired_subscription_deactivates_owner_and_guest(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    with flask_app.app_context():
+        owner = User(
+            email="ios-owner-expire@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Owner",
+            admin=True,
+            is_account_owner=True,
+            is_active=True,
+            subscription_status="active",
+            subscription_source="app_store",
+            subscription_id="orig_expire",
+        )
+        db.session.add(owner)
+        db.session.commit()
+
+        guest = User(
+            email="ios-guest-expire@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Guest",
+            admin=False,
+            is_active=True,
+            is_account_owner=False,
+            owner_user_id=owner.id,
+            account_owner_id=owner.id,
+            subscription_status="inactive",
+            subscription_source="none",
+        )
+        db.session.add(guest)
+        db.session.commit()
+
+    monkeypatch.setattr(
+        billing_routes_module,
+        "_verify_appstore_purchase",
+        lambda transaction_info, receipt_data: {
+            "verification_status": "verified",
+            "is_active": False,
+            "expiry": datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1),
+            "subscription_id": "orig_expire",
+            "environment": "production",
+        },
+    )
+
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-owner-expire@test.local",
+            "receipt_data": "receipt",
+            "transaction": {"original_transaction_id": "orig_expire"},
+        },
+    )
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        owner = User.query.filter_by(email="ios-owner-expire@test.local").first()
+        guest = User.query.filter_by(email="ios-guest-expire@test.local").first()
+        assert owner is not None
+        assert guest is not None
+        assert owner.subscription_status == "expired"
+        assert owner.is_active is False
+        assert guest.is_active is True
+
+        # Enforced access checks must also disable guests when owner is expired.
+        raw, _ = create_token_for_user(guest)
+
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = True
+    me_resp = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {raw}"})
+    assert me_resp.status_code == 401
+    with flask_app.app_context():
+        refreshed_guest = User.query.filter_by(email="ios-guest-expire@test.local").first()
+        assert refreshed_guest.is_active is False
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
+def test_appstore_renewed_subscription_reactivates_deactivated_owner(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    with flask_app.app_context():
+        owner = User(
+            email="ios-owner-renew@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Owner Renew",
+            admin=True,
+            is_account_owner=True,
+            is_active=False,
+            subscription_status="expired",
+            subscription_source="app_store",
+            subscription_id="orig_renew",
+        )
+        db.session.add(owner)
+        db.session.commit()
+
+    monkeypatch.setattr(
+        billing_routes_module,
+        "_verify_appstore_purchase",
+        lambda transaction_info, receipt_data: {
+            "verification_status": "verified",
+            "is_active": True,
+            "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=25),
+            "subscription_id": "orig_renew",
+            "environment": "sandbox",
+        },
+    )
+
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-owner-renew@test.local",
+            "receipt_data": "receipt",
+            "transaction": {"original_transaction_id": "orig_renew"},
+        },
+    )
+    assert resp.status_code == 200
+    assert _json(resp)["data"]["environment"] == "sandbox"
+
+    with flask_app.app_context():
+        owner = User.query.filter_by(email="ios-owner-renew@test.local").first()
+        assert owner is not None
+        assert owner.subscription_status == "active"
+        assert owner.is_active is True
+
+
+def test_appstore_failed_verification_does_not_activate_user(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    with flask_app.app_context():
+        user = User(
+            email="ios-fail@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Failed",
+            admin=True,
+            is_account_owner=True,
+            is_active=False,
+            subscription_status="expired",
+            subscription_source="app_store",
+        )
+        db.session.add(user)
+        db.session.commit()
+
+    def _raise_verification_error(transaction_info, receipt_data):
+        raise billing_routes_module.AppStoreVerificationError("bad receipt")
+
+    monkeypatch.setattr(billing_routes_module, "_verify_appstore_purchase", _raise_verification_error)
+
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={"email": "ios-fail@test.local", "receipt_data": "bad", "transaction": {}},
+    )
+    assert resp.status_code == 401
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="ios-fail@test.local").first()
+        assert user is not None
+        assert user.subscription_status == "expired"
+        assert user.is_active is False
+
+
 def test_stripe_new_user_generates_setup_token_and_sends_email(
     flask_app, client, monkeypatch, billing_routes_module
 ):


### PR DESCRIPTION
### Motivation

- Enable real App Store Server API verification for iOS subscriptions and replace the previous stubbed flow to support production subscription truth sources.
- Expose configurable App Store credentials and controls via environment variables so deployments can opt into real verification or a local stub mode.

### Description

- Added `app/appstore.py` implementing ES256 JWT auth and calls to App Store Server API with `verify_app_store_subscription` and `AppStoreVerificationResult`/`AppStoreVerificationError` types.
- Extended billing routes in `app/api/routes/billing.py` to perform App Store verification via `_verify_appstore_purchase`, support stub mode (`APPSTORE_ALLOW_STUB_VERIFICATION`), and apply subscription lifecycle (activate/deactivate) based on Apple truth.
- Added configuration keys to `create_app` in `app/__init__.py` for `APPLE_*` credentials, `APPSTORE_ALLOW_STUB_VERIFICATION`, and `APPLE_ENVIRONMENT` and updated the `.env_example` with required/optional variables.
- Updated documentation (`PAYMENTS.md`, `MOBILE_API_REFERENCE.md`, `AGENTS.md`) to describe App Store Server API usage, environment variables, and verification behavior.
- Added unit tests: `tests/test_appstore_verification.py` for the App Store client boundary and several expanded `tests/test_billing.py` cases covering stub mode, renewal, expiration, and error handling.

### Testing

- Ran the new App Store client unit tests via `pytest tests/test_appstore_verification.py`, which exercise production/sandbox fallbacks and expired-status handling, and they passed locally.
- Ran the updated billing endpoint tests in `tests/test_billing.py` that cover stub activation, existing-user updates, expiration/reactivation, and failed verification, and they passed locally.
- Performed a full test run of the test suite with `pytest`, which completed successfully with the added/modified tests included.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc364b99748320a5add7bd9b665abf)