### PR TITLE
Improve iOS layout responsiveness and scrolling

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
@@ -84,10 +84,10 @@ struct DashboardDTO: Decodable {
 }
 
 struct RiskScoreDTO: Decodable {
-    let score: Int
-    let status: String
-    let runway_days: Int
-    let lowest_balance: String
+    let score: Int?
+    let status: String?
+    let runway_days: Int?
+    let lowest_balance: String?
 }
 
 struct TransactionDTO: Decodable, Identifiable {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -13,14 +13,14 @@ struct DashboardView: View {
                     .foregroundStyle(AppTheme.textPrimary)
 
                 if let dashboard {
-                    HStack {
+                    metricsGrid {
                         statCard(title: "Balance", value: "$\(dashboard.balance)")
                         statCard(title: "Min (90d)", value: "$\(dashboard.min_balance)")
                     }
                     if let risk = dashboard.risk_v2 {
-                        HStack {
-                            statCard(title: "Risk", value: "\(risk.score) · \(risk.status)")
-                            statCard(title: "Runway", value: "\(risk.runway_days) days")
+                        metricsGrid {
+                            statCard(title: "Risk", value: "\(risk.score ?? 0) · \(risk.status ?? "Unknown")")
+                            statCard(title: "Runway", value: "\(risk.runway_days ?? 0) days")
                         }
                     }
 
@@ -59,6 +59,17 @@ struct DashboardView: View {
         .refreshable { await loadDashboard() }
         .appBackground()
         .navigationTitle("Dashboard")
+    }
+
+    private func metricsGrid<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        ViewThatFits(in: .horizontal) {
+            HStack(spacing: 12) {
+                content()
+            }
+            VStack(spacing: 10) {
+                content()
+            }
+        }
     }
 
     private func statCard(title: String, value: String) -> some View {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -14,11 +14,12 @@ struct ScenariosView: View {
     private let frequencies = ["Monthly", "Quarterly", "Yearly", "Weekly", "BiWeekly", "Onetime"]
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+        List {
+            Section {
                 Text("Scenarios")
                     .font(.title2.bold())
                     .foregroundStyle(AppTheme.textPrimary)
+                    .listRowBackground(Color.clear)
 
                 VStack(spacing: 8) {
                     TextField("Name", text: $name).fieldStyle()
@@ -30,26 +31,45 @@ struct ScenariosView: View {
                         .buttonStyle(PrimaryButtonStyle())
                 }
                 .surfaceCard()
+                .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
+                .listRowBackground(Color.clear)
 
-                if let errorText { Text(errorText).foregroundStyle(AppTheme.danger) }
-
-                ForEach(scenarios) { scenario in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text(scenario.name).foregroundStyle(AppTheme.textPrimary)
-                            Text("\(scenario.frequency) · \(scenario.start_date)").font(.caption).foregroundStyle(AppTheme.textMuted)
-                        }
-                        Spacer()
-                        Text("$\(scenario.amount)")
-                        Button(role: .destructive) { Task { await deleteScenario(scenario.id) } } label: {
-                            Image(systemName: "trash")
-                        }
-                    }
-                    .surfaceCard()
+                if let errorText {
+                    Text(errorText)
+                        .foregroundStyle(AppTheme.danger)
+                        .listRowBackground(Color.clear)
                 }
             }
-            .padding(20)
+
+            Section("Existing Scenarios") {
+                if scenarios.isEmpty {
+                    Text("No scenarios yet.")
+                        .foregroundStyle(AppTheme.textMuted)
+                }
+
+                ForEach(scenarios) { scenario in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 14) {
+                            VStack(alignment: .leading) {
+                                Text(scenario.name).foregroundStyle(AppTheme.textPrimary)
+                                Text("\(scenario.frequency) · \(scenario.start_date)").font(.caption).foregroundStyle(AppTheme.textMuted)
+                            }
+                            Spacer(minLength: 16)
+                            Text("$\(scenario.amount)")
+                                .foregroundStyle(scenario.type == "Expense" ? AppTheme.danger : AppTheme.success)
+                            Button(role: .destructive) { Task { await deleteScenario(scenario.id) } } label: {
+                                Image(systemName: "trash")
+                            }
+                        }
+                        .frame(minWidth: 340, alignment: .leading)
+                    }
+                    .surfaceCard()
+                    .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+                    .listRowBackground(Color.clear)
+                }
+            }
         }
+        .listStyle(.plain)
         .task { await load() }
         .refreshable { await load() }
         .appBackground()

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -14,11 +14,12 @@ struct SchedulesView: View {
     private let frequencies = ["Monthly", "Quarterly", "Yearly", "Weekly", "BiWeekly", "Onetime"]
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+        List {
+            Section {
                 Text("Schedules")
                     .font(.title2.bold())
                     .foregroundStyle(AppTheme.textPrimary)
+                    .listRowBackground(Color.clear)
 
                 VStack(spacing: 8) {
                     TextField("Name", text: $name).fieldStyle()
@@ -30,26 +31,45 @@ struct SchedulesView: View {
                         .buttonStyle(PrimaryButtonStyle())
                 }
                 .surfaceCard()
+                .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
+                .listRowBackground(Color.clear)
 
-                if let errorText { Text(errorText).foregroundStyle(AppTheme.danger) }
-
-                ForEach(schedules) { schedule in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text(schedule.name).foregroundStyle(AppTheme.textPrimary)
-                            Text("\(schedule.frequency) · \(schedule.start_date)").font(.caption).foregroundStyle(AppTheme.textMuted)
-                        }
-                        Spacer()
-                        Text("$\(schedule.amount)")
-                        Button(role: .destructive) { Task { await deleteSchedule(schedule.id) } } label: {
-                            Image(systemName: "trash")
-                        }
-                    }
-                    .surfaceCard()
+                if let errorText {
+                    Text(errorText)
+                        .foregroundStyle(AppTheme.danger)
+                        .listRowBackground(Color.clear)
                 }
             }
-            .padding(20)
+
+            Section("Existing Schedules") {
+                if schedules.isEmpty {
+                    Text("No schedules yet.")
+                        .foregroundStyle(AppTheme.textMuted)
+                }
+
+                ForEach(schedules) { schedule in
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 14) {
+                            VStack(alignment: .leading) {
+                                Text(schedule.name).foregroundStyle(AppTheme.textPrimary)
+                                Text("\(schedule.frequency) · \(schedule.start_date)").font(.caption).foregroundStyle(AppTheme.textMuted)
+                            }
+                            Spacer(minLength: 16)
+                            Text("$\(schedule.amount)")
+                                .foregroundStyle(schedule.type == "Expense" ? AppTheme.danger : AppTheme.success)
+                            Button(role: .destructive) { Task { await deleteSchedule(schedule.id) } } label: {
+                                Image(systemName: "trash")
+                            }
+                        }
+                        .frame(minWidth: 340, alignment: .leading)
+                    }
+                    .surfaceCard()
+                    .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+                    .listRowBackground(Color.clear)
+                }
+            }
         }
+        .listStyle(.plain)
         .task { await load() }
         .refreshable { await load() }
         .appBackground()


### PR DESCRIPTION
### Motivation
- Ensure iOS SwiftUI screens fit narrow phone widths and avoid horizontal overflow by providing stacking or scrolling where needed.
- Prevent dashboard load/runtime errors caused by missing/null risk payload fields from crashing the UI.
- Make schedule and scenario lists usable on small screens by exposing row content and actions via horizontal scrolling and a proper list layout.

### Description
- Updated `DashboardView` to render metric cards through a new `metricsGrid` helper that uses `ViewThatFits` so cards stack vertically on narrow widths instead of overflowing.
- Made `RiskScoreDTO` fields optional in `APIModels.swift` and added safe UI fallbacks in `DashboardView` to avoid decode/render failures when risk fields are missing or null.
- Reworked `SchedulesView` and `ScenariosView` from a raw `ScrollView`/`VStack` into a `List` with `Section`s, added explicit empty-state text, and applied `.listStyle(.plain)` and row background/inset tuning for better compact layout.
- Added horizontal `ScrollView` wrappers around individual schedule/scenario rows and a minimum row width so long content and action buttons remain accessible on small phones.

### Testing
- Ran `python -m pytest -q`, all tests passed (`260 passed`, `48 warnings`).
- Attempted `xcodebuild -project ios-app/pycashflow.xcodeproj -scheme pycashflow -destination 'generic/platform=iOS' -quiet build` but it could not be executed in this environment because `xcodebuild` is not available (`xcodebuild: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaadbd19208320aa4df70ff561a567)