### PR TITLE
Prevent duplicate balance imports from email

### DIFF
--- a/app/getemail.py
+++ b/app/getemail.py
@@ -251,17 +251,32 @@ def process_email_balances():
                 new_balance = email_content[subjectstr][start_index:end_index].replace(',', '')
                 new_balance = new_balance.replace('$', '')
                 new_balance = float(new_balance)
+                balance_date = datetime.today().date()
 
-                # Insert balance WITH user_id using SQLAlchemy ORM
-                balance = Balance(
+                existing_balance = Balance.query.filter_by(
+                    user_id=user_id,
+                    date=balance_date,
                     amount=new_balance,
-                    date=datetime.today().date(),
-                    user_id=user_id
-                )
-                db.session.add(balance)
-                db.session.commit()
-                balance_updated = True
-                logger.info("Balance updated successfully for user %s", user_id)
+                ).first()
+
+                if existing_balance:
+                    logger.info(
+                        "Duplicate balance ignored for user %s (date=%s, amount=%s)",
+                        user_id,
+                        balance_date.isoformat(),
+                        f"{new_balance:.2f}",
+                    )
+                else:
+                    # Insert balance WITH user_id using SQLAlchemy ORM
+                    balance = Balance(
+                        amount=new_balance,
+                        date=balance_date,
+                        user_id=user_id
+                    )
+                    db.session.add(balance)
+                    db.session.commit()
+                    balance_updated = True
+                    logger.info("Balance updated successfully for user %s", user_id)
             except KeyError:
                 # No email with the specified subject found
                 pass
@@ -271,7 +286,11 @@ def process_email_balances():
                 logger.error("Failed to save balance for user %s: %s", user_id, exc)
 
             if not balance_updated:
-                logger.info("Balance was not updated for user %s (no matching email found)", user_id)
+                logger.info(
+                    "Balance was not updated for user %s "
+                    "(no matching email found or duplicate balance)",
+                    user_id,
+                )
 
             # Close IMAP connection for THIS user
             imap.close()


### PR DESCRIPTION
### Motivation
- Avoid inserting the same balance multiple times when the email importer parses identical balance values for the same user on the same date.

### Description
- In `process_email_balances()` added a `balance_date` and a uniqueness check using `Balance.query.filter_by(user_id=user_id, date=balance_date, amount=new_balance).first()` to skip inserts when an exact `(user_id, date, amount)` row already exists.
- If a duplicate is found the code now logs an informational message and does not write to the database; otherwise it inserts the new `Balance` as before.
- Updated the final non-update log to reflect both "no matching email" and "duplicate balance" outcomes.

### Testing
- Ran the full test suite with `python -m pytest -q` which completed successfully: `260 passed, 48 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb508736a08320842f314285b57bbb)