### PR TITLE
Fix DashboardView risk DTO type references

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -73,13 +73,13 @@ struct DashboardView: View {
     }
 
 
-    private func riskSummaryText(_ risk: RiskV2DTO) -> String {
+    private func riskSummaryText(_ risk: RiskScoreDTO) -> String {
         let scoreText = risk.score.map(String.init) ?? "—"
         let statusText = risk.status ?? "Unavailable"
         return "\(scoreText) · \(statusText)"
     }
 
-    private func runwayText(_ risk: RiskV2DTO) -> String {
+    private func runwayText(_ risk: RiskScoreDTO) -> String {
         guard let runwayDays = risk.runway_days else {
             return "Unavailable"
         }


### PR DESCRIPTION
### Motivation
- Fix an iOS compile error in `DashboardView` caused by stale `RiskV2DTO` type references that no longer exist in the app models.

### Description
- Update two helper method signatures in `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift` to use `RiskScoreDTO` instead of `RiskV2DTO` for `riskSummaryText` and `runwayText`.

### Testing
- Ran `rg -n "RiskV2DTO" ios-app/pycashflow -S` and `git diff --check`, both succeeded with no remaining references or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab52e9c308320a84b43e62d086215)