### PR TITLE
Add scrollable card lists with Load More pagination

### DIFF
--- a/app/static/css/improved.css
+++ b/app/static/css/improved.css
@@ -1396,6 +1396,50 @@ body.modal-open {
 .insight-card-list {
   display: grid;
   gap: 0.75rem;
+  max-height: 40rem;
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(59, 130, 246, 0.4) transparent;
+}
+
+.insight-card-list::-webkit-scrollbar {
+  width: 8px;
+}
+
+.insight-card-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.insight-card-list::-webkit-scrollbar-thumb {
+  background: rgba(59, 130, 246, 0.4);
+  border-radius: 4px;
+}
+
+.insight-card-list::-webkit-scrollbar-thumb:hover {
+  background: rgba(59, 130, 246, 0.65);
+}
+
+.insight-card-list-footer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 0.5rem 0.25rem;
+  margin-top: 0.25rem;
+  border-top: 1px solid var(--border);
+}
+
+.insight-card-list-status {
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 768px) {
+  .insight-card-list {
+    max-height: 32rem;
+  }
 }
 
 .insight-data-card {

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -180,5 +180,98 @@
 
     <!-- Bootstrap 5 JS Bundle (includes Popper) -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Insight card list pagination (Load More for large lists) -->
+    <script>
+        (function() {
+            var PAGE_SIZE = 100;
+
+            function getPrimaryCards(list) {
+                var cards = [];
+                for (var i = 0; i < list.children.length; i++) {
+                    var child = list.children[i];
+                    if (child.classList && child.classList.contains('insight-data-card')) {
+                        cards.push(child);
+                    }
+                }
+                return cards;
+            }
+
+            function associatedNested(card) {
+                var next = card.nextElementSibling;
+                if (next && next.classList && next.classList.contains('row-nested')) {
+                    return next;
+                }
+                return null;
+            }
+
+            function initList(list) {
+                if (list.dataset.paginateInit === '1') return;
+                list.dataset.paginateInit = '1';
+
+                var cards = getPrimaryCards(list);
+                if (cards.length === 0) return;
+
+                var visibleCount = Math.min(PAGE_SIZE, cards.length);
+                if (cards.length <= PAGE_SIZE) {
+                    // Nothing to hide, but still allow scrolling within the container
+                    return;
+                }
+
+                var footer = document.createElement('div');
+                footer.className = 'insight-card-list-footer';
+
+                var status = document.createElement('span');
+                status.className = 'insight-card-list-status';
+
+                var btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'btn-outline-modern btn-modern';
+
+                footer.appendChild(status);
+                footer.appendChild(btn);
+                list.appendChild(footer);
+
+                function render() {
+                    for (var i = 0; i < cards.length; i++) {
+                        var hidden = i >= visibleCount;
+                        cards[i].style.display = hidden ? 'none' : '';
+                        var nested = associatedNested(cards[i]);
+                        if (nested) nested.style.display = hidden ? 'none' : '';
+                    }
+                    var remaining = cards.length - visibleCount;
+                    if (remaining > 0) {
+                        var next = Math.min(PAGE_SIZE, remaining);
+                        btn.innerHTML = '<i class="fa-solid fa-plus"></i> Load ' + next + ' more';
+                        btn.style.display = '';
+                        status.textContent = 'Showing ' + visibleCount + ' of ' + cards.length;
+                    } else {
+                        btn.style.display = 'none';
+                        status.textContent = 'Showing all ' + cards.length;
+                    }
+                }
+
+                btn.addEventListener('click', function() {
+                    visibleCount = Math.min(visibleCount + PAGE_SIZE, cards.length);
+                    render();
+                });
+
+                render();
+            }
+
+            function initAll() {
+                var lists = document.querySelectorAll('.insight-card-list[data-paginate]');
+                for (var i = 0; i < lists.length; i++) {
+                    initList(lists[i]);
+                }
+            }
+
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', initAll);
+            } else {
+                initAll();
+            }
+        })();
+    </script>
 </body>
 </html>

--- a/app/templates/global_admin.html
+++ b/app/templates/global_admin.html
@@ -56,7 +56,7 @@
             </button>
         </div>
     </div>
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% for user in global_admins %}
         <div class="insight-data-card insight-data-card--admin">
             <div class="rc-cell rc-primary">{{user.name}}</div>
@@ -230,7 +230,7 @@
             Account Owners & Guests
         </h2>
     </div>
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% for owner in account_owners %}
         <div class="insight-data-card insight-data-card--admin">
             <div class="rc-cell rc-primary">{{owner.name}}</div>

--- a/app/templates/holds_table.html
+++ b/app/templates/holds_table.html
@@ -42,7 +42,7 @@
         </div>
     </div>
 
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% for row in hold %}
         <div class="insight-data-card insight-data-card--holds">
             <div class="insight-data-top">
@@ -86,7 +86,7 @@
         </div>
     </div>
 
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% for row in skip %}
         <div class="insight-data-card insight-data-card--holds">
             <div class="insight-data-top">

--- a/app/templates/manage_guests.html
+++ b/app/templates/manage_guests.html
@@ -39,7 +39,7 @@
         </div>
     </div>
 
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% if guests %}
         {% for guest in guests %}
         <div class="insight-data-card insight-data-card--guests">

--- a/app/templates/scenario_table.html
+++ b/app/templates/scenario_table.html
@@ -39,7 +39,7 @@
         </div>
     </div>
 
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% for row in scenario %}
         <div class="insight-data-card insight-data-card--scenario">
             <div class="insight-data-top">

--- a/app/templates/schedule_table.html
+++ b/app/templates/schedule_table.html
@@ -34,7 +34,7 @@
         </div>
     </div>
 
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% for row in schedule %}
         <div class="insight-data-card insight-data-card--schedule">
             <div class="insight-data-top">

--- a/app/templates/transactions_table.html
+++ b/app/templates/transactions_table.html
@@ -33,7 +33,7 @@
         </h2>
     </div>
 
-    <div class="insight-card-list">
+    <div class="insight-card-list" data-paginate>
         {% for row in total %}
         <div class="insight-data-card insight-data-card--transactions">
             <div class="insight-data-top">


### PR DESCRIPTION
Cap each insight-card-list at ~5 cards tall with internal scrolling so
long lists no longer push page height, and reveal only the first 100
cards with a Load More button that reveals the next 100 on demand.
Applied to schedule, scenario, transactions, holds/skips, guest users,
and global admin tables.

https://claude.ai/code/session_018ngyj8vUK4PQK3ZWBRG8iX