### PR TITLE
Preserve Alembic migration ancestry via merge revision

### DIFF
--- a/migrations/versions/b1c2d3e4f5a6_add_user_scoped_indexes.py
+++ b/migrations/versions/b1c2d3e4f5a6_add_user_scoped_indexes.py
@@ -1,7 +1,7 @@
 """add user-scoped indexes for hot query paths
 
 Revision ID: b1c2d3e4f5a6
-Revises: a8c9d0e1f2a3
+Revises: 3979d4be8acf
 Create Date: 2026-04-18 00:00:00.000000
 
 """
@@ -10,7 +10,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'b1c2d3e4f5a6'
-down_revision = 'a8c9d0e1f2a3'
+down_revision = '3979d4be8acf'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/c4d5e6f7a8b9_merge_user_scoped_indexes_and_text_settings.py
+++ b/migrations/versions/c4d5e6f7a8b9_merge_user_scoped_indexes_and_text_settings.py
@@ -1,0 +1,22 @@
+"""merge user-scoped indexes and text settings heads
+
+Revision ID: c4d5e6f7a8b9
+Revises: b1c2d3e4f5a6, a8c9d0e1f2a3
+Create Date: 2026-04-18 00:00:00.000000
+
+"""
+
+
+# revision identifiers, used by Alembic.
+revision = 'c4d5e6f7a8b9'
+down_revision = ('b1c2d3e4f5a6', 'a8c9d0e1f2a3')
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    pass
+
+
+def downgrade():
+    pass


### PR DESCRIPTION
### Motivation
- Prevent rewriting Alembic history which can strand databases that already applied the `b1c2d3e4f5a6` revision by restoring its original parent linkage. 
- Reconcile two migration heads without mutating existing migration files so deployments that already applied migrations keep a consistent lineage. 

### Description
- Restored `migrations/versions/b1c2d3e4f5a6_add_user_scoped_indexes.py` to reference its original parent by setting `Revises`/`down_revision` back to `3979d4be8acf`. 
- Added a new no-op merge migration `migrations/versions/c4d5e6f7a8b9_merge_user_scoped_indexes_and_text_settings.py` with `down_revision = ('b1c2d3e4f5a6','a8c9d0e1f2a3')` to join the two heads. 
- The merge migration contains empty `upgrade()`/`downgrade()` functions so it is additive and safe to apply. 

### Testing
- Ran the full test suite with `python -m pytest -q` and observed `260 passed, 48 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f1ab028c8320aeb48565174bd822)