### PR TITLE
Improve passkey UI presentation anchor handling

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Auth/PasskeyLoginController.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Auth/PasskeyLoginController.swift
@@ -117,15 +117,23 @@ final class PasskeyLoginController: NSObject, ASAuthorizationControllerDelegate,
         for controller: ASAuthorizationController
     ) -> ASPresentationAnchor {
         MainActor.assumeIsolated {
-            Self.keyWindow() ?? ASPresentationAnchor()
+            Self.presentationAnchor()
         }
     }
 
-    private static func keyWindow() -> UIWindow? {
-        UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow }
+    private static func presentationAnchor() -> ASPresentationAnchor {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let windows = scenes.flatMap(\.windows)
+        if let keyWindow = windows.first(where: \.isKeyWindow) {
+            return keyWindow
+        }
+        if let anyWindow = windows.first {
+            return anyWindow
+        }
+        if let scene = scenes.first {
+            return UIWindow(windowScene: scene)
+        }
+        preconditionFailure("No connected window scenes available to anchor passkey UI")
     }
 }
 


### PR DESCRIPTION
## Summary
Refactored the passkey login presentation anchor logic to provide more robust fallback behavior when retrieving the key window for ASAuthorizationController.

## Key Changes
- Renamed `keyWindow()` to `presentationAnchor()` to better reflect its purpose of returning an `ASPresentationAnchor`
- Changed return type from `UIWindow?` to `ASPresentationAnchor` to eliminate optional handling at the call site
- Implemented a tiered fallback strategy:
  1. First attempts to find the key window
  2. Falls back to any available window if key window is not found
  3. Creates a new UIWindow from the first available scene as a last resort
  4. Fails with a clear precondition error if no window scenes are available
- Improved code readability by using explicit variable names and conditional logic instead of chained optionals

## Implementation Details
The new approach ensures that a valid presentation anchor is always returned (or the app fails fast with a descriptive error), eliminating the previous behavior of returning an empty `ASPresentationAnchor()` when no key window was available. This provides better error visibility and more reliable passkey authentication UI presentation.

https://claude.ai/code/session_015tJXsN6zyGPosmTAhAUFDK