### PR TITLE
Add edit, hold, and skip functionality to Schedules and Scenarios

### DIFF
--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -518,15 +518,29 @@ def api_create_skip():
     user_id = _effective_user_id()
     body = request.get_json(silent=True) or {}
     transaction_index = body.get("transaction_index")
-    if transaction_index is None:
-        return validation_error({"transaction_index": "transaction_index is required"})
+    schedule_id = body.get("schedule_id")
+    if transaction_index is None and schedule_id is None:
+        return validation_error(
+            {"transaction_index": "transaction_index or schedule_id is required"}
+        )
 
     _balance, _balance_amount, trans, _run, _run_scenario = _project_data(user_id)
 
-    try:
-        tx = trans.loc[int(transaction_index)]
-    except Exception:
-        return validation_error({"transaction_index": "transaction index not found"})
+    if schedule_id is not None:
+        schedule = Schedule.query.filter_by(user_id=user_id, id=schedule_id).first()
+        if not schedule:
+            return not_found("Schedule not found")
+        matches = trans[trans["name"] == schedule.name]
+        if matches.empty:
+            return validation_error(
+                {"schedule_id": "No upcoming transaction found for this schedule"}
+            )
+        tx = matches.iloc[0]
+    else:
+        try:
+            tx = trans.loc[int(transaction_index)]
+        except Exception:
+            return validation_error({"transaction_index": "transaction index not found"})
 
     trans_type = "Income" if tx["type"] == "Expense" else "Expense"
     skip = Skip(

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
@@ -114,6 +114,21 @@ struct ScheduleDTO: Decodable, Identifiable {
     let start_date: String
 }
 
+struct HoldDTO: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let amount: String
+    let type: String
+}
+
+struct SkipDTO: Decodable, Identifiable {
+    let id: Int
+    let name: String
+    let amount: String
+    let type: String
+    let date: String?
+}
+
 struct ScenarioDTO: Decodable, Identifiable {
     let id: Int
     let name: String

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Theme/AppTheme.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Theme/AppTheme.swift
@@ -16,6 +16,7 @@ enum AppTheme {
 
     static let success = Color(red: 16/255, green: 185/255, blue: 129/255)        // #10b981
     static let danger = Color(red: 239/255, green: 68/255, blue: 68/255)          // #ef4444
+    static let warning = Color(red: 245/255, green: 158/255, blue: 11/255)        // #f59e0b
 
     static let textPrimary = Color(red: 241/255, green: 245/255, blue: 249/255)   // #f1f5f9
     static let textSecondary = Color(red: 203/255, green: 213/255, blue: 225/255) // #cbd5e1

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct AccountsView: View {
+struct BalanceView: View {
     @EnvironmentObject var session: SessionManager
     @State private var balance: BalanceDTO?
     @State private var history: [BalanceDTO] = []
@@ -73,7 +73,7 @@ struct AccountsView: View {
         .task { await load() }
         .refreshable { await load() }
         .appBackground()
-        .navigationTitle("Accounts")
+        .navigationTitle("Balance")
     }
 
     private func load() async {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -78,7 +78,7 @@ struct DashboardView: View {
 
     private var navItems: [FloatingNavItem] {
         [
-            FloatingNavItem(title: "Accounts", systemImage: "creditcard") { AccountsView() },
+            FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle") { BalanceView() },
             FloatingNavItem(title: "Schedules", systemImage: "calendar") { SchedulesView() },
             FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3") { ScenariosView() },
             FloatingNavItem(title: "AI Insights", systemImage: "sparkles") { AIInsightsView() },

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -3,11 +3,18 @@ import SwiftUI
 struct ScenariosView: View {
     @EnvironmentObject var session: SessionManager
     @State private var scenarios: [ScenarioDTO] = []
+    @State private var showAddForm = false
     @State private var name = ""
     @State private var amount = ""
     @State private var type = "Expense"
     @State private var frequency = "Monthly"
-    @State private var startDate = "2026-01-01"
+    @State private var startDate = defaultStartDate()
+    @State private var editingID: Int?
+    @State private var editName = ""
+    @State private var editAmount = ""
+    @State private var editType = "Expense"
+    @State private var editFrequency = "Monthly"
+    @State private var editStartDate = defaultStartDate()
     @State private var errorText: String?
 
     private let types = ["Expense", "Income"]
@@ -16,18 +23,35 @@ struct ScenariosView: View {
     var body: some View {
         List {
             Section {
-                VStack(spacing: 8) {
-                    TextField("Name", text: $name).fieldStyle()
-                    TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()
-                    pickerRow(label: "Type", selection: $type, options: types)
-                    pickerRow(label: "Frequency", selection: $frequency, options: frequencies)
-                    TextField("Start date (YYYY-MM-DD)", text: $startDate).fieldStyle()
-                    Button("Add Scenario") { Task { await addScenario() } }
-                        .buttonStyle(PrimaryButtonStyle())
+                Button {
+                    withAnimation {
+                        showAddForm.toggle()
+                        if !showAddForm { resetAddForm() }
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: showAddForm ? "xmark.circle" : "plus.circle.fill")
+                        Text(showAddForm ? "Cancel" : "Add Scenario")
+                    }
                 }
-                .surfaceCard()
+                .buttonStyle(PrimaryButtonStyle())
                 .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
                 .listRowBackground(Color.clear)
+
+                if showAddForm {
+                    VStack(spacing: 8) {
+                        TextField("Name", text: $name).fieldStyle()
+                        TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()
+                        pickerRow(label: "Type", selection: $type, options: types)
+                        pickerRow(label: "Frequency", selection: $frequency, options: frequencies)
+                        TextField("Start date (YYYY-MM-DD)", text: $startDate).fieldStyle()
+                        Button("Save Scenario") { Task { await addScenario() } }
+                            .buttonStyle(PrimaryButtonStyle())
+                    }
+                    .surfaceCard()
+                    .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
+                    .listRowBackground(Color.clear)
+                }
 
                 if let errorText {
                     Text(errorText)
@@ -45,30 +69,53 @@ struct ScenariosView: View {
                 }
 
                 ForEach(scenarios) { scenario in
-                    HStack(spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(scenario.name)
-                                .foregroundStyle(AppTheme.textPrimary)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                            Text("\(scenario.frequency) · \(scenario.start_date)")
-                                .font(.caption)
-                                .foregroundStyle(AppTheme.textMuted)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.85)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 12) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(scenario.name)
+                                    .foregroundStyle(AppTheme.textPrimary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                                Text("\(scenario.frequency) · \(scenario.start_date)")
+                                    .font(.caption)
+                                    .foregroundStyle(AppTheme.textMuted)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.85)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Text("$\(scenario.amount)")
-                            .foregroundStyle(scenario.type == "Expense" ? AppTheme.danger : AppTheme.success)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.7)
-                            .layoutPriority(1)
-
-                        Button(role: .destructive) { Task { await deleteScenario(scenario.id) } } label: {
-                            Image(systemName: "trash")
+                            Text("$\(scenario.amount)")
+                                .foregroundStyle(scenario.type == "Expense" ? AppTheme.danger : AppTheme.success)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                                .layoutPriority(1)
                         }
-                        .buttonStyle(.borderless)
+
+                        HStack(spacing: 16) {
+                            iconButton(systemName: "pencil", color: AppTheme.accent, label: "Edit") {
+                                beginEdit(scenario)
+                            }
+                            iconButton(systemName: "trash", color: AppTheme.danger, label: "Delete") {
+                                Task { await deleteScenario(scenario.id) }
+                            }
+                        }
+
+                        if editingID == scenario.id {
+                            VStack(spacing: 8) {
+                                TextField("Name", text: $editName).fieldStyle()
+                                TextField("Amount", text: $editAmount).keyboardType(.decimalPad).fieldStyle()
+                                pickerRow(label: "Type", selection: $editType, options: types)
+                                pickerRow(label: "Frequency", selection: $editFrequency, options: frequencies)
+                                TextField("Start date (YYYY-MM-DD)", text: $editStartDate).fieldStyle()
+                                HStack(spacing: 8) {
+                                    Button("Save") { Task { await saveEdit(scenario.id) } }
+                                        .buttonStyle(PrimaryButtonStyle())
+                                    Button("Cancel") { editingID = nil }
+                                        .buttonStyle(PrimaryButtonStyle())
+                                }
+                            }
+                            .padding(.top, 4)
+                        }
                     }
                     .surfaceCard()
                     .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
@@ -81,6 +128,20 @@ struct ScenariosView: View {
         .refreshable { await load() }
         .appBackground()
         .navigationTitle("Scenarios")
+    }
+
+    private func iconButton(systemName: String, color: Color, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 2) {
+                Image(systemName: systemName)
+                    .font(.system(size: 16, weight: .semibold))
+                Text(label)
+                    .font(.caption2)
+            }
+            .foregroundStyle(color)
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderless)
     }
 
     private func pickerRow(label: String, selection: Binding<String>, options: [String]) -> some View {
@@ -100,6 +161,30 @@ struct ScenariosView: View {
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private static func defaultStartDate() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+
+    private func resetAddForm() {
+        name = ""
+        amount = ""
+        type = "Expense"
+        frequency = "Monthly"
+        startDate = Self.defaultStartDate()
+        errorText = nil
+    }
+
+    private func beginEdit(_ scenario: ScenarioDTO) {
+        editingID = scenario.id
+        editName = scenario.name
+        editAmount = scenario.amount
+        editType = scenario.type
+        editFrequency = scenario.frequency
+        editStartDate = scenario.start_date
     }
 
     private func load() async {
@@ -138,9 +223,36 @@ struct ScenariosView: View {
                 as: APIEnvelope<ScenarioDTO>.self
             )
             await load()
-            await MainActor.run { name = ""; amount = "" }
+            await MainActor.run {
+                resetAddForm()
+                showAddForm = false
+            }
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to add scenario" }
+        }
+    }
+
+    private func saveEdit(_ id: Int) async {
+        guard let token = session.token else { return }
+        do {
+            struct Payload: Encodable {
+                let name: String
+                let amount: String
+                let type: String
+                let frequency: String
+                let start_date: String
+            }
+            _ = try await APIClient.shared.request(
+                "scenarios/\(id)",
+                method: "PUT",
+                token: token,
+                body: Payload(name: editName, amount: editAmount, type: editType, frequency: editFrequency, start_date: editStartDate),
+                as: APIEnvelope<ScenarioDTO>.self
+            )
+            await load()
+            await MainActor.run { editingID = nil }
+        } catch {
+            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to update scenario" }
         }
     }
 

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -3,12 +3,20 @@ import SwiftUI
 struct SchedulesView: View {
     @EnvironmentObject var session: SessionManager
     @State private var schedules: [ScheduleDTO] = []
+    @State private var showAddForm = false
     @State private var name = ""
     @State private var amount = ""
     @State private var type = "Expense"
     @State private var frequency = "Monthly"
-    @State private var startDate = "2026-01-01"
+    @State private var startDate = defaultStartDate()
+    @State private var editingID: Int?
+    @State private var editName = ""
+    @State private var editAmount = ""
+    @State private var editType = "Expense"
+    @State private var editFrequency = "Monthly"
+    @State private var editStartDate = defaultStartDate()
     @State private var errorText: String?
+    @State private var statusText: String?
 
     private let types = ["Expense", "Income"]
     private let frequencies = ["Monthly", "Quarterly", "Yearly", "Weekly", "BiWeekly", "Onetime"]
@@ -16,22 +24,47 @@ struct SchedulesView: View {
     var body: some View {
         List {
             Section {
-                VStack(spacing: 8) {
-                    TextField("Name", text: $name).fieldStyle()
-                    TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()
-                    pickerRow(label: "Type", selection: $type, options: types)
-                    pickerRow(label: "Frequency", selection: $frequency, options: frequencies)
-                    TextField("Start date (YYYY-MM-DD)", text: $startDate).fieldStyle()
-                    Button("Add Schedule") { Task { await addSchedule() } }
-                        .buttonStyle(PrimaryButtonStyle())
+                Button {
+                    withAnimation {
+                        showAddForm.toggle()
+                        if !showAddForm { resetAddForm() }
+                    }
+                } label: {
+                    HStack {
+                        Image(systemName: showAddForm ? "xmark.circle" : "plus.circle.fill")
+                        Text(showAddForm ? "Cancel" : "Add Schedule")
+                    }
                 }
-                .surfaceCard()
+                .buttonStyle(PrimaryButtonStyle())
                 .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
                 .listRowBackground(Color.clear)
+
+                if showAddForm {
+                    VStack(spacing: 8) {
+                        TextField("Name", text: $name).fieldStyle()
+                        TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()
+                        pickerRow(label: "Type", selection: $type, options: types)
+                        pickerRow(label: "Frequency", selection: $frequency, options: frequencies)
+                        TextField("Start date (YYYY-MM-DD)", text: $startDate).fieldStyle()
+                        Button("Save Schedule") { Task { await addSchedule() } }
+                            .buttonStyle(PrimaryButtonStyle())
+                    }
+                    .surfaceCard()
+                    .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 8, trailing: 0))
+                    .listRowBackground(Color.clear)
+                }
 
                 if let errorText {
                     Text(errorText)
                         .foregroundStyle(AppTheme.danger)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .listRowBackground(Color.clear)
+                }
+
+                if let statusText {
+                    Text(statusText)
+                        .foregroundStyle(AppTheme.success)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
                         .listRowBackground(Color.clear)
@@ -45,30 +78,59 @@ struct SchedulesView: View {
                 }
 
                 ForEach(schedules) { schedule in
-                    HStack(spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(schedule.name)
-                                .foregroundStyle(AppTheme.textPrimary)
-                                .lineLimit(1)
-                                .truncationMode(.tail)
-                            Text("\(schedule.frequency) · \(schedule.start_date)")
-                                .font(.caption)
-                                .foregroundStyle(AppTheme.textMuted)
-                                .lineLimit(1)
-                                .minimumScaleFactor(0.85)
-                        }
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                    VStack(alignment: .leading, spacing: 10) {
+                        HStack(spacing: 12) {
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(schedule.name)
+                                    .foregroundStyle(AppTheme.textPrimary)
+                                    .lineLimit(1)
+                                    .truncationMode(.tail)
+                                Text("\(schedule.frequency) · \(schedule.start_date)")
+                                    .font(.caption)
+                                    .foregroundStyle(AppTheme.textMuted)
+                                    .lineLimit(1)
+                                    .minimumScaleFactor(0.85)
+                            }
+                            .frame(maxWidth: .infinity, alignment: .leading)
 
-                        Text("$\(schedule.amount)")
-                            .foregroundStyle(schedule.type == "Expense" ? AppTheme.danger : AppTheme.success)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.7)
-                            .layoutPriority(1)
-
-                        Button(role: .destructive) { Task { await deleteSchedule(schedule.id) } } label: {
-                            Image(systemName: "trash")
+                            Text("$\(schedule.amount)")
+                                .foregroundStyle(schedule.type == "Expense" ? AppTheme.danger : AppTheme.success)
+                                .lineLimit(1)
+                                .minimumScaleFactor(0.7)
+                                .layoutPriority(1)
                         }
-                        .buttonStyle(.borderless)
+
+                        HStack(spacing: 16) {
+                            iconButton(systemName: "pencil", color: AppTheme.accent, label: "Edit") {
+                                beginEdit(schedule)
+                            }
+                            iconButton(systemName: "pause.fill", color: AppTheme.warning, label: "Hold") {
+                                Task { await addHold(schedule.id) }
+                            }
+                            iconButton(systemName: "forward.fill", color: AppTheme.warning, label: "Skip") {
+                                Task { await addSkip(schedule.id) }
+                            }
+                            iconButton(systemName: "trash", color: AppTheme.danger, label: "Delete") {
+                                Task { await deleteSchedule(schedule.id) }
+                            }
+                        }
+
+                        if editingID == schedule.id {
+                            VStack(spacing: 8) {
+                                TextField("Name", text: $editName).fieldStyle()
+                                TextField("Amount", text: $editAmount).keyboardType(.decimalPad).fieldStyle()
+                                pickerRow(label: "Type", selection: $editType, options: types)
+                                pickerRow(label: "Frequency", selection: $editFrequency, options: frequencies)
+                                TextField("Start date (YYYY-MM-DD)", text: $editStartDate).fieldStyle()
+                                HStack(spacing: 8) {
+                                    Button("Save") { Task { await saveEdit(schedule.id) } }
+                                        .buttonStyle(PrimaryButtonStyle())
+                                    Button("Cancel") { editingID = nil }
+                                        .buttonStyle(PrimaryButtonStyle())
+                                }
+                            }
+                            .padding(.top, 4)
+                        }
                     }
                     .surfaceCard()
                     .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
@@ -81,6 +143,20 @@ struct SchedulesView: View {
         .refreshable { await load() }
         .appBackground()
         .navigationTitle("Schedules")
+    }
+
+    private func iconButton(systemName: String, color: Color, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            VStack(spacing: 2) {
+                Image(systemName: systemName)
+                    .font(.system(size: 16, weight: .semibold))
+                Text(label)
+                    .font(.caption2)
+            }
+            .foregroundStyle(color)
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.borderless)
     }
 
     private func pickerRow(label: String, selection: Binding<String>, options: [String]) -> some View {
@@ -100,6 +176,30 @@ struct SchedulesView: View {
         .padding(.vertical, 8)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private static func defaultStartDate() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: Date())
+    }
+
+    private func resetAddForm() {
+        name = ""
+        amount = ""
+        type = "Expense"
+        frequency = "Monthly"
+        startDate = Self.defaultStartDate()
+        errorText = nil
+    }
+
+    private func beginEdit(_ schedule: ScheduleDTO) {
+        editingID = schedule.id
+        editName = schedule.name
+        editAmount = schedule.amount
+        editType = schedule.type
+        editFrequency = schedule.frequency
+        editStartDate = schedule.start_date
     }
 
     private func load() async {
@@ -138,9 +238,36 @@ struct SchedulesView: View {
                 as: APIEnvelope<ScheduleDTO>.self
             )
             await load()
-            await MainActor.run { name = ""; amount = "" }
+            await MainActor.run {
+                resetAddForm()
+                showAddForm = false
+            }
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to add schedule" }
+        }
+    }
+
+    private func saveEdit(_ id: Int) async {
+        guard let token = session.token else { return }
+        do {
+            struct Payload: Encodable {
+                let name: String
+                let amount: String
+                let type: String
+                let frequency: String
+                let start_date: String
+            }
+            _ = try await APIClient.shared.request(
+                "schedules/\(id)",
+                method: "PUT",
+                token: token,
+                body: Payload(name: editName, amount: editAmount, type: editType, frequency: editFrequency, start_date: editStartDate),
+                as: APIEnvelope<ScheduleDTO>.self
+            )
+            await load()
+            await MainActor.run { editingID = nil }
+        } catch {
+            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to update schedule" }
         }
     }
 
@@ -151,6 +278,40 @@ struct SchedulesView: View {
             await load()
         } catch {
             await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to delete schedule" }
+        }
+    }
+
+    private func addHold(_ scheduleID: Int) async {
+        guard let token = session.token else { return }
+        do {
+            struct Payload: Encodable { let schedule_id: Int }
+            let _: APIEnvelope<HoldDTO> = try await APIClient.shared.request(
+                "holds",
+                method: "POST",
+                token: token,
+                body: Payload(schedule_id: scheduleID),
+                as: APIEnvelope<HoldDTO>.self
+            )
+            await MainActor.run { statusText = "Added to Holds"; errorText = nil }
+        } catch {
+            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to add hold"; statusText = nil }
+        }
+    }
+
+    private func addSkip(_ scheduleID: Int) async {
+        guard let token = session.token else { return }
+        do {
+            struct Payload: Encodable { let schedule_id: Int }
+            let _: APIEnvelope<SkipDTO> = try await APIClient.shared.request(
+                "skips",
+                method: "POST",
+                token: token,
+                body: Payload(schedule_id: scheduleID),
+                as: APIEnvelope<SkipDTO>.self
+            )
+            await MainActor.run { statusText = "Added to Skips"; errorText = nil }
+        } catch {
+            await MainActor.run { errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to add skip"; statusText = nil }
         }
     }
 }


### PR DESCRIPTION
## Summary
Enhanced the Schedules and Scenarios views with comprehensive CRUD operations and schedule management features. Users can now edit existing items, hold schedules, skip upcoming transactions, and toggle the add form with improved UX.

## Key Changes

**Schedules View (`SchedulesView.swift`)**
- Added collapsible add form with toggle button (plus/cancel icon)
- Implemented full edit functionality with inline editing UI
- Added "Hold" and "Skip" action buttons for schedule management
- Replaced single delete button with icon-based action buttons (Edit, Hold, Skip, Delete)
- Added status text display for successful operations (holds/skips)
- Changed default start date from hardcoded "2026-01-01" to current date
- Implemented `saveEdit()` method for PUT requests to update schedules
- Implemented `addHold()` and `addSkip()` methods for schedule actions
- Added helper methods: `resetAddForm()`, `beginEdit()`, `defaultStartDate()`, `iconButton()`

**Scenarios View (`ScenariosView.swift`)**
- Applied identical UX improvements as Schedules (collapsible form, edit functionality)
- Added full edit capability with inline editing UI
- Replaced delete-only button with Edit and Delete icon buttons
- Changed default start date to current date
- Implemented `saveEdit()` method for PUT requests
- Added helper methods: `resetAddForm()`, `beginEdit()`, `defaultStartDate()`, `iconButton()`

**API Models (`APIModels.swift`)**
- Added `HoldDTO` struct for hold responses
- Added `SkipDTO` struct for skip responses

**Backend (`data.py`)**
- Enhanced `/api/skips` endpoint to accept `schedule_id` in addition to `transaction_index`
- Added logic to find upcoming transactions by schedule name when `schedule_id` is provided
- Improved validation to accept either parameter

**Theme & Navigation**
- Added `warning` color to `AppTheme` for hold/skip actions
- Renamed `AccountsView` to `BalanceView` for clarity
- Updated dashboard navigation references

## Implementation Details
- Form state is properly reset when toggling the add form closed
- Edit mode is isolated per item using `editingID` state variable
- Action buttons use a reusable `iconButton()` helper for consistent styling
- Status messages are cleared when errors occur and vice versa
- All async operations properly handle token validation and error states

https://claude.ai/code/session_011Zjh3kDgKBSP1kVrzrmAtr