### PR TITLE
Enable auto-generated launch screen for iOS app

### DIFF
--- a/ios-app/pycashflow.xcodeproj/project.pbxproj
+++ b/ios-app/pycashflow.xcodeproj/project.pbxproj
@@ -370,6 +370,7 @@
 				DEVELOPMENT_TEAM = JFTUN6NUAB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -398,6 +399,7 @@
 				DEVELOPMENT_TEAM = JFTUN6NUAB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary
This change enables Xcode's automatic launch screen generation feature for the pycashflow iOS app by adding the `INFOPLIST_KEY_UILaunchScreen_Generation` build setting.

## Key Changes
- Added `INFOPLIST_KEY_UILaunchScreen_Generation = YES;` to both Debug and Release build configurations in the project settings
- This allows Xcode to automatically generate a launch screen based on the app's Info.plist configuration instead of requiring a manual storyboard or XIB file

## Implementation Details
The setting was added to both build configurations (Debug and Release) to ensure consistent behavior across development and production builds. This is a modern approach to launch screen management in iOS development that simplifies the build process and reduces the need for separate launch screen assets.

https://claude.ai/code/session_01Aa1xzRawZGCqjXUPTddgUT