### PR TITLE
Improve passkey login validation and error messaging

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -103,7 +103,7 @@ struct LoginView: View {
                             }
                         }
                         .buttonStyle(PrimaryButtonStyle())
-                        .disabled(isLoading || isPasskeyLoading || email.trimmingCharacters(in: .whitespaces).isEmpty)
+                        .disabled(isLoading || isPasskeyLoading)
                     }
                 }
                 .surfaceCard()
@@ -226,7 +226,10 @@ struct LoginView: View {
         dismissKeyboard()
         focusedField = nil
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedEmail.isEmpty else { return }
+        guard !trimmedEmail.isEmpty else {
+            authErrorText = "Please enter your email first, then select Sign in with Passkey."
+            return
+        }
         guard !isPasskeyLoading, !isLoading else { return }
         Task { @MainActor in
             isPasskeyLoading = true


### PR DESCRIPTION
## Summary
Enhanced the passkey login flow with better validation and user feedback by removing premature email validation from the button disabled state and adding a clear error message when users attempt passkey login without entering an email.

## Key Changes
- Removed email validation from the Sign in with Passkey button's disabled state, allowing the button to remain enabled even when the email field is empty
- Added explicit error message ("Please enter your email first, then select Sign in with Passkey.") that displays when users attempt passkey authentication without providing an email address
- Moved email validation logic from the UI layer (button state) to the action handler (passkey login method) for better separation of concerns

## Implementation Details
The validation now occurs at the point of action rather than preventing the button from being clickable. This provides a better user experience by:
1. Keeping the button visually available to interact with
2. Providing immediate, contextual feedback when the user attempts an invalid action
3. Guiding users on what they need to do next (enter email, then select passkey)

https://claude.ai/code/session_017T7ULB9pUPeL85RCWnggeX