### PR TITLE
Optimize CashFlowChartView to only render visible data points

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/CashFlowChartView.swift
@@ -26,9 +26,18 @@ struct CashFlowChartView: View {
         return today...end
     }
 
+    private var visibleSchedulePoints: [CashFlowPoint] {
+        let domain = xDomain
+        return schedulePoints.filter { domain.contains($0.date) }
+    }
+
+    private var visibleScenarioPoints: [CashFlowPoint] {
+        let domain = xDomain
+        return scenarioPoints.filter { domain.contains($0.date) }
+    }
+
     private var allPointsInHorizon: [CashFlowPoint] {
-        let end = xDomain.upperBound
-        return (schedulePoints + scenarioPoints).filter { $0.date <= end }
+        visibleSchedulePoints + visibleScenarioPoints
     }
 
     private var yDomain: ClosedRange<Double> {
@@ -44,8 +53,8 @@ struct CashFlowChartView: View {
     private var selectedPoint: SelectedChartPoint? {
         guard let selectedDate else { return nil }
         let candidates: [(point: CashFlowPoint, series: SelectedChartPoint.Series)] = [
-            nearestPoint(to: selectedDate, in: schedulePoints).map { ($0, .schedule) },
-            nearestPoint(to: selectedDate, in: scenarioPoints).map { ($0, .scenario) }
+            nearestPoint(to: selectedDate, in: visibleSchedulePoints).map { ($0, .schedule) },
+            nearestPoint(to: selectedDate, in: visibleScenarioPoints).map { ($0, .scenario) }
         ].compactMap { $0 }
         guard let best = candidates.min(by: { lhs, rhs in
             let lhsX = abs(lhs.point.date.timeIntervalSince(selectedDate))
@@ -83,16 +92,18 @@ struct CashFlowChartView: View {
                     .frame(maxWidth: .infinity, minHeight: 180, alignment: .center)
             } else {
                 chart
+                    .frame(maxWidth: .infinity)
                     .frame(height: 240)
             }
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .surfaceCard()
     }
 
     @ViewBuilder
     private var chart: some View {
         Chart {
-            ForEach(scenarioPoints) { point in
+            ForEach(visibleScenarioPoints) { point in
                 LineMark(
                     x: .value("Date", point.date),
                     y: .value("Balance", point.amount),
@@ -103,7 +114,7 @@ struct CashFlowChartView: View {
                 .lineStyle(StrokeStyle(lineWidth: 2, dash: [6, 4]))
             }
 
-            ForEach(schedulePoints) { point in
+            ForEach(visibleSchedulePoints) { point in
                 LineMark(
                     x: .value("Date", point.date),
                     y: .value("Balance", point.amount),


### PR DESCRIPTION
## Summary
Refactored the CashFlowChartView to filter data points based on the visible x-axis domain before rendering, improving performance by reducing the number of points processed by the Chart component.

## Key Changes
- Added `visibleSchedulePoints` computed property that filters schedule points to only those within the current x-axis domain
- Added `visibleScenarioPoints` computed property that filters scenario points to only those within the current x-axis domain
- Updated `allPointsInHorizon` to use the new visible point properties instead of filtering all points
- Updated `selectedPoint` logic to search for nearest points within the visible datasets rather than all points
- Updated Chart rendering to iterate over `visibleSchedulePoints` and `visibleScenarioPoints` instead of the full datasets
- Added frame modifiers for improved layout consistency (maxWidth: .infinity on chart and container)

## Implementation Details
The refactoring centralizes the domain-based filtering logic into reusable computed properties, eliminating duplicate filtering code and ensuring consistency across point selection and rendering. This approach reduces the computational overhead when rendering large datasets by only processing points that are actually visible in the current viewport.

https://claude.ai/code/session_01TEHPvziyoD5nfMS9GRZKpo