### PR TITLE
Make text_settings reconcile migration downgrade a no-op

### DIFF
--- a/migrations/versions/b3c4d5e6f7a8_reconcile_text_settings_table.py
+++ b/migrations/versions/b3c4d5e6f7a8_reconcile_text_settings_table.py
@@ -34,8 +34,6 @@ def upgrade():
 
 
 def downgrade():
-    bind = op.get_bind()
-    inspector = sa.inspect(bind)
-
-    if inspector.has_table('text_settings'):
-        op.drop_table('text_settings')
+    # The down revision already includes text_settings via a8c9d0e1f2a3.
+    # Dropping here would remove schema/data that should exist at c4d5e6f7a8b9.
+    pass


### PR DESCRIPTION
### Motivation
- The `b3c4d5e6f7a8` reconcile migration previously dropped `text_settings` in its `downgrade()`, which can remove schema/data when rolling back because the down revision already creates `text_settings` via `a8c9d0e1f2a3`, making the migration non-invertible.  

### Description
- Update `migrations/versions/b3c4d5e6f7a8_reconcile_text_settings_table.py` to make `downgrade()` a no-op (`pass`) and add a comment explaining why the table must not be dropped.  

### Testing
- Ran `python -m pytest -q` and all automated tests passed (`260 passed, 48 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2f84678b08320a3795fa7ce182854)