### PR TITLE
Handle missing window scenes gracefully in passkey login

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Auth/PasskeyLoginController.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Auth/PasskeyLoginController.swift
@@ -133,7 +133,10 @@ final class PasskeyLoginController: NSObject, ASAuthorizationControllerDelegate,
         if let scene = scenes.first {
             return UIWindow(windowScene: scene)
         }
-        preconditionFailure("No connected window scenes available to anchor passkey UI")
+        // No connected scenes (e.g. backgrounded or mid-lifecycle transition).
+        // Return a detached window so ASAuthorizationController surfaces a
+        // normal auth error instead of crashing the app.
+        return ASPresentationAnchor()
     }
 }
 


### PR DESCRIPTION
## Summary
Changed the passkey login controller to handle cases where no connected window scenes are available, preventing app crashes during authentication in edge cases like app backgrounding or lifecycle transitions.

## Key Changes
- Replaced `preconditionFailure()` with a fallback that returns a detached `ASPresentationAnchor()` window
- Added explanatory comments documenting the scenario (backgrounded app or mid-lifecycle transition)
- Allows `ASAuthorizationController` to surface a normal auth error instead of crashing the app

## Implementation Details
When no connected window scenes are available to anchor the passkey UI, the controller now returns a detached window anchor. This enables the system authentication controller to handle the presentation gracefully and return an appropriate error to the user, rather than terminating the application with a precondition failure.

https://claude.ai/code/session_01LLg411ZG83pBoJVRz1ZDNS