### PR TITLE
Update FloatingNavBar to use iOS 26 Liquid Glass material

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-/// Floating bottom navigation bar styled after iOS pill-shaped controls
-/// (think Apple News' Today / News+ / Sports / Audio tray). The bar
-/// horizontally scrolls when buttons do not fit within the available width.
+/// Floating bottom navigation bar rendered with the iOS 26 Liquid Glass
+/// material so it matches the translucent back button SwiftUI renders in
+/// the navigation bar. Scrolls horizontally when buttons overflow.
 struct FloatingNavBar: View {
     let items: [FloatingNavItem]
 
@@ -21,21 +21,7 @@ struct FloatingNavBar: View {
             .padding(.horizontal, 10)
             .padding(.vertical, 8)
         }
-        .background(
-            Capsule(style: .continuous)
-                .fill(.ultraThinMaterial)
-                .overlay(
-                    Capsule(style: .continuous)
-                        .fill(AppTheme.primaryDark.opacity(0.25))
-                )
-                .overlay(
-                    Capsule(style: .continuous)
-                        .stroke(AppTheme.border.opacity(0.5), lineWidth: 1)
-                )
-                .shadow(color: Color.black.opacity(0.35), radius: 18, x: 0, y: 8)
-                .opacity(0.85)
-        )
-        .clipShape(Capsule(style: .continuous))
+        .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
         .padding(.horizontal, 16)
     }
 }


### PR DESCRIPTION
## Summary
Updated the FloatingNavBar component to use the new iOS 26 Liquid Glass material effect instead of a custom layered background composition. This provides a more consistent visual appearance with SwiftUI's native navigation bar styling.

## Key Changes
- Replaced custom background styling (ultraThinMaterial with overlays, shadows, and opacity) with the `.glassEffect(.regular.interactive())` modifier
- Simplified the background implementation from multiple layered Capsule shapes to a single glass effect call
- Updated documentation to reflect the new Liquid Glass material usage and its purpose of matching the translucent back button styling
- Maintained the same Capsule shape and horizontal scrolling behavior

## Implementation Details
The previous implementation used a complex composition of:
- Base ultraThinMaterial fill
- Primary dark color overlay with 25% opacity
- Border stroke with 50% opacity
- Black shadow with 35% opacity and 18pt radius
- Overall 85% opacity

This has been consolidated into a single `.glassEffect()` call with the `.regular.interactive()` style, which provides the Liquid Glass appearance while reducing code complexity and improving maintainability.

https://claude.ai/code/session_01Bd1svRtjSmNz29G5UyR8w8