### PR TITLE
Canonicalize legacy cloud host to app.pycashflow.com and migrate stored self-hosted URLs

### DIFF
--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -44,7 +44,7 @@ The iOS app supports **Apple App Store** purchase flow only. Stripe is intention
 ## Runtime configuration
 These values are hardcoded in `PyCashFlowApp/Core/Config/Config.swift`:
 
-- `API_BASE_URL` => `https://cloud.pycashflow.com/api/v1`
+- `API_BASE_URL` => `https://app.pycashflow.com/api/v1`
 - `SELF_HOSTED_API_BASE_URL` => `https://localhost:5000`
 - `APP_STORE_PRODUCT_IDS` => empty string for now
 

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -119,10 +119,11 @@ final class SessionManager: ObservableObject {
         guard let parsed = URL(string: trimmed), parsed.scheme != nil, parsed.host != nil else {
             return false
         }
-        selfHostedBaseURLText = parsed.absoluteString
-        UserDefaults.standard.set(parsed.absoluteString, forKey: Self.selfHostedURLKey)
+        let canonical = Self.canonicalizedHostedURL(parsed)
+        selfHostedBaseURLText = canonical.absoluteString
+        UserDefaults.standard.set(canonical.absoluteString, forKey: Self.selfHostedURLKey)
         if appMode == .selfHosted {
-            APIClient.shared.baseURL = parsed
+            APIClient.shared.baseURL = canonical
         }
         return true
     }
@@ -149,9 +150,22 @@ final class SessionManager: ObservableObject {
            let url = URL(string: raw),
            url.scheme != nil,
            url.host != nil {
-            return url
+            let canonical = canonicalizedHostedURL(url)
+            if canonical != url {
+                UserDefaults.standard.set(canonical.absoluteString, forKey: selfHostedURLKey)
+            }
+            return canonical
         }
         return AppEnvironment.defaultSelfHostedAPIBaseURL
+    }
+
+    private static func canonicalizedHostedURL(_ url: URL) -> URL {
+        guard url.host?.lowercased() == "cloud.pycashflow.com",
+              var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+        components.host = "app.pycashflow.com"
+        return components.url ?? url
     }
 }
 

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum AppConfig {
-    static let apiBaseURL = "https://cloud.pycashflow.com/api/v1"
+    static let apiBaseURL = "https://app.pycashflow.com/api/v1"
     static let selfHostedAPIBaseURL = "https://localhost:5000"
     static let appStoreProductIDs = "com.h3consultingpartners.pycashflow.cloud.monthly"
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -79,7 +79,7 @@ private struct AnyEncodable: Encodable {
 enum AppEnvironment {
     static let cloudAPIBaseURL: URL = {
         normalizedAPIBaseURL(from: AppConfig.apiBaseURL)
-            ?? URL(string: "https://cloud.pycashflow.com/api/v1")!
+            ?? URL(string: "https://app.pycashflow.com/api/v1")!
     }()
 
     static let defaultSelfHostedAPIBaseURL: URL = {
@@ -99,10 +99,19 @@ enum AppEnvironment {
             return nil
         }
 
-        if candidate.path.isEmpty || candidate.path == "/" {
-            return candidate.appending(path: "api/v1")
+        var normalized = candidate
+        if candidate.host?.lowercased() == "cloud.pycashflow.com",
+           var components = URLComponents(url: candidate, resolvingAgainstBaseURL: false) {
+            components.host = "app.pycashflow.com"
+            if let migrated = components.url {
+                normalized = migrated
+            }
         }
 
-        return candidate
+        if normalized.path.isEmpty || normalized.path == "/" {
+            return normalized.appending(path: "api/v1")
+        }
+
+        return normalized
     }
 }

--- a/ios-app/pycashflow/PyCashFlowAppTests/SessionManagerModeTests.swift
+++ b/ios-app/pycashflow/PyCashFlowAppTests/SessionManagerModeTests.swift
@@ -41,4 +41,26 @@ final class SessionManagerModeTests: XCTestCase {
         let ok = session.updateSelfHostedBaseURL("not-a-url")
         XCTAssertFalse(ok)
     }
+
+    func testLegacyCloudHostIsCanonicalizedForSelfHostedURL() async {
+        let session = SessionManager()
+
+        let ok = session.updateSelfHostedBaseURL("https://cloud.pycashflow.com/api/v1")
+
+        XCTAssertTrue(ok)
+        XCTAssertEqual(session.selfHostedBaseURLText, "https://app.pycashflow.com/api/v1")
+    }
+
+    func testLegacyCloudHostStoredInDefaultsIsMigratedOnLoad() async {
+        UserDefaults.standard.set("https://cloud.pycashflow.com/api/v1", forKey: "SELF_HOSTED_API_BASE_URL")
+        UserDefaults.standard.set("selfHosted", forKey: "APP_MODE")
+
+        let session = SessionManager()
+
+        XCTAssertEqual(session.currentBaseURL.absoluteString, "https://app.pycashflow.com/api/v1")
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: "SELF_HOSTED_API_BASE_URL"),
+            "https://app.pycashflow.com/api/v1"
+        )
+    }
 }


### PR DESCRIPTION
### Motivation
- Migrate legacy references to `cloud.pycashflow.com` to the new host `app.pycashflow.com` so cloud and self-hosted base URLs remain consistent and avoid accidental use of the old hostname.

### Description
- Updated default cloud API base URL in `AppConfig` and README from `https://cloud.pycashflow.com/api/v1` to `https://app.pycashflow.com/api/v1`.
- Added normalization in `AppEnvironment.normalizedAPIBaseURL(from:)` to rewrite `cloud.pycashflow.com` host to `app.pycashflow.com` and to normalize trailing paths.
- Introduced `SessionManager.canonicalizedHostedURL(_:)` and applied it in `updateSelfHostedBaseURL(_:)` and `loadSelfHostedURL()` so user-provided or stored self-hosted URLs using the legacy host are migrated and persisted using the canonical host.
- Adjusted `APIClient`/environment fallbacks to reference the new `app.pycashflow.com` default where applicable.

### Testing
- Added unit tests in `SessionManagerModeTests` for `testLegacyCloudHostIsCanonicalizedForSelfHostedURL` and `testLegacyCloudHostStoredInDefaultsIsMigratedOnLoad`, and ran the test suite; both new tests passed.
- Ran the full unit test suite (`PyCashFlowAppTests`) and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaaa947384832087f13d4da44a7651)