### PR TITLE
Add passkey (WebAuthn) authentication support

### DIFF
--- a/MOBILE_API_REFERENCE.md
+++ b/MOBILE_API_REFERENCE.md
@@ -262,6 +262,114 @@ credential-validation oracle attacks.
 
 ---
 
+### POST /api/v1/auth/passkey/options
+
+Begin a passkey (WebAuthn) login flow. Returns the challenge parameters and a
+signed `challenge_token` that must be echoed back to
+`POST /api/v1/auth/passkey/verify`.
+
+**Auth required:** No
+
+**Rate limit:** 10/minute
+
+**Request:**
+
+```json
+{
+  "email": "user@example.com"
+}
+```
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `email` | string | Yes | Trimmed and lowercased server-side |
+
+**Response `200 OK`:**
+
+```json
+{
+  "data": {
+    "challenge_token": "<opaque signed token>",
+    "options": {
+      "challenge": "<base64url>",
+      "rpId": "app.pycashflow.com",
+      "allowCredentials": [
+        { "id": "<base64url>", "type": "public-key" }
+      ],
+      "userVerification": "required",
+      "timeout": 60000
+    }
+  }
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `challenge_token` | string | Opaque, server-signed. Store in memory and pass verbatim to `/verify`. TTL 5 minutes, single-use. |
+| `options` | object | WebAuthn `PublicKeyCredentialRequestOptions`. Pass its `challenge` and `allowCredentials` to the platform authenticator (e.g. `ASAuthorizationPlatformPublicKeyCredentialProvider` on iOS). |
+
+**Response `401 Unauthorized`:**
+
+Returned — with a deliberately generic message — when the account does not exist,
+is inactive, has no registered passkeys, or when passkey auth is not enabled on
+the server.
+
+```json
+{
+  "error": "Unable to start passkey login",
+  "code": "unauthorized",
+  "status": 401
+}
+```
+
+---
+
+### POST /api/v1/auth/passkey/verify
+
+Finish a passkey login. On success returns a Bearer token identical in shape to
+`POST /api/v1/auth/login`.
+
+**Auth required:** No
+
+**Rate limit:** 10/minute
+
+**Request:**
+
+```json
+{
+  "challenge_token": "<value from /options>",
+  "credential": {
+    "id": "<base64url credential id>",
+    "rawId": "<base64url credential id>",
+    "type": "public-key",
+    "response": {
+      "authenticatorData": "<base64url>",
+      "clientDataJSON": "<base64url>",
+      "signature": "<base64url>",
+      "userHandle": "<base64url, optional>"
+    }
+  }
+}
+```
+
+**Response `200 OK`:**
+
+```json
+{
+  "data": {
+    "token": "<bearer token>",
+    "user": { "...": "same shape as /auth/login" }
+  }
+}
+```
+
+**Response `401 Unauthorized`:**
+
+Returned when the challenge is expired, already consumed, or the assertion
+fails WebAuthn verification.
+
+---
+
 ### POST /api/v1/auth/logout
 
 Revoke the Bearer token used in this request.

--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -1,5 +1,7 @@
 """API v1 authentication routes."""
 
+import json
+import logging
 from datetime import datetime, timedelta, timezone
 from threading import Lock
 
@@ -8,8 +10,8 @@ from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from app import limiter, db
-from app.models import User, UserToken
-from app.auth import _DUMMY_HASH
+from app.models import PasskeyCredential, User, UserToken
+from app.auth import _DUMMY_HASH, _passkey_enabled
 from app.password_setup import consume_password_setup_token
 from app.totp_utils import decrypt_totp_secret, verify_totp, verify_and_consume_backup_code
 from app.subscription import enforce_user_access
@@ -25,6 +27,38 @@ from app.api.auth_utils import (
 from app.api.errors import unauthorized, validation_error, forbidden
 from app.api.responses import api_ok
 from app.api.serializers import serialize_user
+
+
+logger = logging.getLogger(__name__)
+
+
+try:
+    from webauthn import (
+        generate_authentication_options,
+        verify_authentication_response,
+        options_to_json,
+    )
+    from webauthn.helpers.base64url_to_bytes import base64url_to_bytes
+    from webauthn.helpers.bytes_to_base64url import bytes_to_base64url
+    from webauthn.helpers.structs import (
+        PublicKeyCredentialDescriptor,
+        UserVerificationRequirement,
+    )
+    _WEBAUTHN_AVAILABLE = True
+except Exception:  # pragma: no cover - webauthn is an optional dependency
+    _WEBAUTHN_AVAILABLE = False
+    generate_authentication_options = None
+    verify_authentication_response = None
+    options_to_json = None
+    base64url_to_bytes = None
+    bytes_to_base64url = None
+    PublicKeyCredentialDescriptor = None
+    UserVerificationRequirement = None
+
+
+_PASSKEY_CHALLENGE_MAX_AGE_SECONDS = 300
+_CONSUMED_PASSKEY_CHALLENGES: dict[str, datetime] = {}
+_CONSUMED_PASSKEY_CHALLENGES_LOCK = Lock()
 
 
 _TWOFA_CHALLENGE_MAX_AGE_SECONDS = 300
@@ -276,3 +310,176 @@ def api_complete_password_setup():
     user.is_active = True
     db.session.commit()
     return api_ok({"message": "Password setup complete"})
+
+
+def _api_passkey_enabled() -> bool:
+    return bool(_WEBAUTHN_AVAILABLE and _passkey_enabled())
+
+
+def _passkey_challenge_serializer() -> URLSafeTimedSerializer:
+    return URLSafeTimedSerializer(current_app.config["SECRET_KEY"], salt="api-login-passkey")
+
+
+def _purge_expired_consumed_passkey_challenges(now: datetime | None = None) -> None:
+    now = now or datetime.now(timezone.utc)
+    expired = [
+        token
+        for token, expires_at in _CONSUMED_PASSKEY_CHALLENGES.items()
+        if expires_at <= now
+    ]
+    for token in expired:
+        _CONSUMED_PASSKEY_CHALLENGES.pop(token, None)
+
+
+def _is_passkey_challenge_consumed(challenge_token: str) -> bool:
+    with _CONSUMED_PASSKEY_CHALLENGES_LOCK:
+        _purge_expired_consumed_passkey_challenges()
+        return challenge_token in _CONSUMED_PASSKEY_CHALLENGES
+
+
+def _try_mark_passkey_challenge_consumed(challenge_token: str) -> bool:
+    now = datetime.now(timezone.utc)
+    with _CONSUMED_PASSKEY_CHALLENGES_LOCK:
+        _purge_expired_consumed_passkey_challenges(now)
+        if challenge_token in _CONSUMED_PASSKEY_CHALLENGES:
+            return False
+        _CONSUMED_PASSKEY_CHALLENGES[challenge_token] = now + timedelta(
+            seconds=_PASSKEY_CHALLENGE_MAX_AGE_SECONDS
+        )
+        return True
+
+
+def _build_passkey_challenge_token(user: User, challenge_b64url: str) -> str:
+    payload = {
+        "uid": user.id,
+        "email": user.email,
+        "challenge": challenge_b64url,
+        "nonce": hash_token(f"{user.id}:{datetime.now(timezone.utc).isoformat()}"),
+    }
+    return _passkey_challenge_serializer().dumps(payload)
+
+
+def _decode_passkey_challenge_token(challenge_token: str) -> dict | None:
+    try:
+        payload = _passkey_challenge_serializer().loads(
+            challenge_token,
+            max_age=_PASSKEY_CHALLENGE_MAX_AGE_SECONDS,
+        )
+    except (BadSignature, SignatureExpired):
+        return None
+
+    if (
+        not isinstance(payload, dict)
+        or not isinstance(payload.get("uid"), int)
+        or not isinstance(payload.get("challenge"), str)
+    ):
+        return None
+    return payload
+
+
+@api.route("/auth/passkey/options", methods=["POST"])
+@limiter.limit("10 per minute", exempt_when=lambda: current_app.testing)
+def api_passkey_login_options():
+    if not _api_passkey_enabled():
+        return unauthorized("Passkey authentication is not enabled")
+
+    body = request.get_json(silent=True) or {}
+    email_raw = body.get("email")
+    email = email_raw.strip().lower() if isinstance(email_raw, str) else ""
+
+    errors: dict = {}
+    if not email:
+        errors["email"] = "Email is required"
+    if errors:
+        return validation_error(errors)
+
+    user = User.query.filter_by(email=email).first()
+    if (
+        user is None
+        or not enforce_user_access(user)
+        or not user.passkey_credentials
+    ):
+        # Generic message to avoid revealing whether an account exists.
+        return unauthorized("Unable to start passkey login")
+
+    allow_credentials = [
+        PublicKeyCredentialDescriptor(id=base64url_to_bytes(c.credential_id))
+        for c in user.passkey_credentials
+    ]
+    options = generate_authentication_options(
+        rp_id=current_app.config["PASSKEY_RP_ID"],
+        allow_credentials=allow_credentials,
+        user_verification=UserVerificationRequirement.REQUIRED,
+    )
+    challenge_b64url = bytes_to_base64url(options.challenge)
+    challenge_token = _build_passkey_challenge_token(user, challenge_b64url)
+
+    return api_ok({
+        "challenge_token": challenge_token,
+        "options": json.loads(options_to_json(options)),
+    })
+
+
+@api.route("/auth/passkey/verify", methods=["POST"])
+@limiter.limit("10 per minute", exempt_when=lambda: current_app.testing)
+def api_passkey_login_verify():
+    if not _api_passkey_enabled():
+        return unauthorized("Passkey authentication is not enabled")
+
+    body = request.get_json(silent=True) or {}
+
+    errors: dict = {}
+    challenge_token_raw = body.get("challenge_token")
+    challenge_token = (
+        challenge_token_raw.strip() if isinstance(challenge_token_raw, str) else ""
+    )
+    if not challenge_token:
+        errors["challenge_token"] = "Challenge token is required"
+    credential = body.get("credential")
+    if not isinstance(credential, dict) or not credential.get("id"):
+        errors["credential"] = "Credential is required"
+    if errors:
+        return validation_error(errors)
+
+    payload = _decode_passkey_challenge_token(challenge_token)
+    if payload is None or _is_passkey_challenge_consumed(challenge_token):
+        return unauthorized("Invalid or expired passkey challenge")
+
+    user = db.session.get(User, payload["uid"])
+    if user is None or not enforce_user_access(user):
+        return unauthorized("Invalid or expired passkey challenge")
+
+    raw_credential_id = credential.get("id")
+    stored_credential = PasskeyCredential.query.filter_by(
+        credential_id=raw_credential_id,
+        user_id=user.id,
+    ).first()
+    if stored_credential is None:
+        return unauthorized("Passkey not recognized for this account")
+
+    try:
+        verification = verify_authentication_response(
+            credential=credential,
+            expected_challenge=base64url_to_bytes(payload["challenge"]),
+            expected_origin=current_app.config["PASSKEY_ORIGIN"],
+            expected_rp_id=current_app.config["PASSKEY_RP_ID"],
+            credential_public_key=base64url_to_bytes(stored_credential.public_key),
+            credential_current_sign_count=stored_credential.sign_count,
+            require_user_verification=True,
+        )
+    except Exception as exc:
+        logger.warning("API passkey login verification failed: %s", exc)
+        return unauthorized("Passkey verification failed")
+
+    if not _try_mark_passkey_challenge_consumed(challenge_token):
+        return unauthorized("Invalid or expired passkey challenge")
+
+    stored_credential.sign_count = verification.new_sign_count
+    stored_credential.last_used_at = datetime.now(timezone.utc)
+    db.session.commit()
+
+    raw_token, _record = create_token_for_user(user)
+    return api_ok({
+        "token": raw_token,
+        "user": serialize_user(user),
+    })

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Auth/PasskeyLoginController.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Auth/PasskeyLoginController.swift
@@ -1,0 +1,154 @@
+import Foundation
+import AuthenticationServices
+import UIKit
+
+enum PasskeyLoginError: LocalizedError {
+    case unsupported
+    case invalidServerChallenge
+    case cancelled
+    case failed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupported:
+            return "Passkeys require iOS 16 or later."
+        case .invalidServerChallenge:
+            return "Server returned an invalid passkey challenge."
+        case .cancelled:
+            return "Passkey sign-in was cancelled."
+        case .failed(let message):
+            return message
+        }
+    }
+}
+
+/// Drives a single passkey assertion flow.
+///
+/// Retains itself for the duration of the `ASAuthorizationController`
+/// presentation so the delegate callbacks are guaranteed to fire. Must be
+/// invoked from the main actor because it touches `UIWindow`.
+@MainActor
+final class PasskeyLoginController: NSObject, ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+
+    private var continuation: CheckedContinuation<ASAuthorizationPlatformPublicKeyCredentialAssertion, Error>?
+    private var retainSelf: PasskeyLoginController?
+
+    /// Prompt the system passkey sheet and return the raw assertion.
+    ///
+    /// - Parameters:
+    ///   - relyingPartyIdentifier: The WebAuthn RP ID (typically the API host,
+    ///     e.g. `app.pycashflow.com`). Must match an associated domain.
+    ///   - challenge: The server-issued challenge, decoded from base64url.
+    ///   - allowedCredentialIDs: Optional list of credential IDs returned by
+    ///     the server, decoded from base64url.
+    func performAssertion(
+        relyingPartyIdentifier: String,
+        challenge: Data,
+        allowedCredentialIDs: [Data]
+    ) async throws -> ASAuthorizationPlatformPublicKeyCredentialAssertion {
+        guard #available(iOS 16.0, *) else {
+            throw PasskeyLoginError.unsupported
+        }
+
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
+            relyingPartyIdentifier: relyingPartyIdentifier
+        )
+        let request = provider.createCredentialAssertionRequest(challenge: challenge)
+        request.allowedCredentials = allowedCredentialIDs.map {
+            ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: $0)
+        }
+        request.userVerificationPreference = .required
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = self
+        controller.presentationContextProvider = self
+
+        return try await withCheckedThrowingContinuation { cont in
+            self.continuation = cont
+            self.retainSelf = self
+            controller.performRequests()
+        }
+    }
+
+    // MARK: - ASAuthorizationControllerDelegate
+
+    nonisolated func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        Task { @MainActor in
+            defer { self.retainSelf = nil }
+            guard let cont = self.continuation else { return }
+            self.continuation = nil
+
+            if let assertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion {
+                cont.resume(returning: assertion)
+            } else {
+                cont.resume(throwing: PasskeyLoginError.failed("Unexpected passkey response type."))
+            }
+        }
+    }
+
+    nonisolated func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        Task { @MainActor in
+            defer { self.retainSelf = nil }
+            guard let cont = self.continuation else { return }
+            self.continuation = nil
+
+            if let asError = error as? ASAuthorizationError {
+                switch asError.code {
+                case .canceled:
+                    cont.resume(throwing: PasskeyLoginError.cancelled)
+                    return
+                default:
+                    break
+                }
+            }
+            cont.resume(throwing: PasskeyLoginError.failed(error.localizedDescription))
+        }
+    }
+
+    // MARK: - ASAuthorizationControllerPresentationContextProviding
+
+    nonisolated func presentationAnchor(
+        for controller: ASAuthorizationController
+    ) -> ASPresentationAnchor {
+        MainActor.assumeIsolated {
+            Self.keyWindow() ?? ASPresentationAnchor()
+        }
+    }
+
+    private static func keyWindow() -> UIWindow? {
+        UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow }
+    }
+}
+
+/// Base64URL helpers used when exchanging WebAuthn payloads with the server.
+///
+/// The WebAuthn spec (and this backend) uses base64url — unlike `Data`'s
+/// built-in base64 encoding, it is URL-safe and has no padding.
+enum Base64URL {
+    static func encode(_ data: Data) -> String {
+        data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    static func decode(_ string: String) -> Data? {
+        var value = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = value.count % 4
+        if remainder > 0 {
+            value.append(String(repeating: "=", count: 4 - remainder))
+        }
+        return Data(base64Encoded: value)
+    }
+}

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
@@ -33,6 +33,25 @@ struct LoginResponseDTO: Decodable {
     let user: UserDTO
 }
 
+struct PasskeyLoginOptionsDTO: Decodable {
+    struct Options: Decodable {
+        struct AllowCredential: Decodable {
+            let id: String
+            let type: String?
+            let transports: [String]?
+        }
+
+        let challenge: String
+        let rpId: String?
+        let timeout: Int?
+        let userVerification: String?
+        let allowCredentials: [AllowCredential]?
+    }
+
+    let challenge_token: String
+    let options: Options
+}
+
 struct BillingStatusDTO: Decodable {
     let user_id: Int?
     let is_active: Bool?

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import AuthenticationServices
 
 struct LoginView: View {
     private enum Field: Hashable {
@@ -17,6 +18,7 @@ struct LoginView: View {
     @State private var authErrorText: String?
     @State private var selfHostedErrorText: String?
     @State private var isLoading = false
+    @State private var isPasskeyLoading = false
     @FocusState private var focusedField: Field?
 
     var body: some View {
@@ -89,7 +91,20 @@ struct LoginView: View {
                         submitFromKeyboard()
                     }
                     .buttonStyle(PrimaryButtonStyle())
-                    .disabled(isLoading)
+                    .disabled(isLoading || isPasskeyLoading)
+
+                    if challenge == nil {
+                        Button {
+                            startPasskeyLogin()
+                        } label: {
+                            HStack(spacing: 8) {
+                                Image(systemName: "person.badge.key.fill")
+                                Text(isPasskeyLoading ? "Signing in…" : "Sign in with Passkey")
+                            }
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .disabled(isLoading || isPasskeyLoading || email.trimmingCharacters(in: .whitespaces).isEmpty)
+                    }
                 }
                 .surfaceCard()
 
@@ -204,6 +219,116 @@ struct LoginView: View {
             await session.establishSession(token: token, user: response.data.user)
         } catch {
             await MainActor.run { authErrorText = (error as? APIErrorEnvelope)?.error ?? "Login failed" }
+        }
+    }
+
+    private func startPasskeyLogin() {
+        dismissKeyboard()
+        focusedField = nil
+        let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedEmail.isEmpty else { return }
+        guard !isPasskeyLoading, !isLoading else { return }
+        Task { @MainActor in
+            isPasskeyLoading = true
+            defer { isPasskeyLoading = false }
+            authErrorText = nil
+            await passkeyLogin(email: trimmedEmail)
+        }
+    }
+
+    @MainActor
+    private func passkeyLogin(email: String) async {
+        let optionsResponse: PasskeyLoginOptionsDTO
+        do {
+            struct Payload: Encodable { let email: String }
+            let envelope: APIEnvelope<PasskeyLoginOptionsDTO> = try await APIClient.shared.request(
+                "auth/passkey/options",
+                method: "POST",
+                body: Payload(email: email),
+                as: APIEnvelope<PasskeyLoginOptionsDTO>.self
+            )
+            optionsResponse = envelope.data
+        } catch {
+            authErrorText = (error as? APIErrorEnvelope)?.error ?? "Unable to start passkey sign-in"
+            return
+        }
+
+        guard let challengeData = Base64URL.decode(optionsResponse.options.challenge) else {
+            authErrorText = "Server returned an invalid passkey challenge"
+            return
+        }
+
+        let rpId = optionsResponse.options.rpId ?? APIClient.shared.baseURL.host ?? ""
+        guard !rpId.isEmpty else {
+            authErrorText = "Passkey sign-in is not available for this server"
+            return
+        }
+
+        let allowedCredentialIDs: [Data] = (optionsResponse.options.allowCredentials ?? [])
+            .compactMap { Base64URL.decode($0.id) }
+
+        let controller = PasskeyLoginController()
+        let assertion: ASAuthorizationPlatformPublicKeyCredentialAssertion
+        do {
+            assertion = try await controller.performAssertion(
+                relyingPartyIdentifier: rpId,
+                challenge: challengeData,
+                allowedCredentialIDs: allowedCredentialIDs
+            )
+        } catch PasskeyLoginError.cancelled {
+            return
+        } catch {
+            authErrorText = (error as? LocalizedError)?.errorDescription ?? "Passkey sign-in failed"
+            return
+        }
+
+        do {
+            struct CredentialResponse: Encodable {
+                let authenticatorData: String
+                let clientDataJSON: String
+                let signature: String
+                let userHandle: String?
+            }
+            struct Credential: Encodable {
+                let id: String
+                let rawId: String
+                let type: String
+                let response: CredentialResponse
+            }
+            struct VerifyPayload: Encodable {
+                let challenge_token: String
+                let credential: Credential
+            }
+
+            let credentialID = Base64URL.encode(assertion.credentialID)
+            let payload = VerifyPayload(
+                challenge_token: optionsResponse.challenge_token,
+                credential: Credential(
+                    id: credentialID,
+                    rawId: credentialID,
+                    type: "public-key",
+                    response: CredentialResponse(
+                        authenticatorData: Base64URL.encode(assertion.rawAuthenticatorData),
+                        clientDataJSON: Base64URL.encode(assertion.rawClientDataJSON),
+                        signature: Base64URL.encode(assertion.signature),
+                        userHandle: assertion.userID.map { Base64URL.encode($0) }
+                    )
+                )
+            )
+
+            let response: APIEnvelope<LoginResponseDTO> = try await APIClient.shared.request(
+                "auth/passkey/verify",
+                method: "POST",
+                body: payload,
+                as: APIEnvelope<LoginResponseDTO>.self
+            )
+            guard let token = response.data.token else {
+                authErrorText = "Passkey sign-in token missing"
+                return
+            }
+            await session.establishSession(token: token, user: response.data.user)
+        } catch {
+            authErrorText = (error as? APIErrorEnvelope)?.error ?? "Passkey sign-in failed"
         }
     }
 

--- a/tests/test_api_passkey.py
+++ b/tests/test_api_passkey.py
@@ -1,0 +1,263 @@
+"""Tests for the mobile passkey login API endpoints."""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from app import db
+import app.api.routes.auth as api_auth_module
+from app.models import PasskeyCredential, User
+
+
+def _enable_passkey(monkeypatch):
+    monkeypatch.setattr(api_auth_module, "_WEBAUTHN_AVAILABLE", True)
+    monkeypatch.setattr(api_auth_module, "_passkey_enabled", lambda: True)
+
+
+def _seed_passkey_user(app_ctx, email: str, credential_id: str = "ios-cred") -> User:
+    user = User.query.filter_by(email=email).first()
+    if user is None:
+        user = User(
+            email=email,
+            password="x",
+            name="Passkey User",
+            admin=True,
+            is_active=True,
+        )
+        db.session.add(user)
+        db.session.commit()
+
+    if not PasskeyCredential.query.filter_by(credential_id=credential_id).first():
+        db.session.add(
+            PasskeyCredential(
+                user_id=user.id,
+                credential_id=credential_id,
+                public_key="pub",
+                sign_count=0,
+                label="iPhone",
+                last_used_at=datetime.now(timezone.utc),
+            )
+        )
+        db.session.commit()
+    return user
+
+
+def test_api_passkey_options_returns_challenge_token(client, app_ctx, monkeypatch):
+    _enable_passkey(monkeypatch)
+
+    user = _seed_passkey_user(app_ctx, email="passkey-options@test.local")
+
+    stub_options = SimpleNamespace(challenge=b"challenge-bytes")
+    monkeypatch.setattr(
+        api_auth_module,
+        "generate_authentication_options",
+        lambda **kwargs: stub_options,
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "options_to_json",
+        lambda opts: '{"challenge": "Y2hhbGxlbmdlLWJ5dGVz", "rpId": "localhost"}',
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "bytes_to_base64url",
+        lambda b: "Y2hhbGxlbmdlLWJ5dGVz" if b == b"challenge-bytes" else str(b),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "base64url_to_bytes",
+        lambda s: s.encode("utf-8"),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "PublicKeyCredentialDescriptor",
+        lambda id: SimpleNamespace(id=id),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "UserVerificationRequirement",
+        SimpleNamespace(REQUIRED="required"),
+    )
+
+    resp = client.post("/api/v1/auth/passkey/options", json={"email": user.email})
+    assert resp.status_code == 200
+
+    data = resp.get_json()["data"]
+    assert data["challenge_token"]
+    assert data["options"]["challenge"] == "Y2hhbGxlbmdlLWJ5dGVz"
+
+
+def test_api_passkey_options_requires_email(client, monkeypatch):
+    _enable_passkey(monkeypatch)
+
+    resp = client.post("/api/v1/auth/passkey/options", json={})
+    assert resp.status_code == 422
+    assert resp.get_json()["fields"]["email"]
+
+
+def test_api_passkey_options_unknown_user_returns_401(client, monkeypatch):
+    _enable_passkey(monkeypatch)
+
+    resp = client.post(
+        "/api/v1/auth/passkey/options",
+        json={"email": "no-such-user@test.local"},
+    )
+    assert resp.status_code == 401
+    body = resp.get_json()
+    assert body["code"] == "unauthorized"
+
+
+def test_api_passkey_verify_returns_bearer_token(client, app_ctx, monkeypatch):
+    _enable_passkey(monkeypatch)
+
+    user = _seed_passkey_user(
+        app_ctx,
+        email="passkey-verify@test.local",
+        credential_id="cred-xyz",
+    )
+
+    # First: obtain options to receive a signed challenge_token.
+    stub_options = SimpleNamespace(challenge=b"verify-challenge-bytes")
+    monkeypatch.setattr(
+        api_auth_module,
+        "generate_authentication_options",
+        lambda **kwargs: stub_options,
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "options_to_json",
+        lambda opts: '{"challenge": "dmVyaWZ5LWNoYWxsZW5nZS1ieXRlcw"}',
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "bytes_to_base64url",
+        lambda b: "dmVyaWZ5LWNoYWxsZW5nZS1ieXRlcw",
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "base64url_to_bytes",
+        lambda s: s.encode("utf-8"),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "PublicKeyCredentialDescriptor",
+        lambda id: SimpleNamespace(id=id),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "UserVerificationRequirement",
+        SimpleNamespace(REQUIRED="required"),
+    )
+
+    options_resp = client.post(
+        "/api/v1/auth/passkey/options",
+        json={"email": user.email},
+    )
+    assert options_resp.status_code == 200
+    challenge_token = options_resp.get_json()["data"]["challenge_token"]
+
+    # Now: stub the verification itself and call verify.
+    monkeypatch.setattr(
+        api_auth_module,
+        "verify_authentication_response",
+        lambda **kwargs: SimpleNamespace(new_sign_count=7),
+    )
+
+    credential_payload = {
+        "id": "cred-xyz",
+        "rawId": "cred-xyz",
+        "type": "public-key",
+        "response": {
+            "authenticatorData": "AAAA",
+            "clientDataJSON": "AAAA",
+            "signature": "AAAA",
+        },
+    }
+    verify_resp = client.post(
+        "/api/v1/auth/passkey/verify",
+        json={"challenge_token": challenge_token, "credential": credential_payload},
+    )
+    assert verify_resp.status_code == 200
+
+    body = verify_resp.get_json()["data"]
+    assert body["token"]
+    assert body["user"]["email"] == user.email
+
+    refreshed = PasskeyCredential.query.filter_by(credential_id="cred-xyz").first()
+    assert refreshed.sign_count == 7
+    assert refreshed.last_used_at is not None
+
+
+def test_api_passkey_verify_rejects_replay(client, app_ctx, monkeypatch):
+    _enable_passkey(monkeypatch)
+
+    user = _seed_passkey_user(
+        app_ctx,
+        email="passkey-replay@test.local",
+        credential_id="cred-replay",
+    )
+
+    stub_options = SimpleNamespace(challenge=b"replay-bytes")
+    monkeypatch.setattr(
+        api_auth_module,
+        "generate_authentication_options",
+        lambda **kwargs: stub_options,
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "options_to_json",
+        lambda opts: '{"challenge": "cmVwbGF5LWJ5dGVz"}',
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "bytes_to_base64url",
+        lambda b: "cmVwbGF5LWJ5dGVz",
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "base64url_to_bytes",
+        lambda s: s.encode("utf-8"),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "PublicKeyCredentialDescriptor",
+        lambda id: SimpleNamespace(id=id),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "UserVerificationRequirement",
+        SimpleNamespace(REQUIRED="required"),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "verify_authentication_response",
+        lambda **kwargs: SimpleNamespace(new_sign_count=1),
+    )
+
+    options_resp = client.post(
+        "/api/v1/auth/passkey/options",
+        json={"email": user.email},
+    )
+    challenge_token = options_resp.get_json()["data"]["challenge_token"]
+
+    credential_payload = {
+        "id": "cred-replay",
+        "rawId": "cred-replay",
+        "type": "public-key",
+        "response": {
+            "authenticatorData": "AAAA",
+            "clientDataJSON": "AAAA",
+            "signature": "AAAA",
+        },
+    }
+
+    first = client.post(
+        "/api/v1/auth/passkey/verify",
+        json={"challenge_token": challenge_token, "credential": credential_payload},
+    )
+    assert first.status_code == 200
+
+    replay = client.post(
+        "/api/v1/auth/passkey/verify",
+        json={"challenge_token": challenge_token, "credential": credential_payload},
+    )
+    assert replay.status_code == 401


### PR DESCRIPTION
## Summary
Implements WebAuthn/passkey-based authentication for both the backend API and iOS mobile app, allowing users to sign in using biometric or device-based passkeys instead of passwords.

## Key Changes

### Backend (Python/Flask)
- **New API endpoints:**
  - `POST /api/v1/auth/passkey/options` — Initiates passkey login by returning WebAuthn challenge parameters and a signed challenge token
  - `POST /api/v1/auth/passkey/verify` — Completes passkey login by verifying the WebAuthn assertion and issuing a bearer token

- **Passkey credential management:**
  - Added `PasskeyCredential` model integration for storing and validating registered passkeys
  - Tracks sign count and last used timestamp to detect cloned authenticators and replay attacks
  - Implements challenge token serialization with 5-minute TTL and single-use enforcement via in-memory consumed challenge tracking

- **Security features:**
  - Replay attack prevention via consumed challenge tracking with thread-safe locking
  - User verification requirement enforced at the protocol level
  - Generic error messages to avoid account enumeration
  - Graceful handling of optional webauthn dependency

- **API documentation:**
  - Added comprehensive endpoint documentation to `MOBILE_API_REFERENCE.md` with request/response examples

### iOS App (Swift)
- **New `PasskeyLoginController`:**
  - Wraps `ASAuthorizationController` to drive passkey assertion flow
  - Handles system passkey sheet presentation and credential selection
  - Manages async/await continuation for seamless integration with async code

- **Base64URL encoding/decoding:**
  - Utility functions to convert between `Data` and WebAuthn-spec base64url format (URL-safe, no padding)

- **UI updates:**
  - Added "Sign in with Passkey" button to login screen (visible when no 2FA challenge is active)
  - Integrated passkey login flow with existing session management
  - Proper error handling and user feedback for passkey-specific failures

- **Data models:**
  - Added `PasskeyLoginOptionsDTO` to decode server challenge parameters and allowed credentials

## Implementation Details
- Passkey feature is optional and gracefully degrades if webauthn library is unavailable
- Challenge tokens are cryptographically signed using Flask's `URLSafeTimedSerializer` with a dedicated salt
- Sign count validation prevents use of cloned authenticators
- Both endpoints rate-limited to 10 requests/minute to prevent brute force attacks
- iOS implementation uses `@MainActor` for thread safety and proper UI updates

https://claude.ai/code/session_011T7MtxWbWLTbxrR9FY1Xyf