### PR TITLE
Harden iOS API client against empty 204 responses and bad URL config

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -42,7 +42,18 @@ final class APIClient {
         let decoder = JSONDecoder()
 
         if (200..<300).contains(code) {
-            if code == 204 { return EmptyResponse() as! T }
+            if code == 204 {
+                if T.self == EmptyResponse.self,
+                   let empty = EmptyResponse() as? T {
+                    return empty
+                }
+                throw APIErrorEnvelope(
+                    error: "Unexpected empty response body",
+                    code: "empty_response_body",
+                    status: code,
+                    fields: nil
+                )
+            }
             return try decoder.decode(T.self, from: data)
         }
 
@@ -67,11 +78,13 @@ private struct AnyEncodable: Encodable {
 
 enum AppEnvironment {
     static let cloudAPIBaseURL: URL = {
-        normalizedAPIBaseURL(from: AppConfig.apiBaseURL)!
+        normalizedAPIBaseURL(from: AppConfig.apiBaseURL)
+            ?? URL(string: "https://cloud.pycashflow.com/api/v1")!
     }()
 
     static let defaultSelfHostedAPIBaseURL: URL = {
-        normalizedAPIBaseURL(from: AppConfig.selfHostedAPIBaseURL)!
+        normalizedAPIBaseURL(from: AppConfig.selfHostedAPIBaseURL)
+            ?? URL(string: "https://localhost:5000/api/v1")!
     }()
 
     static let appStoreProductIDs: [String] = {


### PR DESCRIPTION
### Motivation
- Users experienced the iOS app returning to the home screen during login, which pointed to crash-prone API client behavior and strict URL unwrapping at startup.
- The client used an unsafe forced cast on HTTP 204 responses and force-unwrapped configured base URLs, both of which can terminate the app at runtime.

### Description
- Replaced the unsafe `EmptyResponse() as! T` forced cast in `APIClient.swift` with guarded handling that returns `EmptyResponse` only when the expected `T` matches and otherwise throws an `APIErrorEnvelope` with code `empty_response_body`.
- Added defensive fallback defaults when initializing `cloudAPIBaseURL` and `defaultSelfHostedAPIBaseURL` to avoid force-unwrapping misconfigured `AppConfig` values.
- Preserved existing decoding and error-envelope behavior for non-204 responses.

### Testing
- Ran `python -m pytest -q`, which succeeded with `260 passed` tests.
- Attempted to run iOS unit tests via `xcodebuild test ...` but the `xcodebuild` command was not available in this environment so iOS tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9f5d528c83208863672260a68edd)