### PR TITLE
Fix Swift 6 actor-isolation warnings and StoreKit receipt deprecation in iOS app

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -89,18 +89,10 @@ final class StoreKitSubscriptionManager: ObservableObject {
     }
 
     private func submit(transaction: StoreKit.Transaction, email: String, token: String?) async throws {
-        let receiptData: String
-        if let receiptURL = Bundle.main.appStoreReceiptURL,
-           let data = try? Data(contentsOf: receiptURL) {
-            receiptData = data.base64EncodedString()
-        } else {
-            receiptData = ""
-        }
-
         let expiryISO = transaction.expirationDate.map(Self.isoDate)
         let payload = AppStoreVerificationPayload(
             email: email,
-            receipt_data: receiptData,
+            receipt_data: "",
             expiry_date: expiryISO,
             transaction: .init(
                 id: String(transaction.id),
@@ -108,7 +100,7 @@ final class StoreKitSubscriptionManager: ObservableObject {
                 product_id: transaction.productID,
                 purchase_date: Self.isoDate(transaction.purchaseDate),
                 expiry_date: expiryISO,
-                signed_transaction_info: nil
+                signed_transaction_info: transaction.jwsRepresentation
             )
         )
 

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Accounts/AccountsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Accounts/AccountsView.swift
@@ -52,8 +52,12 @@ struct AccountsView: View {
     private func load() async {
         guard let token = session.token else { return }
         do {
-            async let current: APIEnvelope<BalanceDTO> = APIClient.shared.request("balance", token: token, as: APIEnvelope<BalanceDTO>.self)
-            async let list: APIListEnvelope<BalanceDTO> = APIClient.shared.request(
+            let current: APIEnvelope<BalanceDTO> = try await APIClient.shared.request(
+                "balance",
+                token: token,
+                as: APIEnvelope<BalanceDTO>.self
+            )
+            let list: APIListEnvelope<BalanceDTO> = try await APIClient.shared.request(
                 "balance/history",
                 queryItems: [
                     URLQueryItem(name: "limit", value: "20"),
@@ -62,13 +66,10 @@ struct AccountsView: View {
                 token: token,
                 as: APIListEnvelope<BalanceDTO>.self
             )
-            let (currentRes, listRes) = try await (current, list)
-            await MainActor.run {
-                balance = currentRes.data
-                history = listRes.data
-            }
+            balance = current.data
+            history = list.data
         } catch {
-            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load balances" }
+            errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load balances"
         }
     }
 
@@ -78,9 +79,9 @@ struct AccountsView: View {
             struct Payload: Encodable { let amount: String }
             _ = try await APIClient.shared.request("balance", method: "POST", token: token, body: Payload(amount: newAmount), as: APIEnvelope<BalanceDTO>.self)
             await load()
-            await MainActor.run { newAmount = "" }
+            newAmount = ""
         } catch {
-            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to save balance" }
+            errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to save balance"
         }
     }
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -76,15 +76,20 @@ struct SettingsView: View {
     private func load() async {
         guard let token = session.token else { return }
         do {
-            async let settingsCall: APIEnvelope<SettingsDTO> = APIClient.shared.request("settings", token: token, as: APIEnvelope<SettingsDTO>.self)
-            async let insightsCall: APIEnvelope<InsightsDTO> = APIClient.shared.request("insights", token: token, as: APIEnvelope<InsightsDTO>.self)
-            let (settingsRes, insightsRes) = try await (settingsCall, insightsCall)
-            await MainActor.run {
-                settings = settingsRes.data
-                insights = insightsRes.data
-            }
+            let settingsResponse: APIEnvelope<SettingsDTO> = try await APIClient.shared.request(
+                "settings",
+                token: token,
+                as: APIEnvelope<SettingsDTO>.self
+            )
+            let insightsResponse: APIEnvelope<InsightsDTO> = try await APIClient.shared.request(
+                "insights",
+                token: token,
+                as: APIEnvelope<InsightsDTO>.self
+            )
+            settings = settingsResponse.data
+            insights = insightsResponse.data
         } catch {
-            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load settings" }
+            errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load settings"
         }
     }
 
@@ -92,9 +97,9 @@ struct SettingsView: View {
         guard let token = session.token else { return }
         do {
             let response: APIEnvelope<InsightsDTO> = try await APIClient.shared.request("insights/refresh", method: "POST", token: token, as: APIEnvelope<InsightsDTO>.self)
-            await MainActor.run { insights = response.data }
+            insights = response.data
         } catch {
-            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to refresh insights" }
+            errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to refresh insights"
         }
     }
 
@@ -109,22 +114,20 @@ struct SettingsView: View {
                 body: Payload(current_password: currentPassword, new_password: newPassword),
                 as: APIEnvelope<[String: String]>.self
             )
-            await MainActor.run {
-                currentPassword = ""
-                newPassword = ""
-                session.clear()
-            }
+            currentPassword = ""
+            newPassword = ""
+            session.clear()
         } catch {
-            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to change password" }
+            errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to change password"
         }
     }
 
     private func logout() async {
         guard let token = session.token else {
-            await MainActor.run { session.clear() }
+            session.clear()
             return
         }
         _ = try? await APIClient.shared.request("auth/logout", method: "POST", token: token, as: APIEnvelope<[String: String]>.self)
-        await MainActor.run { session.clear() }
+        session.clear()
     }
 }


### PR DESCRIPTION
### Motivation
- Silence Xcode warnings caused by StoreKit receipt API deprecation and Swift 6 actor-isolation when decoding API responses into main-actor state.

### Description
- In `StoreKitSubscriptionManager`, removed use of `Bundle.main.appStoreReceiptURL` and set `receipt_data` to an empty string while passing `transaction.jwsRepresentation` as `signed_transaction_info` in `AppStoreVerificationPayload` to avoid the deprecated receipt access.
- Reworked `AccountsView.load()` to replace `async let` child tasks with sequential `try await` calls and assign `balance`/`history` from the returned envelope `data`, eliminating unsafe cross-actor decoding patterns and simplifying error handling.
- Reworked `SettingsView.load()` similarly to fetch `settings` and `insights` sequentially and removed redundant `MainActor.run` wrappers in related async methods to reduce unnecessary actor hops.
- Changes are confined to the iOS client code and preserve the existing API envelope shapes and fields.

### Testing
- Attempted to build the iOS app with `xcodebuild -project pycashflow.xcodeproj -scheme pycashflow -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' build`, but `xcodebuild` is not available in this environment so the build could not be executed.
- No automated backend or unit test runs were performed in this environment; code-level edits were limited to Swift files under `ios-app` and require an Xcode environment for compilation verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea7eac6b3083209414024cbcf50945)