### PR TITLE
Fix projection loading and chart timezone handling

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
@@ -17,8 +17,10 @@ struct CashFlowChartView: View {
     private static let visibleDays = 30
 
     private var xDomain: ClosedRange<Date> {
-        let today = Calendar.current.startOfDay(for: Date())
-        let end = Calendar.current.date(byAdding: .day, value: Self.horizonDays, to: today) ?? today
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC") ?? calendar.timeZone
+        let today = calendar.startOfDay(for: Date())
+        let end = calendar.date(byAdding: .day, value: Self.horizonDays, to: today) ?? today
         return today...end
     }
 

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -144,12 +144,16 @@ struct DashboardView: View {
     }
 
     private func loadProjections() async {
-        guard let token = session.token else { return }
+        guard let token = session.token else {
+            await MainActor.run { projections = nil }
+            return
+        }
         do {
             let response: APIEnvelope<ProjectionsDTO> = try await APIClient.shared.request("projections", token: token, as: APIEnvelope<ProjectionsDTO>.self)
             await MainActor.run { projections = response.data }
         } catch {
-            // Chart silently hides if projections fail; dashboard error surfaces other issues.
+            // Clear stale data so the chart hides silently; dashboard error surfaces other issues.
+            await MainActor.run { projections = nil }
         }
     }
 


### PR DESCRIPTION
## Summary
This PR fixes two issues in the Dashboard feature: ensuring stale projection data is cleared when loading fails, and correcting timezone handling in the cash flow chart calculations.

## Key Changes
- **DashboardView.swift**: 
  - Clear projections to `nil` when token is unavailable, ensuring the chart hides properly
  - Clear projections to `nil` on API errors instead of silently failing, preventing stale data from displaying
  
- **CashFlowChartView.swift**:
  - Use explicit UTC timezone for date calculations in `xDomain` to ensure consistent chart rendering across different device timezones
  - Replace implicit calendar with explicit Gregorian calendar configured with UTC timezone

## Implementation Details
The projection clearing ensures the UI responds correctly to both authentication and network failures by hiding the chart rather than displaying outdated information. The timezone fix prevents date calculation discrepancies that could occur when the device timezone differs from the expected UTC reference point for the chart's date range.

https://claude.ai/code/session_01Mqpk5SHNczuUBQuSyL77ua