### PR TITLE
Fix iOS list overflow and local self-hosted API defaults

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
@@ -2,6 +2,6 @@ import Foundation
 
 enum AppConfig {
     static let apiBaseURL = "https://app.pycashflow.com/api/v1"
-    static let selfHostedAPIBaseURL = "https://localhost:5000"
+    static let selfHostedAPIBaseURL = "http://127.0.0.1:5000/api/v1"
     static let appStoreProductIDs = "com.h3consultingpartners.pycashflow.cloud.monthly"
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -84,7 +84,7 @@ enum AppEnvironment {
 
     static let defaultSelfHostedAPIBaseURL: URL = {
         normalizedAPIBaseURL(from: AppConfig.selfHostedAPIBaseURL)
-            ?? URL(string: "https://localhost:5000/api/v1")!
+            ?? URL(string: "http://127.0.0.1:5000/api/v1")!
     }()
 
     static let appStoreProductIDs: [String] = {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -107,6 +107,9 @@ struct LoginView: View {
                             .padding(12)
                             .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
                             .foregroundStyle(AppTheme.textPrimary)
+                        Text("For local dev use http://127.0.0.1:5000/api/v1 (not https).")
+                            .font(.caption)
+                            .foregroundStyle(AppTheme.textMuted)
                         Button("Save Server URL") {
                             if !session.updateSelfHostedBaseURL(selfHostedURL) {
                                 selfHostedErrorText = "Please enter a valid URL, including /api/v1."

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -48,20 +48,27 @@ struct ScenariosView: View {
                 }
 
                 ForEach(scenarios) { scenario in
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 14) {
-                            VStack(alignment: .leading) {
-                                Text(scenario.name).foregroundStyle(AppTheme.textPrimary)
-                                Text("\(scenario.frequency) · \(scenario.start_date)").font(.caption).foregroundStyle(AppTheme.textMuted)
-                            }
-                            Spacer(minLength: 16)
-                            Text("$\(scenario.amount)")
-                                .foregroundStyle(scenario.type == "Expense" ? AppTheme.danger : AppTheme.success)
-                            Button(role: .destructive) { Task { await deleteScenario(scenario.id) } } label: {
-                                Image(systemName: "trash")
-                            }
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(scenario.name)
+                                .foregroundStyle(AppTheme.textPrimary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            Text("\(scenario.frequency) · \(scenario.start_date)")
+                                .font(.caption)
+                                .foregroundStyle(AppTheme.textMuted)
+                                .lineLimit(1)
                         }
-                        .frame(minWidth: 340, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Text("$\(scenario.amount)")
+                            .foregroundStyle(scenario.type == "Expense" ? AppTheme.danger : AppTheme.success)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.9)
+
+                        Button(role: .destructive) { Task { await deleteScenario(scenario.id) } } label: {
+                            Image(systemName: "trash")
+                        }
                     }
                     .surfaceCard()
                     .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -48,20 +48,27 @@ struct SchedulesView: View {
                 }
 
                 ForEach(schedules) { schedule in
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 14) {
-                            VStack(alignment: .leading) {
-                                Text(schedule.name).foregroundStyle(AppTheme.textPrimary)
-                                Text("\(schedule.frequency) · \(schedule.start_date)").font(.caption).foregroundStyle(AppTheme.textMuted)
-                            }
-                            Spacer(minLength: 16)
-                            Text("$\(schedule.amount)")
-                                .foregroundStyle(schedule.type == "Expense" ? AppTheme.danger : AppTheme.success)
-                            Button(role: .destructive) { Task { await deleteSchedule(schedule.id) } } label: {
-                                Image(systemName: "trash")
-                            }
+                    HStack(spacing: 12) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(schedule.name)
+                                .foregroundStyle(AppTheme.textPrimary)
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            Text("\(schedule.frequency) · \(schedule.start_date)")
+                                .font(.caption)
+                                .foregroundStyle(AppTheme.textMuted)
+                                .lineLimit(1)
                         }
-                        .frame(minWidth: 340, alignment: .leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        Text("$\(schedule.amount)")
+                            .foregroundStyle(schedule.type == "Expense" ? AppTheme.danger : AppTheme.success)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.9)
+
+                        Button(role: .destructive) { Task { await deleteSchedule(schedule.id) } } label: {
+                            Image(systemName: "trash")
+                        }
                     }
                     .surfaceCard()
                     .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))


### PR DESCRIPTION
### Motivation
- Schedule and scenario list rows were causing horizontal overflow on phone-sized screens due to forced scrolling and minimum widths. 
- The iOS debug output showed network timeouts and endpoint warnings when the app targeted `https://localhost:5000` while typical local Flask development uses plain HTTP, leading to unreachable/mismatched endpoints.

### Description
- Reworked `SchedulesView` and `ScenariosView` rows to remove the horizontal `ScrollView`/minimum width and use a flexible `HStack` with `.lineLimit(1)` and `.truncationMode(.tail)` for names so content fits on narrow devices. 
- Compact amount rendering with `.minimumScaleFactor(0.9)` and removed forced row `minWidth` to prevent overflow. 
- Added an inline helper note to the login self-hosted settings advising developers to use `http://127.0.0.1:5000/api/v1` for local development. 
- Aligned self-hosted defaults by changing `AppConfig.selfHostedAPIBaseURL` and `AppEnvironment.defaultSelfHostedAPIBaseURL` to `http://127.0.0.1:5000/api/v1` to avoid HTTPS/TLS mismatch against a plain HTTP dev server.

### Testing
- Ran the backend API tests with `python -m pytest -q tests/test_api_foundation.py tests/test_api_data.py`, which completed with `100 passed` and `11 warnings` (SQLAlchemy deprecation warnings). 
- Attempted to run `xcodebuild -list -project ios-app/pycashflow/pycashflow.xcodeproj` but `xcodebuild` is not available in this environment, so iOS build/simulator verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab32c7d40832098c1ae29e7d400a4)