### PR TITLE
Fix keyboard dismissal gesture conflict on LoginView

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -144,7 +144,13 @@ struct LoginView: View {
         .appBackground()
         .navigationTitle("Login")
         .navigationBarTitleDisplayMode(.inline)
-        .scrollDismissesKeyboard(.interactively)
+        // Interactive dismissal installs a pan recognizer that competes with
+        // the system home-indicator gesture while the keyboard is visible;
+        // when the gesture gate times out iOS hands the swipe to SpringBoard,
+        // which manifests as the app "dropping to the home screen" while the
+        // user is typing. `.immediately` keeps scroll-to-dismiss UX without
+        // the conflicting drag recognizer.
+        .scrollDismissesKeyboard(.immediately)
         .onAppear {
             selfHostedURL = session.selfHostedBaseURLText
         }


### PR DESCRIPTION
## Summary
Changed the keyboard dismissal behavior on LoginView from interactive to immediate to prevent gesture conflicts with the system home-indicator.

## Key Changes
- Modified `scrollDismissesKeyboard` modifier from `.interactively` to `.immediately` on LoginView
- Added detailed comment explaining the gesture conflict issue and rationale for the change

## Implementation Details
The interactive keyboard dismissal was installing a pan recognizer that competed with iOS's home-indicator gesture while the keyboard was visible. This caused a gesture gate timeout that handed the swipe to SpringBoard, resulting in the app unexpectedly dropping to the home screen while users were typing.

By switching to `.immediately`, the scroll-to-dismiss user experience is preserved without the conflicting drag recognizer that was causing the unwanted behavior.

https://claude.ai/code/session_01Wg3HaAPyfWkcBMs49B5wGm