### PR TITLE
Improve error handling and insights display

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
@@ -86,7 +86,7 @@ struct DashboardDTO: Decodable {
 struct RiskScoreDTO: Decodable {
     let score: Int?
     let status: String?
-    let runway_days: Int?
+    let runway_days: Double?
     let lowest_balance: String?
 }
 
@@ -160,9 +160,43 @@ struct SettingsDTO: Decodable {
     let ai: SettingsAIDTO
 }
 
+struct InsightItemDTO: Decodable, Identifiable {
+    let type: String?
+    let severity: String?
+    let title: String?
+    let description: String?
+
+    var id: String { "\(title ?? "")-\(description ?? "")" }
+}
+
 struct InsightsDTO: Decodable {
     let configured: Bool
-    let insights: [String]?
+    let insights: [InsightItemDTO]?
     let last_updated: String?
     let model: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case configured, insights, last_updated, model
+    }
+
+    private struct InsightsWrapper: Decodable {
+        let insights: [InsightItemDTO]?
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        configured = try container.decodeIfPresent(Bool.self, forKey: .configured) ?? false
+        last_updated = try container.decodeIfPresent(String.self, forKey: .last_updated)
+        model = try container.decodeIfPresent(String.self, forKey: .model)
+
+        // The backend stores insights as either an array of objects or the
+        // OpenAI-shaped wrapper {"insights": [...]}; accept either form.
+        if let flat = try? container.decodeIfPresent([InsightItemDTO].self, forKey: .insights) {
+            insights = flat
+        } else if let wrapped = try? container.decodeIfPresent(InsightsWrapper.self, forKey: .insights) {
+            insights = wrapped.insights
+        } else {
+            insights = nil
+        }
+    }
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -37,7 +37,20 @@ final class APIClient {
             request.httpBody = try JSONEncoder().encode(AnyEncodable(body))
         }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            let urlError = error as? URLError
+            throw APIErrorEnvelope(
+                error: urlError?.localizedDescription ?? "Network request failed: \(error.localizedDescription)",
+                code: "network_error",
+                status: 0,
+                fields: nil
+            )
+        }
+
         let code = (response as? HTTPURLResponse)?.statusCode ?? 500
         let decoder = JSONDecoder()
 
@@ -54,13 +67,59 @@ final class APIClient {
                     fields: nil
                 )
             }
-            return try decoder.decode(T.self, from: data)
+            do {
+                return try decoder.decode(T.self, from: data)
+            } catch let decodingError as DecodingError {
+                throw APIErrorEnvelope(
+                    error: "Could not read server response: \(Self.describe(decodingError))",
+                    code: "decoding_error",
+                    status: code,
+                    fields: nil
+                )
+            } catch {
+                throw APIErrorEnvelope(
+                    error: "Could not read server response: \(error.localizedDescription)",
+                    code: "decoding_error",
+                    status: code,
+                    fields: nil
+                )
+            }
         }
 
         if let apiError = try? decoder.decode(APIErrorEnvelope.self, from: data) {
             throw apiError
         }
