### PR TITLE
Adjust iOS Login layout to keep auth fields visible

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -32,38 +32,6 @@ struct LoginView: View {
                 }
                 .surfaceCard()
 
-                if session.appMode == .selfHosted {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Self-Hosted API Base URL")
-                            .foregroundStyle(AppTheme.textPrimary)
-                        TextField("https://your-server.example.com/api/v1", text: $selfHostedURL)
-                            .textInputAutocapitalization(.never)
-                            .autocorrectionDisabled()
-                            .padding(12)
-                            .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
-                            .foregroundStyle(AppTheme.textPrimary)
-                        Button("Save Server URL") {
-                            if !session.updateSelfHostedBaseURL(selfHostedURL) {
-                                errorText = "Please enter a valid URL, including /api/v1."
-                            } else {
-                                errorText = nil
-                            }
-                        }
-                        .buttonStyle(PrimaryButtonStyle())
-                    }
-                    .surfaceCard()
-                } else {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Using PyCashFlow Cloud hosted service.")
-                            .foregroundStyle(AppTheme.textSecondary)
-                        NavigationLink("Activate or Restore Cloud Subscription") {
-                            SubscriptionPaywallView(message: "Use App Store subscription to activate or restore your hosted PyCashFlow Cloud account.")
-                        }
-                        .buttonStyle(PrimaryButtonStyle())
-                    }
-                    .surfaceCard()
-                }
-
                 VStack(spacing: 12) {
                     if challenge == nil {
                         TextField("Email", text: $email)
@@ -99,11 +67,45 @@ struct LoginView: View {
                     .disabled(isLoading)
                 }
                 .surfaceCard()
+
+                if session.appMode == .selfHosted {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Self-Hosted API Base URL")
+                            .foregroundStyle(AppTheme.textPrimary)
+                        TextField("https://your-server.example.com/api/v1", text: $selfHostedURL)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .padding(12)
+                            .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+                            .foregroundStyle(AppTheme.textPrimary)
+                        Button("Save Server URL") {
+                            if !session.updateSelfHostedBaseURL(selfHostedURL) {
+                                errorText = "Please enter a valid URL, including /api/v1."
+                            } else {
+                                errorText = nil
+                            }
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                    }
+                    .surfaceCard()
+                } else {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Using PyCashFlow Cloud hosted service.")
+                            .foregroundStyle(AppTheme.textSecondary)
+                        NavigationLink("Activate or Restore Cloud Subscription") {
+                            SubscriptionPaywallView(message: "Use App Store subscription to activate or restore your hosted PyCashFlow Cloud account.")
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                    }
+                    .surfaceCard()
+                }
+
             }
             .padding(20)
         }
         .appBackground()
         .navigationTitle("Login")
+        .navigationBarTitleDisplayMode(.inline)
         .onAppear {
             selfHostedURL = session.selfHostedBaseURLText
         }


### PR DESCRIPTION
### Motivation
- The login screen's subscription/self-hosted card could push the email/password (or 2FA) inputs off the visible area on smaller devices or simulator heights, causing the UI to appear zoomed and the bottom fields to be obscured. 
- Reduce vertical header usage to reclaim space for the auth form.

### Description
- Reordered the `LoginView` cards so the authentication form (`email`/`password` or 2FA input + submit) appears before the cloud/self-hosted configuration card in `ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift`. 
- Set the navigation title display mode to inline by adding `.navigationBarTitleDisplayMode(.inline)` to the `LoginView` to reduce top bar height. 
- This change is UI-only and does not modify any backend, API, or tests.

### Testing
- Attempted to list the Xcode project with `xcodebuild -list -project ios-app/pycashflow.xcodeproj`, but the command failed in this environment because `xcodebuild` is not installed. 
- No automated iOS build or simulator tests were executed here; recommend running a local build and simulator test on macOS with Xcode (e.g., open the workspace in Xcode and run on a device/simulator) to validate the layout on multiple device sizes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea97acae148320a646402d71e30e74)