### PR TITLE
Fix keyboard dismissal race conditions in login flow

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Theme/AppTheme.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Theme/AppTheme.swift
@@ -1,4 +1,7 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 /// Shared visual style aligned to the web app's `improved.css` palette.
 enum AppTheme {
@@ -82,4 +85,19 @@ extension View {
             .fixedSize(horizontal: false, vertical: true)
             .surfaceCard()
     }
+}
+
+/// Resigns the active text input via UIKit's responder chain. This runs
+/// synchronously and bypasses SwiftUI's `@FocusState` update cycle, which
+/// avoids races with `UIKeyboardTaskQueue` when a submit handler mutates
+/// other state (e.g. toggling `isLoading`) in the same tick.
+func dismissKeyboard() {
+#if canImport(UIKit)
+    UIApplication.shared.sendAction(
+        #selector(UIResponder.resignFirstResponder),
+        to: nil,
+        from: nil,
+        for: nil
+    )
+#endif
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -37,6 +37,11 @@ struct LoginView: View {
                     }
                 }
                 .onChange(of: session.appMode) { _, newValue in
+                    // Resign any active text field before the self-hosted
+                    // card appears/disappears; otherwise the keyboard layout
+                    // constraints conflict with the view hierarchy change.
+                    dismissKeyboard()
+                    focusedField = nil
                     session.switchMode(newValue)
                     authErrorText = nil
                     selfHostedErrorText = nil
@@ -58,10 +63,7 @@ struct LoginView: View {
                         SecureField("Password", text: $password)
                             .submitLabel(.go)
                             .focused($focusedField, equals: .password)
-                            .onSubmit {
-                                focusedField = nil
-                                Task { await submit() }
-                            }
+                            .onSubmit { submitFromKeyboard() }
                             .padding(12)
                             .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
                             .foregroundStyle(AppTheme.textPrimary)
@@ -71,10 +73,7 @@ struct LoginView: View {
                             .autocorrectionDisabled()
                             .submitLabel(.go)
                             .focused($focusedField, equals: .twoFACode)
-                            .onSubmit {
-                                focusedField = nil
-                                Task { await submit() }
-                            }
+                            .onSubmit { submitFromKeyboard() }
                             .padding(12)
                             .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
                             .foregroundStyle(AppTheme.textPrimary)
@@ -87,8 +86,7 @@ struct LoginView: View {
                     }
 
                     Button(challenge == nil ? "Login" : "Verify 2FA") {
-                        focusedField = nil
-                        Task { await submit() }
+                        submitFromKeyboard()
                     }
                     .buttonStyle(PrimaryButtonStyle())
                     .disabled(isLoading)
@@ -111,6 +109,8 @@ struct LoginView: View {
                             .font(.caption)
                             .foregroundStyle(AppTheme.textMuted)
                         Button("Save Server URL") {
+                            dismissKeyboard()
+                            focusedField = nil
                             if !session.updateSelfHostedBaseURL(selfHostedURL) {
                                 selfHostedErrorText = "Please enter a valid URL, including /api/v1."
                             } else {
@@ -150,17 +150,29 @@ struct LoginView: View {
         }
     }
 
-    private func submit() async {
-        await MainActor.run {
-            isLoading = true
-            authErrorText = nil
+    /// Dismiss the keyboard up front, then launch the submit task on the
+    /// next runloop tick so SwiftUI can finish applying the focus state
+    /// mutation before `isLoading` triggers another view update. Doing both
+    /// in the same tick is what triggers `UIKeyboardTaskQueue` timeouts.
+    private func submitFromKeyboard() {
+        dismissKeyboard()
+        focusedField = nil
+        Task { @MainActor in
+            await Task.yield()
+            await submit()
         }
+    }
+
+    @MainActor
+    private func submit() async {
+        isLoading = true
+        authErrorText = nil
         if challenge == nil {
             await login()
         } else {
             await completeTwoFA()
         }
-        await MainActor.run { isLoading = false }
+        isLoading = false
     }
 
     private func login() async {


### PR DESCRIPTION
## Summary
This PR fixes UIKeyboardTaskQueue timeout issues that occur when dismissing the keyboard and mutating view state simultaneously during login submission. The changes ensure keyboard dismissal happens synchronously via UIKit's responder chain before any SwiftUI state updates.

## Key Changes
- **New `dismissKeyboard()` utility function**: Added to `AppTheme.swift` to synchronously resign first responder via UIKit, bypassing SwiftUI's `@FocusState` update cycle
- **New `submitFromKeyboard()` method**: Extracted common keyboard dismissal + submission logic with proper sequencing:
  - Dismisses keyboard synchronously
  - Clears focus state
  - Yields to next runloop tick before executing submit task
  - Prevents state mutations from racing with keyboard layout updates
- **Refactored `submit()` method**: Simplified with `@MainActor` annotation and removed nested `MainActor.run` calls
- **Applied keyboard dismissal consistently**: Added explicit `dismissKeyboard()` + `focusedField = nil` calls to:
  - Mode switching onChange handler
  - Self-hosted URL save button
  - All keyboard submit handlers (password, 2FA code fields, login button)

## Implementation Details
The core issue was that SwiftUI's `@FocusState` mutations and state changes (like `isLoading`) happening in the same runloop tick would conflict with UIKit's keyboard layout constraints. By:
1. Using UIKit's `resignFirstResponder` directly (synchronous, immediate)
2. Yielding to the next runloop tick with `Task.yield()` before state mutations
3. Allowing SwiftUI to process the focus state change before `isLoading` triggers view updates

This eliminates the race condition that was causing UIKeyboardTaskQueue timeouts.

https://claude.ai/code/session_018bt8JXijf83zVdNcmh7un9