### PR TITLE
Improve passkey enumeration resistance by making decoy responses indistinguishable

### DIFF
--- a/app/api/routes/auth.py
+++ b/app/api/routes/auth.py
@@ -1,5 +1,7 @@
 """API v1 authentication routes."""
 
+import hashlib
+import hmac
 import json
 import logging
 from datetime import datetime, timedelta, timezone
@@ -349,24 +351,15 @@ def _try_mark_passkey_challenge_consumed(challenge_token: str) -> bool:
         return True
 
 
-def _build_passkey_challenge_token(user: User, challenge_b64url: str) -> str:
+def _build_passkey_challenge_token(email: str, challenge_b64url: str) -> str:
+    # The payload is identical in shape for real and ineligible emails so a
+    # caller cannot distinguish the two by decoding the (signed, not encrypted)
+    # token. /auth/passkey/verify re-resolves the user by email and still
+    # requires a matching stored credential, so ineligible emails fail there.
     payload = {
-        "uid": user.id,
-        "email": user.email,
-        "challenge": challenge_b64url,
-        "nonce": hash_token(f"{user.id}:{datetime.now(timezone.utc).isoformat()}"),
-    }
-    return _passkey_challenge_serializer().dumps(payload)
-
-
-def _build_decoy_passkey_challenge_token(email: str, challenge_b64url: str) -> str:
-    # uid=0 never matches a real user, so /auth/passkey/verify naturally
-    # rejects this token without revealing whether the email exists.
-    payload = {
-        "uid": 0,
         "email": email,
         "challenge": challenge_b64url,
-        "nonce": hash_token(f"decoy:{email}:{datetime.now(timezone.utc).isoformat()}"),
+        "nonce": hash_token(f"{email}:{datetime.now(timezone.utc).isoformat()}"),
     }
     return _passkey_challenge_serializer().dumps(payload)
 
@@ -382,11 +375,23 @@ def _decode_passkey_challenge_token(challenge_token: str) -> dict | None:
 
     if (
         not isinstance(payload, dict)
-        or not isinstance(payload.get("uid"), int)
+        or not isinstance(payload.get("email"), str)
         or not isinstance(payload.get("challenge"), str)
     ):
         return None
     return payload
+
+
+def _derive_decoy_credential_id(email: str) -> str:
+    # HMAC with SECRET_KEY so the decoy id is unpredictable to callers but
+    # stable across retries for the same email, matching the shape of a real
+    # PasskeyCredential.credential_id (base64url of 32 bytes).
+    digest = hmac.new(
+        current_app.config["SECRET_KEY"].encode("utf-8"),
+        f"passkey-decoy:{email}".encode("utf-8"),
+        hashlib.sha256,
+    ).digest()
+    return bytes_to_base64url(digest)
 
 
 @api.route("/auth/passkey/options", methods=["POST"])
@@ -414,15 +419,22 @@ def api_passkey_login_options():
 
     # Always return a success-shaped response so an unauthenticated caller
     # cannot enumerate which emails have passkey-enabled accounts. For
-    # ineligible emails we issue a decoy challenge token that will fail
-    # at /auth/passkey/verify.
+    # ineligible emails we fill allow_credentials with a deterministic decoy
+    # descriptor so the response shape matches a real user with a single
+    # passkey (the common case), and issue a challenge_token whose payload
+    # is structurally identical to a real one. Verification naturally fails
+    # at /auth/passkey/verify because no stored credential matches.
     if eligible:
         allow_credentials = [
             PublicKeyCredentialDescriptor(id=base64url_to_bytes(c.credential_id))
             for c in user.passkey_credentials
         ]
     else:
-        allow_credentials = []
+        allow_credentials = [
+            PublicKeyCredentialDescriptor(
+                id=base64url_to_bytes(_derive_decoy_credential_id(email))
+            )
+        ]
 
     options = generate_authentication_options(
         rp_id=current_app.config["PASSKEY_RP_ID"],
@@ -430,10 +442,7 @@ def api_passkey_login_options():
         user_verification=UserVerificationRequirement.REQUIRED,
     )
     challenge_b64url = bytes_to_base64url(options.challenge)
