### PR TITLE
Fix login keyboard submit loading race

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -158,9 +158,10 @@ struct LoginView: View {
         dismissKeyboard()
         focusedField = nil
         guard !isLoading else { return }
-        isLoading = true
         Task { @MainActor in
             await Task.yield()
+            guard !isLoading else { return }
+            isLoading = true
             await submit()
         }
     }


### PR DESCRIPTION
### Motivation
- Avoid `UIKeyboardTaskQueue` timeouts by preventing `isLoading` from being mutated in the same runloop tick as `dismissKeyboard()` and focus state clearing.

### Description
- Move `isLoading = true` into the yielded `Task` on `@MainActor` after `await Task.yield()` and add a second `guard !isLoading` there while preserving the early guard to prevent duplicate submissions.

### Testing
- Ran `python -m pytest -q` and all tests passed (`260 passed, 48 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac30b0e00832083807804f3ac3392)