### PR TITLE
Fix self-hosted URL validation error visibility in iOS LoginView

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -14,7 +14,8 @@ struct LoginView: View {
     @State private var challenge: String?
     @State private var twoFACode = ""
     @State private var selfHostedURL = ""
-    @State private var errorText: String?
+    @State private var authErrorText: String?
+    @State private var selfHostedErrorText: String?
     @State private var isLoading = false
     @FocusState private var focusedField: Field?
 
@@ -37,6 +38,8 @@ struct LoginView: View {
                 }
                 .onChange(of: session.appMode) { _, newValue in
                     session.switchMode(newValue)
+                    authErrorText = nil
+                    selfHostedErrorText = nil
                 }
                 .surfaceCard()
 
@@ -77,8 +80,8 @@ struct LoginView: View {
                             .foregroundStyle(AppTheme.textPrimary)
                     }
 
-                    if let errorText {
-                        Text(errorText)
+                    if let authErrorText {
+                        Text(authErrorText)
                             .foregroundStyle(AppTheme.danger)
                             .frame(maxWidth: .infinity, alignment: .leading)
                     }
@@ -106,12 +109,18 @@ struct LoginView: View {
                             .foregroundStyle(AppTheme.textPrimary)
                         Button("Save Server URL") {
                             if !session.updateSelfHostedBaseURL(selfHostedURL) {
-                                errorText = "Please enter a valid URL, including /api/v1."
+                                selfHostedErrorText = "Please enter a valid URL, including /api/v1."
                             } else {
-                                errorText = nil
+                                selfHostedErrorText = nil
                             }
                         }
                         .buttonStyle(PrimaryButtonStyle())
+
+                        if let selfHostedErrorText {
+                            Text(selfHostedErrorText)
+                                .foregroundStyle(AppTheme.danger)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                        }
                     }
                     .surfaceCard()
                 } else {
@@ -139,7 +148,10 @@ struct LoginView: View {
     }
 
     private func submit() async {
-        await MainActor.run { isLoading = true; errorText = nil }
+        await MainActor.run {
+            isLoading = true
+            authErrorText = nil
+        }
         if challenge == nil {
             await login()
         } else {
@@ -163,12 +175,12 @@ struct LoginView: View {
                 return
             }
             guard let token = response.data.token else {
-                await MainActor.run { errorText = "Login token missing" }
+                await MainActor.run { authErrorText = "Login token missing" }
                 return
             }
             await session.establishSession(token: token, user: response.data.user)
         } catch {
-            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Login failed" }
+            await MainActor.run { authErrorText = (error as? APIErrorEnvelope)?.error ?? "Login failed" }
         }
     }
 
@@ -183,12 +195,12 @@ struct LoginView: View {
                 as: APIEnvelope<LoginResponseDTO>.self
             )
             guard let token = response.data.token else {
-                await MainActor.run { errorText = "2FA login token missing" }
+                await MainActor.run { authErrorText = "2FA login token missing" }
                 return
             }
             await session.establishSession(token: token, user: response.data.user)
         } catch {
-            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "2FA failed" }
+            await MainActor.run { authErrorText = (error as? APIErrorEnvelope)?.error ?? "2FA failed" }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ensure validation feedback for the self-hosted API URL appears next to the `Save Server URL` action so users on small screens see immediate error messages instead of hidden auth-card errors.

### Description
- Replace the single `errorText` state with separate `authErrorText` and `selfHostedErrorText` states and update all login/2FA error assignments to use `authErrorText` in `ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift`.
- Render `selfHostedErrorText` directly beneath the self-hosted card's `Save Server URL` button and clear both error states when `session.appMode` changes.

### Testing
- No automated tests were run because this is a UI-only SwiftUI change to the iOS app; the change was validated by static inspection, file diffs, and a local commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaac17466c8320a4fb591a4e5e7a03)