-        throw APIErrorEnvelope(error: "Request failed", code: "request_failed", status: code, fields: nil)
+
+        let bodyPreview = String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .prefix(200)
+        let suffix = (bodyPreview?.isEmpty == false) ? ": \(bodyPreview!)" : ""
+        throw APIErrorEnvelope(
+            error: "Request failed (HTTP \(code))\(suffix)",
+            code: "request_failed",
+            status: code,
+            fields: nil
+        )
+    }
+
+    private static func describe(_ error: DecodingError) -> String {
+        switch error {
+        case .typeMismatch(_, let ctx):
+            return "type mismatch at \(Self.path(ctx.codingPath)) — \(ctx.debugDescription)"
+        case .valueNotFound(_, let ctx):
+            return "missing value at \(Self.path(ctx.codingPath)) — \(ctx.debugDescription)"
+        case .keyNotFound(let key, let ctx):
+            return "missing key '\(key.stringValue)' at \(Self.path(ctx.codingPath))"
+        case .dataCorrupted(let ctx):
+            return "corrupted data at \(Self.path(ctx.codingPath)) — \(ctx.debugDescription)"
+        @unknown default:
+            return "\(error)"
+        }
+    }
+
+    private static func path(_ keys: [CodingKey]) -> String {
+        let rendered = keys.map { $0.stringValue }.joined(separator: ".")
+        return rendered.isEmpty ? "(root)" : rendered
     }
 }
 

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Accounts/AccountsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Accounts/AccountsView.swift
@@ -10,10 +10,6 @@ struct AccountsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                Text("Accounts")
-                    .font(.title2.bold())
-                    .foregroundStyle(AppTheme.textPrimary)
-
                 if let balance {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Current Balance")

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -8,10 +8,6 @@ struct DashboardView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
-                Text("Dashboard")
-                    .font(.largeTitle.bold())
-                    .foregroundStyle(AppTheme.textPrimary)
-
                 if let dashboard {
                     metricsGrid {
                         statCard(title: "Balance", value: "$\(dashboard.balance)")

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -91,7 +91,11 @@ struct DashboardView: View {
         guard let runwayDays = risk.runway_days else {
             return "Unavailable"
         }
-        return "\(runwayDays) days"
+        let rounded = runwayDays.rounded()
+        if abs(runwayDays - rounded) < 0.05 {
+            return "\(Int(rounded)) days"
+        }
+        return String(format: "%.1f days", runwayDays)
     }
 
     private func statCard(title: String, value: String) -> some View {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Projections/ProjectionsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Projections/ProjectionsView.swift
@@ -9,10 +9,6 @@ struct ProjectionsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                Text("Projections")
-                    .font(.title2.bold())
-                    .foregroundStyle(AppTheme.textPrimary)
-
                 Text("Schedule projection points: \(scheduleSeries.count)")
                     .foregroundStyle(AppTheme.textSecondary)
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -16,11 +16,6 @@ struct ScenariosView: View {
     var body: some View {
         List {
             Section {
-                Text("Scenarios")
-                    .font(.title2.bold())
-                    .foregroundStyle(AppTheme.textPrimary)
-                    .listRowBackground(Color.clear)
-
                 VStack(spacing: 8) {
                     TextField("Name", text: $name).fieldStyle()
                     TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -16,11 +16,6 @@ struct SchedulesView: View {
     var body: some View {
         List {
             Section {
-                Text("Schedules")
-                    .font(.title2.bold())
-                    .foregroundStyle(AppTheme.textPrimary)
-                    .listRowBackground(Color.clear)
-
                 VStack(spacing: 8) {
                     TextField("Name", text: $name).fieldStyle()
                     TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -31,17 +31,25 @@ struct SettingsView: View {
                 }
 
                 if let insights, let items = insights.insights, !items.isEmpty {
-                    VStack(alignment: .leading, spacing: 6) {
+                    VStack(alignment: .leading, spacing: 10) {
                         Text("Insights")
                             .font(.caption)
                             .foregroundStyle(AppTheme.textMuted)
-                        ForEach(Array(items.enumerated()), id: \.offset) { _, line in
-                            HStack(alignment: .top, spacing: 8) {
-                                Text("•").foregroundStyle(AppTheme.textMuted)
-                                Text(line)
-                                    .foregroundStyle(AppTheme.textPrimary)
-                                    .fixedSize(horizontal: false, vertical: true)
+                        ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                            VStack(alignment: .leading, spacing: 2) {
+                                if let title = item.title, !title.isEmpty {
+                                    Text(title)
+                                        .font(.subheadline.weight(.semibold))
+                                        .foregroundStyle(AppTheme.textPrimary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
+                                if let description = item.description, !description.isEmpty {
+                                    Text(description)
+                                        .foregroundStyle(AppTheme.textSecondary)
+                                        .fixedSize(horizontal: false, vertical: true)
+                                }
                             }
+                            .frame(maxWidth: .infinity, alignment: .leading)
                         }
                     }
                     .cardRow()

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -11,10 +11,6 @@ struct SettingsView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
-                Text("Settings")
-                    .font(.title2.bold())
-                    .foregroundStyle(AppTheme.textPrimary)
-
                 if let settings {
                     infoRow(label: "Signed in as", value: settings.user.email)
                     infoRow(label: "App Version", value: settings.app.version)


### PR DESCRIPTION
## Summary
This PR enhances error handling in the API client with detailed error messages and improves the insights display by supporting structured insight items instead of plain strings. It also removes redundant view titles that are now handled by navigation.

## Key Changes

**API Client Error Handling**
- Added try-catch wrapper around `URLSession.data()` to catch network errors and convert them to `APIErrorEnvelope`
- Added detailed decoding error handling with a new `describe()` helper that provides specific information about type mismatches, missing values, missing keys, and corrupted data
- Enhanced the generic request failure error to include HTTP status code and a preview of the response body (up to 200 characters)
- Added `path()` helper to format coding key paths for better error context

**Data Models**
- Changed `RiskScoreDTO.runway_days` from `Int?` to `Double?` to support fractional day values
- Created new `InsightItemDTO` struct with `type`, `severity`, `title`, and `description` fields
- Updated `InsightsDTO` to use `[InsightItemDTO]?` instead of `[String]?`
- Implemented custom `Decodable` for `InsightsDTO` to handle both flat array format and OpenAI-shaped wrapper format (`{"insights": [...]}`)

**UI Updates**
- Removed redundant section titles from DashboardView, SettingsView, ScenariosView, SchedulesView, AccountsView, and ProjectionsView (now handled by navigation)
- Enhanced insights display in SettingsView to show structured items with title and description instead of plain bullet points
- Updated DashboardView to format runway days intelligently: displays as integer when close to whole number, otherwise shows one decimal place

## Notable Implementation Details
- The `InsightsDTO` decoder accepts both flat and wrapped insight formats for backend compatibility
- Decoding errors now provide precise location information (e.g., "type mismatch at user.email")
- Network errors are consistently wrapped in `APIErrorEnvelope` for uniform error handling throughout the app

https://claude.ai/code/session_01QyvZjnhKBMmMAjnPWCPsAA