### PR TITLE
Fix iOS Info.plist duplicate build output

### DIFF
--- a/ios-app/pycashflow.xcodeproj/project.pbxproj
+++ b/ios-app/pycashflow.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		1C456D2F2F9AAFE200B2B374 /* Exceptions for "pycashflow" folder in "pycashflow" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				PyCashFlowApp/Info.plist,
 				PyCashFlowAppTests/BillingStatusTests.swift,
 				PyCashFlowAppTests/SessionManagerModeTests.swift,
 			);


### PR DESCRIPTION
### Motivation
- Prevent Xcode from copying `PyCashFlowApp/Info.plist` as a bundle resource while it is already processed via the `INFOPLIST_FILE` build setting, which caused a "Multiple commands produce .../pycashflow.app/Info" build failure.

### Description
- Added `PyCashFlowApp/Info.plist` to the `membershipExceptions` list in `ios-app/pycashflow.xcodeproj/project.pbxproj` under the `PBXFileSystemSynchronizedBuildFileExceptionSet` for the app target so the file is not treated as an automatic bundle resource.

### Testing
- Ran `python -m pytest -q` which completed successfully with `260 passed, 48 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea82f6157883209d6d414d705d996e)