### PR TITLE
Fix Dashboard risk cards when API risk metrics are null

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -19,8 +19,8 @@ struct DashboardView: View {
                     }
                     if let risk = dashboard.risk_v2 {
                         metricsGrid {
-                            statCard(title: "Risk", value: "\(risk.score ?? 0) · \(risk.status ?? "Unknown")")
-                            statCard(title: "Runway", value: "\(risk.runway_days ?? 0) days")
+                            statCard(title: "Risk", value: riskSummaryText(risk))
+                            statCard(title: "Runway", value: runwayText(risk))
                         }
                     }
 
@@ -70,6 +70,20 @@ struct DashboardView: View {
                 content()
             }
         }
+    }
+
+
+    private func riskSummaryText(_ risk: RiskV2DTO) -> String {
+        let scoreText = risk.score.map(String.init) ?? "—"
+        let statusText = risk.status ?? "Unavailable"
+        return "\(scoreText) · \(statusText)"
+    }
+
+    private func runwayText(_ risk: RiskV2DTO) -> String {
+        guard let runwayDays = risk.runway_days else {
+            return "Unavailable"
+        }
+        return "\(runwayDays) days"
     }
 
     private func statCard(title: String, value: String) -> some View {


### PR DESCRIPTION
### Motivation
- The Dashboard view previously coerced nullable `risk_v2` fields (`score`, `runway_days`) to `0`, which can mislead users when the backend intentionally omits those metrics. 
- Missing risk fields should display an unavailable placeholder rather than implying a real numeric value or critical state.

### Description
- Update `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift` to stop nil-coalescing `risk.score` and `risk.runway_days` to `0` and to call new formatter helpers instead. 
- Add `riskSummaryText(_:)` which renders `score` as `—` when missing and `status` as `Unavailable` when nil. 
- Add `runwayText(_:)` which renders `runway_days` as `Unavailable` when nil and formats the day count when present, preserving existing card layout.

### Testing
- Ran the full test suite with `python -m pytest -q`, which completed successfully with `260 passed, 48 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab478df7083209cbaa58df5efb283)