### PR TITLE
Fix date formatting and schedule skip transaction selection

### DIFF
--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -530,12 +530,16 @@ def api_create_skip():
         schedule = Schedule.query.filter_by(user_id=user_id, id=schedule_id).first()
         if not schedule:
             return not_found("Schedule not found")
-        matches = trans[trans["name"] == schedule.name]
-        if matches.empty:
+        # Project this schedule in isolation so a matching hold (same name/type/amount)
+        # or other user data can't be selected as the skip target.
+        schedule_trans, _run, _run_scenario = update_cash(
+            0.0, [schedule], [], [], [], commit=False
+        )
+        if schedule_trans.empty:
             return validation_error(
                 {"schedule_id": "No upcoming transaction found for this schedule"}
             )
-        tx = matches.iloc[0]
+        tx = schedule_trans.iloc[0]
     else:
         try:
             tx = trans.loc[int(transaction_index)]

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -165,6 +165,9 @@ struct ScenariosView: View {
 
     private static func defaultStartDate() -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(identifier: "UTC")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
     }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -180,6 +180,9 @@ struct SchedulesView: View {
 
     private static func defaultStartDate() -> String {
         let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = TimeZone(identifier: "UTC")
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
     }


### PR DESCRIPTION
## Summary
This PR fixes two issues: improper date formatting in iOS date pickers and incorrect transaction selection logic when creating schedule skips.

## Key Changes

- **Backend (data.py)**: Fixed `api_create_skip()` to properly isolate the target schedule when selecting a transaction to skip. Instead of matching by name across all transactions, the schedule is now projected in isolation using `update_cash()` to prevent selecting unrelated transactions with the same name (e.g., holds or other user data).

- **iOS (ScenariosView.swift & SchedulesView.swift)**: Added explicit locale, calendar, and timezone configuration to `DateFormatter` instances in `defaultStartDate()` methods. This ensures consistent date formatting across different device locales and prevents locale-dependent date parsing issues.

## Implementation Details

The backend change ensures that when skipping a schedule, only the projected transaction from that specific schedule is considered, not any other transaction that happens to have the same name. This prevents edge cases where a hold or another user's data could be incorrectly selected.

The iOS changes follow Apple's best practices for `DateFormatter` by explicitly setting the locale to `en_US_POSIX`, calendar to Gregorian, and timezone to UTC. This guarantees the "yyyy-MM-dd" format is applied consistently regardless of device settings.

https://claude.ai/code/session_01MMJQbYnVSUguULUvHDRsSD