### PR TITLE
Keep insight cards at content size in tall card lists

### DIFF
--- a/app/static/css/improved.css
+++ b/app/static/css/improved.css
@@ -1395,6 +1395,8 @@ body.modal-open {
 /* AI-insight style data cards for management pages */
 .insight-card-list {
   display: grid;
+  grid-auto-rows: max-content;
+  align-content: start;
   gap: 0.75rem;
   max-height: calc(100vh - 20rem);
   max-height: calc(100dvh - 20rem);


### PR DESCRIPTION
The min-height added to .insight-card-list caused single grid items to
stretch and fill the container, making short lists (e.g. one guest) look
oversized. Pin rows to max-content and align tracks to the start so the
container still fills the viewport while individual cards stay their
natural size.