### PR TITLE
Add additive migration to reconcile text_settings table

### DIFF
--- a/migrations/versions/b3c4d5e6f7a8_reconcile_text_settings_table.py
+++ b/migrations/versions/b3c4d5e6f7a8_reconcile_text_settings_table.py
@@ -1,8 +1,8 @@
-"""add text settings table
+"""reconcile text settings table
 
-Revision ID: a8c9d0e1f2a3
-Revises: 3979d4be8acf
-Create Date: 2026-04-12 00:00:00.000000
+Revision ID: b3c4d5e6f7a8
+Revises: c4d5e6f7a8b9
+Create Date: 2026-04-18 00:00:00.000000
 """
 
 from alembic import op
@@ -10,13 +10,19 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision = 'a8c9d0e1f2a3'
-down_revision = '3979d4be8acf'
+revision = 'b3c4d5e6f7a8'
+down_revision = 'c4d5e6f7a8b9'
 branch_labels = None
 depends_on = None
 
 
 def upgrade():
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table('text_settings'):
+        return
+
     op.create_table(
         'text_settings',
         sa.Column('id', sa.Integer(), nullable=False),
@@ -28,4 +34,8 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_table('text_settings')
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if inspector.has_table('text_settings'):
+        op.drop_table('text_settings')


### PR DESCRIPTION
### Motivation
- Prevent rewriting an existing migration (`a8c9d0e1f2a3`) which violates the repository rule that migrations must be additive and preserves reproducible migration history. 
- Provide a safe, additive way to reconcile environments where the `text_settings` table may already exist without changing historical revision bodies.

### Description
- Restored `migrations/versions/a8c9d0e1f2a3_add_text_settings_table.py` to a deterministic body that always creates and drops the `text_settings` table using plain `op.create_table`/`op.drop_table` semantics. 
- Added a new additive migration `migrations/versions/b3c4d5e6f7a8_reconcile_text_settings_table.py` which uses `bind = op.get_bind()` and `sa.inspect(bind)` to conditionally create `text_settings` only when it is missing. 
- Implemented defensive downgrade behavior in the new migration so the table is dropped only if it exists and set the new migration `revision`/`down_revision` appropriately to preserve the migration graph.

### Testing
- Ran `python -m pytest -q` and the test suite completed successfully with `260 passed, 48 warnings` in the run. 
- No additional automated tests were added or broken by these migration file changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f64ebd44832086e21dc2d7b8c0bd)