-    if eligible:
-        challenge_token = _build_passkey_challenge_token(user, challenge_b64url)
-    else:
-        challenge_token = _build_decoy_passkey_challenge_token(email, challenge_b64url)
+    challenge_token = _build_passkey_challenge_token(email, challenge_b64url)
 
     return api_ok({
         "challenge_token": challenge_token,
@@ -466,7 +475,7 @@ def api_passkey_login_verify():
     if payload is None or _is_passkey_challenge_consumed(challenge_token):
         return unauthorized("Invalid or expired passkey challenge")
 
-    user = db.session.get(User, payload["uid"])
+    user = User.query.filter_by(email=payload["email"]).first()
     if user is None or not enforce_user_access(user):
         return unauthorized("Invalid or expired passkey challenge")
 

--- a/tests/test_api_passkey.py
+++ b/tests/test_api_passkey.py
@@ -158,6 +158,91 @@ def test_api_passkey_options_unknown_user_returns_decoy(client, monkeypatch):
     assert verify_resp.status_code == 401
 
 
+def test_api_passkey_options_decoy_is_indistinguishable_from_real(
+    client, app_ctx, monkeypatch
+):
+    # Enumeration-resistance regression: the signed (not encrypted) challenge
+    # token and the options payload must not expose whether the email maps to
+    # an eligible passkey user.
+    _enable_passkey(monkeypatch)
+
+    _seed_passkey_user(
+        app_ctx,
+        email="indistinguishable-real@test.local",
+        credential_id="abcd1234",  # hex-encoded for the hex stubs below
+    )
+
+    # Stub webauthn helpers so we can exercise both the real-user and decoy
+    # paths without the optional dependency. The stubs echo inputs so the
+    # response shape reflects what the route actually produces.
+    monkeypatch.setattr(
+        api_auth_module,
+        "generate_authentication_options",
+        lambda **kwargs: SimpleNamespace(
+            challenge=b"c",
+            allow_credentials=list(kwargs.get("allow_credentials") or []),
+        ),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "options_to_json",
+        lambda opts: (
+            '{"challenge": "Yw", "allowCredentials": ['
+            + ", ".join(
+                f'{{"id": "{c.id.hex()}"}}' for c in opts.allow_credentials
+            )
+            + "]}"
+        ),
+    )
+    monkeypatch.setattr(api_auth_module, "bytes_to_base64url", lambda b: b.hex())
+    monkeypatch.setattr(api_auth_module, "base64url_to_bytes", lambda s: bytes.fromhex(s))
+    monkeypatch.setattr(
+        api_auth_module,
+        "PublicKeyCredentialDescriptor",
+        lambda id: SimpleNamespace(id=id),
+    )
+    monkeypatch.setattr(
+        api_auth_module,
+        "UserVerificationRequirement",
+        SimpleNamespace(REQUIRED="required"),
+    )
+
+    real_resp = client.post(
+        "/api/v1/auth/passkey/options",
+        json={"email": "indistinguishable-real@test.local"},
+    )
+    decoy_resp = client.post(
+        "/api/v1/auth/passkey/options",
+        json={"email": "indistinguishable-missing@test.local"},
+    )
+
+    assert real_resp.status_code == 200
+    assert decoy_resp.status_code == 200
+
+    real_data = real_resp.get_json()["data"]
+    decoy_data = decoy_resp.get_json()["data"]
+
+    # Both responses expose the same top-level keys.
+    assert set(real_data) == set(decoy_data) == {"challenge_token", "options"}
+
+    # Both options payloads expose the same keys (rpId, challenge, etc.) so a
+    # caller cannot distinguish by inspecting the shape.
+    assert set(real_data["options"]) == set(decoy_data["options"])
+
+    # allow_credentials has the same length — 1 for a user with one passkey,
+    # 1 for the decoy case.
+    assert len(real_data["options"]["allowCredentials"]) == 1
+    assert len(decoy_data["options"]["allowCredentials"]) == 1
+
+    # The decoded challenge_token payloads must have the same keys; nothing
+    # like `uid=0` or a `decoy:` nonce prefix may leak the user state.
+    serializer = api_auth_module._passkey_challenge_serializer()
+    real_payload = serializer.loads(real_data["challenge_token"])
+    decoy_payload = serializer.loads(decoy_data["challenge_token"])
+    assert set(real_payload) == set(decoy_payload)
+    assert "uid" not in real_payload and "uid" not in decoy_payload
+
+
 def test_api_passkey_verify_returns_bearer_token(client, app_ctx, monkeypatch):
     _enable_passkey(monkeypatch)
 


### PR DESCRIPTION
## Summary
This change enhances the security of the passkey authentication flow by making responses for non-existent users indistinguishable from responses for real users. Previously, the decoy response could be differentiated by inspecting the challenge token payload or the structure of the options response.

## Key Changes
- **Unified challenge token structure**: Removed the `uid` field from challenge tokens and changed the nonce generation to use email instead of user ID. Both real and decoy tokens now have identical payload shapes, preventing enumeration via token inspection.
- **Deterministic decoy credentials**: Instead of returning an empty `allow_credentials` list for non-existent users, the endpoint now generates a stable, unpredictable decoy credential descriptor using HMAC-SHA256. This ensures both real and decoy responses have the same structure (one credential in the common case).
- **Simplified verification logic**: The `/auth/passkey/verify` endpoint now resolves users by email from the challenge token instead of relying on a stored `uid`. This works for both real and decoy tokens since verification naturally fails when no matching credential exists in the database.
- **Removed separate decoy token builder**: Consolidated `_build_passkey_challenge_token()` and `_build_decoy_passkey_challenge_token()` into a single function that produces structurally identical tokens regardless of user eligibility.

## Implementation Details
- The decoy credential ID is derived using `HMAC-SHA256(SECRET_KEY, "passkey-decoy:{email}")` to ensure it's unpredictable to callers but stable across retries for the same email.
- Challenge tokens no longer contain user IDs, making them safe to decode without leaking user existence information.
- The verification endpoint performs a fresh email lookup rather than trusting a pre-stored UID, maintaining security even with the simplified token structure.
- Added comprehensive regression test to verify that real and decoy responses are indistinguishable at all levels: response shape, options payload structure, credential list length, and challenge token payload keys.

https://claude.ai/code/session_01PR2HyaqD41Z9441FceGJXH