### PR TITLE
Use transaction JSON for signed_transaction_info and set App Store product ID

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -100,7 +100,7 @@ final class StoreKitSubscriptionManager: ObservableObject {
                 product_id: transaction.productID,
                 purchase_date: Self.isoDate(transaction.purchaseDate),
                 expiry_date: expiryISO,
-                signed_transaction_info: transaction.jwsRepresentation
+                signed_transaction_info: Self.signedTransactionInfo(transaction)
             )
         )
 
@@ -123,6 +123,10 @@ final class StoreKitSubscriptionManager: ObservableObject {
         case .verified(let safe):
             return safe
         }
+    }
+
+    private static func signedTransactionInfo(_ transaction: StoreKit.Transaction) -> String? {
+        String(data: transaction.jsonRepresentation, encoding: .utf8)
     }
 
     private static func isoDate(_ date: Date) -> String {

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
@@ -3,5 +3,5 @@ import Foundation
 enum AppConfig {
     static let apiBaseURL = "https://cloud.pycashflow.com/api/v1"
     static let selfHostedAPIBaseURL = "https://localhost:5000"
-    static let appStoreProductIDs = ""
+    static let appStoreProductIDs = "com.h3consultingpartners.pycashflow.cloud.monthly"
 }


### PR DESCRIPTION
### Motivation
- Fix App Store purchase verification by sending the transaction JSON as `signed_transaction_info` and configure the app store product ID used by the app.

### Description
- Replace usage of `transaction.jwsRepresentation` with a helper `signedTransactionInfo(_:)` that returns a UTF-8 `String` from `transaction.jsonRepresentation`, and wire that into the `AppStoreVerificationPayload`.
- Set `AppConfig.appStoreProductIDs` to the product identifier `"com.h3consultingpartners.pycashflow.cloud.monthly"` instead of an empty string.

### Testing
- Built the iOS project using Xcode (`xcodebuild`) to verify the changes compile successfully; the build completed without errors and no automated tests were added or modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea86aabf708320905aabe38d14a6b4)