### PR TITLE
Serve Apple App Site Association and document iOS passkey requirements

### DIFF
--- a/MOBILE_API_REFERENCE.md
+++ b/MOBILE_API_REFERENCE.md
@@ -268,6 +268,17 @@ Begin a passkey (WebAuthn) login flow. Returns the challenge parameters and a
 signed `challenge_token` that must be echoed back to
 `POST /api/v1/auth/passkey/verify`.
 
+#### iOS Associated Domains requirement (passkeys/shared web credentials)
+
+For iOS passkeys and shared web credentials to work with
+`com.h3consultingpartners.pycashflow`, the app must include this entitlement:
+
+- `webcredentials:app.pycashflow.com`
+
+The backend serves Apple App Site Association (AASA) JSON over HTTPS at:
+
+- `https://app.pycashflow.com/.well-known/apple-app-site-association`
+
 **Auth required:** No
 
 **Rate limit:** 10/minute

--- a/app/.well-known/apple-app-site-association
+++ b/app/.well-known/apple-app-site-association
@@ -1,0 +1,7 @@
+{
+  "webcredentials": {
+    "apps": [
+      "JFTUN6NUAB.com.h3consultingpartners.pycashflow"
+    ]
+  }
+}

--- a/app/main.py
+++ b/app/main.py
@@ -540,6 +540,15 @@ def appleicon():
                                'apple-touch-icon.png', mimetype='image/png')
 
 
+@main.route('/.well-known/apple-app-site-association', methods=['GET'])
+def apple_app_site_association():
+    return send_from_directory(
+        os.path.join(main.root_path, '.well-known'),
+        'apple-app-site-association',
+        mimetype='application/json',
+    )
+
+
 @main.route('/balance', methods=('GET', 'POST'))
 @login_required
 @admin_required

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -16,6 +16,7 @@ status codes, redirects, and flash messages where they are easy to assert.
 
 import pytest
 import importlib
+import json
 from datetime import datetime, timezone
 from werkzeug.security import generate_password_hash
 
@@ -47,6 +48,20 @@ class TestUnauthenticatedAccess:
         assert "login" in location.lower(), (
             f"GET {path} should redirect to login page, got location: {location}"
         )
+
+    def test_apple_app_site_association_is_public_json(self, client):
+        resp = client.get("/.well-known/apple-app-site-association", follow_redirects=False)
+        assert resp.status_code == 200
+        assert resp.content_type.startswith("application/json")
+
+        payload = json.loads(resp.data.decode("utf-8"))
+        assert payload == {
+            "webcredentials": {
+                "apps": [
+                    "JFTUN6NUAB.com.h3consultingpartners.pycashflow",
+                ]
+            }
+        }
 
 
 # ── Tests: authenticated GET routes ──────────────────────────────────────────


### PR DESCRIPTION
### Motivation

- Enable iOS passkeys and shared web credentials by exposing the Apple App Site Association file and documenting the required entitlement for the app domain.

### Description

- Add `app/.well-known/apple-app-site-association` containing the `webcredentials.apps` array with the app identifier.
- Add a public Flask route `/.well-known/apple-app-site-association` that serves the AASA JSON via `send_from_directory` with `application/json` mimetype.
- Update `MOBILE_API_REFERENCE.md` to document the iOS Associated Domains requirement and the AASA endpoint URL and entitlement (`webcredentials:app.pycashflow.com`).
- Add a test in `tests/test_routes.py` verifying the AASA endpoint is public, returns `application/json`, and contains the expected payload, and add an `import json` needed for that test.

### Testing

- Ran the route integration tests with `pytest tests/test_routes.py`, including `TestUnauthenticatedAccess::test_apple_app_site_association_is_public_json`, and they passed.
- Existing authenticated and unauthenticated route tests were exercised and reported passing locally with the updated test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb9edaed90832085800c32b39ddacd)