### PR TITLE
Add cash flow projection chart to dashboard

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
@@ -1,0 +1,189 @@
+import SwiftUI
+import Charts
+
+struct CashFlowChartView: View {
+    let schedule: [ProjectionPointDTO]
+    let scenario: [ProjectionPointDTO]
+
+    private static let scheduleColor = Color(red: 59/255, green: 130/255, blue: 246/255)   // #3b82f6
+    private static let scenarioColor = Color(red: 245/255, green: 158/255, blue: 11/255)   // #f59e0b
+
+    private var schedulePoints: [CashFlowPoint] { CashFlowPoint.parse(schedule) }
+    private var scenarioPoints: [CashFlowPoint] { CashFlowPoint.parse(scenario) }
+
+    private var hasScenario: Bool { !scenarioPoints.isEmpty }
+
+    private var xDomain: ClosedRange<Date> {
+        let today = Calendar.current.startOfDay(for: Date())
+        let end = Calendar.current.date(byAdding: .day, value: 90, to: today) ?? today
+        return today...end
+    }
+
+    private var yDomain: ClosedRange<Double> {
+        let horizonEnd = xDomain.upperBound
+        let inWindow: (CashFlowPoint) -> Bool = { $0.date <= horizonEnd }
+        let values = (schedulePoints + scenarioPoints).filter(inWindow).map(\.amount)
+        guard let rawMin = values.min(), let rawMax = values.max() else {
+            return 0...1
+        }
+        let lower = rawMin >= 0 ? 0 : rawMin * 1.1
+        let upper = max(rawMax * 1.1, lower + 1)
+        return lower...upper
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 6) {
+                Image(systemName: "chart.xyaxis.line")
+                    .foregroundStyle(AppTheme.accent)
+                Text("Cash Flow")
+                    .font(.headline)
+                    .foregroundStyle(AppTheme.textPrimary)
+                Spacer()
+                if hasScenario {
+                    legend()
+                }
+            }
+
+            if schedulePoints.isEmpty && scenarioPoints.isEmpty {
+                Text("No projection data yet.")
+                    .font(.caption)
+                    .foregroundStyle(AppTheme.textMuted)
+                    .frame(maxWidth: .infinity, minHeight: 180, alignment: .center)
+            } else {
+                chart
+                    .frame(height: 220)
+            }
+        }
+        .surfaceCard()
+    }
+
+    @ViewBuilder
+    private var chart: some View {
+        Chart {
+            ForEach(scenarioPoints) { point in
+                LineMark(
+                    x: .value("Date", point.date),
+                    y: .value("Balance", point.amount),
+                    series: .value("Series", "With Scenarios")
+                )
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(Self.scenarioColor)
+                .lineStyle(StrokeStyle(lineWidth: 2, dash: [6, 4]))
+            }
+
+            ForEach(schedulePoints) { point in
+                LineMark(
+                    x: .value("Date", point.date),
+                    y: .value("Balance", point.amount),
+                    series: .value("Series", "Schedule")
+                )
+                .interpolationMethod(.catmullRom)
+                .foregroundStyle(Self.scheduleColor)
+                .lineStyle(StrokeStyle(lineWidth: 2))
+            }
+        }
+        .chartXScale(domain: xDomain)
+        .chartYScale(domain: yDomain)
+        .chartXAxis {
+            AxisMarks(values: .automatic(desiredCount: 4)) { _ in
+                AxisGridLine().foregroundStyle(AppTheme.border.opacity(0.5))
+                AxisTick().foregroundStyle(AppTheme.border)
+                AxisValueLabel()
+                    .foregroundStyle(AppTheme.textMuted)
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: .automatic(desiredCount: 5)) { value in
+                AxisGridLine().foregroundStyle(AppTheme.border.opacity(0.5))
+                AxisTick().foregroundStyle(AppTheme.border)
+                AxisValueLabel {
+                    if let amount = value.as(Double.self) {
+                        Text(currencyAxisLabel(amount))
+                            .foregroundStyle(AppTheme.textMuted)
+                    }
+                }
+            }
+        }
+    }
+
+    private func legend() -> some View {
+        HStack(spacing: 10) {
+            if hasScenario {
+                legendItem(color: Self.scenarioColor, dashed: true, label: "With Scenarios")
+            }
+            legendItem(color: Self.scheduleColor, dashed: false, label: "Schedule")
+        }
+        .font(.caption2)
+        .foregroundStyle(AppTheme.textSecondary)
+    }
+
+    private func legendItem(color: Color, dashed: Bool, label: String) -> some View {
+        HStack(spacing: 4) {
+            LegendSwatch(color: color, dashed: dashed)
+                .frame(width: 18, height: 2)
+            Text(label)
+        }
+    }
+
+    private func currencyAxisLabel(_ amount: Double) -> String {
+        let absValue = abs(amount)
+        let sign = amount < 0 ? "-" : ""
+        if absValue >= 1_000_000 {
+            return "\(sign)$\(formatNumber(absValue / 1_000_000))M"
+        }
+        if absValue >= 1_000 {
+            return "\(sign)$\(formatNumber(absValue / 1_000))k"
+        }
+        return "\(sign)$\(Int(absValue.rounded()))"
+    }
+
+    private func formatNumber(_ value: Double) -> String {
+        if value >= 10 || value.rounded() == value {
+            return String(format: "%.0f", value)
+        }
+        return String(format: "%.1f", value)
+    }
+}
+
+private struct LegendSwatch: View {
+    let color: Color
+    let dashed: Bool
+
+    var body: some View {
+        GeometryReader { geo in
+            Path { path in
+                let y = geo.size.height / 2
+                path.move(to: CGPoint(x: 0, y: y))
+                path.addLine(to: CGPoint(x: geo.size.width, y: y))
+            }
+            .stroke(
+                color,
+                style: StrokeStyle(lineWidth: 2, dash: dashed ? [4, 3] : [])
+            )
+        }
+    }
+}
+
+struct CashFlowPoint: Identifiable {
+    let date: Date
+    let amount: Double
+    var id: Date { date }
+
+    static func parse(_ points: [ProjectionPointDTO]) -> [CashFlowPoint] {
+        points.compactMap { dto in
+            guard let date = dateFormatter.date(from: dto.date),
+                  let amount = Double(dto.amount) else { return nil }
+            return CashFlowPoint(date: date, amount: amount)
+        }
+        .sorted { $0.date < $1.date }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+}

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DashboardView: View {
     @EnvironmentObject var session: SessionManager
     @State private var dashboard: DashboardDTO?
+    @State private var projections: ProjectionsDTO?
     @State private var errorText: String?
 
     var body: some View {
@@ -18,6 +19,13 @@ struct DashboardView: View {
                             statCard(title: "Risk", value: riskSummaryText(risk))
                             statCard(title: "Runway", value: runwayText(risk))
                         }
+                    }
+
+                    if let projections {
+                        CashFlowChartView(
+                            schedule: projections.schedule,
+                            scenario: projections.scenario ?? []
+                        )
                     }
 
                     Text("Upcoming")
@@ -63,8 +71,8 @@ struct DashboardView: View {
             }
             .padding(20)
         }
-        .task { await loadDashboard() }
-        .refreshable { await loadDashboard() }
+        .task { await loadAll() }
+        .refreshable { await loadAll() }
         .appBackground()
         .navigationTitle("Dashboard")
     }
