### PR TITLE
Update Settings view label from "App Version" to "Backend Version"

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
             VStack(alignment: .leading, spacing: 12) {
                 if let settings {
                     infoRow(label: "Signed in as", value: settings.user.email)
-                    infoRow(label: "App Version", value: settings.app.version)
+                    infoRow(label: "Backend Version", value: settings.app.version)
                     infoRow(label: "AI Configured", value: settings.ai.configured ? "Yes" : "No")
                 }
 


### PR DESCRIPTION
## Summary
Updated the Settings view to clarify that the displayed version refers to the backend version rather than the app version.

## Changes
- Changed the label in the Settings view from "App Version" to "Backend Version" to accurately reflect what `settings.app.version` represents

## Details
This change improves clarity in the Settings UI by making it explicit that the version being displayed is the backend version, reducing potential user confusion about which version number is being shown.

https://claude.ai/code/session_01HsY3zv8GgmBwg6B87gm7eg