### PR TITLE
Rebase user-scoped index migration onto latest Alembic head

### DIFF
--- a/migrations/versions/b1c2d3e4f5a6_add_user_scoped_indexes.py
+++ b/migrations/versions/b1c2d3e4f5a6_add_user_scoped_indexes.py
@@ -1,7 +1,7 @@
 """add user-scoped indexes for hot query paths
 
 Revision ID: b1c2d3e4f5a6
-Revises: 3979d4be8acf
+Revises: a8c9d0e1f2a3
 Create Date: 2026-04-18 00:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'b1c2d3e4f5a6'
-down_revision = '3979d4be8acf'
+down_revision = 'a8c9d0e1f2a3'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
### Motivation
- The new migration `b1c2d3e4f5a6_add_user_scoped_indexes.py` referenced an older merge revision which created a parallel Alembic head and would make `flask db upgrade` fail with a multiple-head error. 

### Description
- Updated the migration file header `Revises:` and the `down_revision` value in `migrations/versions/b1c2d3e4f5a6_add_user_scoped_indexes.py` from `3979d4be8acf` to `a8c9d0e1f2a3` to place the migration on the current head. 
- Left the migration operations (index creation and drop logic) unchanged; only the ancestry metadata was adjusted to avoid creating a second Alembic head. 

### Testing
- Ran a migration graph sanity check script to confirm there is a single Alembic head (output: `heads: ['b1c2d3e4f5a6']`).
- Ran the full test suite with `python -m pytest -q`, which succeeded (`260 passed, 48 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f0091f9c8320b34835bef938406f)