### PR TITLE
Improve chart point selection with y-axis proximity tie-breaking

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
@@ -14,10 +14,11 @@ struct CashFlowChartView: View {
     private var hasScenario: Bool { !scenarioPoints.isEmpty }
 
     private static let horizonDays = 90
-    private static let visibleDays = 45
+    private static let visibleDays = 90
     private static let nearTermDays = 30
 
     @State private var selectedDate: Date?
+    @State private var selectedAmount: Double?
 
     private var xDomain: ClosedRange<Date> {
         var calendar = Calendar(identifier: .gregorian)
@@ -72,9 +73,15 @@ struct CashFlowChartView: View {
             nearestPoint(to: selectedDate, in: schedulePoints).map { ($0, .schedule) },
             nearestPoint(to: selectedDate, in: scenarioPoints).map { ($0, .scenario) }
         ].compactMap { $0 }
-        guard let best = candidates.min(by: {
-            abs($0.point.date.timeIntervalSince(selectedDate))
-                < abs($1.point.date.timeIntervalSince(selectedDate))
+        guard let best = candidates.min(by: { lhs, rhs in
+            let lhsX = abs(lhs.point.date.timeIntervalSince(selectedDate))
+            let rhsX = abs(rhs.point.date.timeIntervalSince(selectedDate))
+            if lhsX != rhsX { return lhsX < rhsX }
+            // Tie-break by y-proximity so a tap near the scenario line
+            // selects it even when schedule has a point on the same date.
+            guard let selectedAmount else { return false }
+            return abs(lhs.point.amount - selectedAmount)
+                < abs(rhs.point.amount - selectedAmount)
         }) else { return nil }
         return SelectedChartPoint(point: best.point, series: best.series)
     }
@@ -160,6 +167,7 @@ struct CashFlowChartView: View {
         .chartYVisibleDomain(length: visibleYDomainLength)
         .chartScrollPosition(initialX: xDomain.lowerBound)
         .chartXSelection(value: $selectedDate)
+        .chartYSelection(value: $selectedAmount)
         .chartXAxis {
             AxisMarks(values: .automatic(desiredCount: 4)) { _ in
                 AxisGridLine().foregroundStyle(AppTheme.border.opacity(0.5))


### PR DESCRIPTION
## Summary
Enhanced the cash flow chart's point selection logic to consider both x-axis (date) and y-axis (amount) proximity when multiple data points are near the user's tap location. This provides more intuitive selection behavior when schedule and scenario points overlap on the same date.

## Key Changes
- Extended the visible chart domain from 45 days to 90 days to match the full horizon
- Added `selectedAmount` state variable to track the y-axis position of user interactions
- Improved the point selection algorithm to use tie-breaking logic:
  - Primary selection criterion: closest date (x-axis proximity)
  - Secondary selection criterion: closest amount value (y-axis proximity)
  - This ensures scenario line selection is prioritized when tapping near it, even if a schedule point exists on the same date
- Connected the chart's y-axis selection binding to enable y-coordinate tracking

## Implementation Details
The selection logic now explicitly compares both x and y distances. When two points are equidistant in time, the algorithm selects the point whose amount value is closer to where the user tapped, improving the accuracy and predictability of point selection in crowded chart areas.

https://claude.ai/code/session_01EWb4D9ujznBn4mrcJSYSLj