### PR TITLE
Add "More Settings" link to Settings view

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -38,6 +38,11 @@ struct SettingsView: View {
                 }
                 .surfaceCard()
 
+                if let moreSettingsURL {
+                    Link("More Settings", destination: moreSettingsURL)
+                        .buttonStyle(PrimaryButtonStyle())
+                }
+
                 Button("Refresh Subscription Status") { Task { await session.refreshSubscriptionState(forceProfileRefresh: true) } }
                     .buttonStyle(PrimaryButtonStyle())
 
@@ -63,6 +68,16 @@ struct SettingsView: View {
         .refreshable { await load() }
         .appBackground()
         .navigationTitle("Settings")
+    }
+
+    private var moreSettingsURL: URL? {
+        guard var components = URLComponents(url: session.currentBaseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.path = "/settings"
+        components.query = nil
+        components.fragment = nil
+        return components.url
     }
 
     private func infoRow(label: String, value: String) -> some View {


### PR DESCRIPTION
## Summary
Added a new "More Settings" button to the Settings view that navigates to the web-based settings page on the server.

## Key Changes
- Added a new "More Settings" link button in the Settings view that appears conditionally when a valid URL can be constructed
- Implemented `moreSettingsURL` computed property that constructs the settings URL from the current base URL by:
  - Using the session's `currentBaseURL` as the base
  - Setting the path to `/settings`
  - Clearing any existing query parameters and fragments
- The button uses the existing `PrimaryButtonStyle()` for consistent styling with other action buttons in the view

## Implementation Details
- The URL construction is defensive, returning `nil` if `URLComponents` cannot be initialized, which prevents the button from appearing if a valid URL cannot be built
- The button is positioned before the "Refresh Subscription Status" button in the view hierarchy
- Uses SwiftUI's `Link` component to handle navigation to the external settings URL

https://claude.ai/code/session_01XeiUmdidU3yHJgQjKaYapf