@@ -115,6 +123,12 @@ struct DashboardView: View {
         .surfaceCard()
     }
 
+    private func loadAll() async {
+        async let dashboardTask: Void = loadDashboard()
+        async let projectionsTask: Void = loadProjections()
+        _ = await (dashboardTask, projectionsTask)
+    }
+
     private func loadDashboard() async {
         guard let token = session.token else { return }
         do {
@@ -125,6 +139,16 @@ struct DashboardView: View {
             }
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load dashboard" }
+        }
+    }
+
+    private func loadProjections() async {
+        guard let token = session.token else { return }
+        do {
+            let response: APIEnvelope<ProjectionsDTO> = try await APIClient.shared.request("projections", token: token, as: APIEnvelope<ProjectionsDTO>.self)
+            await MainActor.run { projections = response.data }
+        } catch {
+            // Chart silently hides if projections fail; dashboard error surfaces other issues.
         }
     }
 


### PR DESCRIPTION
## Summary
Added a new cash flow chart visualization to the Dashboard that displays projected cash balances over a 90-day horizon, with support for comparing scheduled projections against scenario-based projections.

## Key Changes
- **New `CashFlowChartView` component**: Renders an interactive chart showing cash flow projections with:
  - Dual-line visualization: solid line for scheduled projections, dashed line for scenario-based projections
  - Automatic Y-axis scaling with 10% padding and minimum range of 1
  - 90-day X-axis horizon from today
  - Currency-formatted Y-axis labels (supporting M/k notation for large values)
  - Legend display when scenario data is available
  - Empty state messaging when no projection data exists

- **New `CashFlowPoint` model**: Parses `ProjectionPointDTO` objects with:
  - Date parsing from "yyyy-MM-dd" format (UTC timezone)
  - Amount conversion to Double
  - Automatic sorting by date

- **New `LegendSwatch` component**: Custom visual indicator for chart lines (solid or dashed)

- **Updated `DashboardView`**:
  - Added `projections` state to hold projection data
  - Integrated `CashFlowChartView` into the dashboard layout
  - Refactored data loading into `loadAll()` that concurrently fetches dashboard and projections
  - Added `loadProjections()` method that gracefully handles failures (chart hides silently if projections fail)

## Implementation Details
- Chart uses SwiftUI's Charts framework with Catmull-Rom interpolation for smooth curves
- Y-axis domain calculation intelligently handles negative values and ensures adequate spacing
- Currency formatting intelligently abbreviates large numbers (e.g., $1.5M, $500k)
- Projections are loaded concurrently with dashboard data for better performance
- Projection load failures don't block dashboard display; the chart simply won't render

https://claude.ai/code/session_01JU1vgpkcYL5nopU3atXTAv