### PR TITLE
Use device timezone instead of UTC for date formatting

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -167,7 +167,7 @@ struct ScenariosView: View {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
     }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -182,7 +182,7 @@ struct SchedulesView: View {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd"
         return formatter.string(from: Date())
     }


### PR DESCRIPTION
## Summary
Updated date formatting logic to use the device's current timezone instead of hardcoded UTC across the Scenarios and Schedules views.

## Key Changes
- Changed `TimeZone(identifier: "UTC")` to `TimeZone.current` in `ScenariosView.swift`
- Changed `TimeZone(identifier: "UTC")` to `TimeZone.current` in `SchedulesView.swift`

## Details
Both views were using UTC timezone when formatting dates to the "yyyy-MM-dd" format. This change ensures that date formatting respects the user's device timezone settings, providing a more intuitive experience aligned with the user's local time context. Since the date format only includes date components (no time), this change primarily affects how dates are interpreted and displayed relative to the user's timezone.

https://claude.ai/code/session_01NgYEj3mx8N7aPMhwtGdahD