### PR TITLE
Enable webcredentials for associated domains

### DIFF
--- a/ios-app/pycashflow/pycashflow.entitlements
+++ b/ios-app/pycashflow/pycashflow.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>app.pycashflow.com</string>
+		<string>webcredentials:app.pycashflow.com</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Updated the associated domains entitlement to enable webcredentials support for password autofill functionality.

## Changes
- Modified the associated domain entry from `app.pycashflow.com` to `webcredentials:app.pycashflow.com` in the entitlements file

## Details
This change enables iOS's AutoFill feature to work with the app by properly configuring the associated domains entitlement. The `webcredentials:` prefix is required for the system to recognize the domain as supporting password autofill and credential management. This allows users to securely save and autofill their credentials within the app.

https://claude.ai/code/session_01GQYGhkTpqspCovrzewScZt