### PR TITLE
Allow guests of global admins to bypass subscription requirements

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -332,15 +332,17 @@ def api_billing_status():
     user = get_api_user()
     owner = owner_for_user(user)
 
+    owner_is_global_admin = bool(owner and owner.is_global_admin)
+
     if not user.is_global_admin and not user.is_active:
         # Keep manual/admin deactivation checks, but allow expired users to
         # retrieve billing status when payments enforcement is enabled.
-        if not payments_enabled() or subscription_is_current(owner):
+        if not payments_enabled() or owner_is_global_admin or subscription_is_current(owner):
             return unauthorized("Invalid credentials or account is not active")
 
     owner_id = user.owner_user_id or user.account_owner_id
 
-    effective_is_active = bool(user.is_global_admin)
+    effective_is_active = bool(user.is_global_admin) or owner_is_global_admin
     if not effective_is_active:
         if payments_enabled():
             effective_is_active = subscription_is_current(owner)

--- a/app/subscription.py
+++ b/app/subscription.py
@@ -136,6 +136,15 @@ def enforce_user_access(user: User | None) -> bool:
     if owner is None:
         return False
 
+    if owner.is_global_admin:
+        changed = False
+        if not user.is_active:
+            user.is_active = True
+            changed = True
+        if changed:
+            db.session.commit()
+        return True
+
     if subscription_is_current(owner):
         changed = False
         if not owner.is_global_admin and not owner.is_active:

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -653,6 +653,92 @@ def test_subscription_webhook_update_without_email_uses_existing_subscription_id
         assert user.is_active is True
 
 
+def test_guest_of_global_admin_is_subscription_exempt(flask_app, client):
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = True
+        admin = User(
+            email="gadmin-owner@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="GlobalAdmin",
+            admin=True,
+            is_global_admin=True,
+            is_active=True,
+            subscription_status="expired",
+            subscription_source="none",
+        )
+        db.session.add(admin)
+        db.session.commit()
+
+        guest = User(
+            email="gadmin-guest@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Guest",
+            admin=False,
+            is_active=True,
+            account_owner_id=admin.id,
+            owner_user_id=admin.id,
+            is_account_owner=False,
+            subscription_status="inactive",
+            subscription_source="none",
+        )
+        db.session.add(guest)
+        db.session.commit()
+
+        raw, _ = create_token_for_user(guest)
+
+    resp = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        guest_db = User.query.filter_by(email="gadmin-guest@test.local").first()
+        assert guest_db.is_active is True
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
+def test_inactive_guest_of_global_admin_is_reactivated(flask_app, client):
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = True
+        admin = User(
+            email="gadmin-owner2@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="GlobalAdmin",
+            admin=True,
+            is_global_admin=True,
+            is_active=True,
+            subscription_status="expired",
+            subscription_source="none",
+        )
+        db.session.add(admin)
+        db.session.commit()
+
+        guest = User(
+            email="gadmin-guest-inactive@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Guest",
+            admin=False,
+            is_active=False,
+            account_owner_id=admin.id,
+            owner_user_id=admin.id,
+            is_account_owner=False,
+            subscription_status="inactive",
+            subscription_source="none",
+        )
+        db.session.add(guest)
+        db.session.commit()
+
+        raw, _ = create_token_for_user(guest)
+
+    resp = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200
+
+    with flask_app.app_context():
+        guest_db = User.query.filter_by(email="gadmin-guest-inactive@test.local").first()
+        assert guest_db.is_active is True
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
 def test_global_admin_is_subscription_exempt(flask_app, client):
     with flask_app.app_context():
         admin = User(


### PR DESCRIPTION
## Summary
This change extends subscription exemption to guest users whose account owner is a global admin. Previously, only global admins themselves were exempt from subscription requirements. Now guests of global admins receive the same exemption, and inactive guests are automatically reactivated when they authenticate.

## Key Changes
- **subscription.py**: Modified `enforce_user_access()` to check if a user's owner is a global admin and grant access accordingly. Inactive guests of global admins are automatically reactivated upon authentication.
- **billing.py**: Updated `api_billing_status()` endpoint to recognize when a user's owner is a global admin and apply the same subscription exemptions, allowing them to access billing status without an active subscription.
- **tests/test_billing.py**: Added two new test cases:
  - `test_guest_of_global_admin_is_subscription_exempt`: Verifies that active guests of global admins can authenticate and remain active
  - `test_inactive_guest_of_global_admin_is_reactivated`: Verifies that inactive guests of global admins are automatically reactivated upon authentication

## Implementation Details
- The logic checks `owner.is_global_admin` in addition to `user.is_global_admin` to determine subscription exemption status
- Guest reactivation happens automatically during the `enforce_user_access()` check when payments are enabled
- The billing status endpoint now considers both direct global admin status and inherited status through account ownership

https://claude.ai/code/session_01UMdTK5Lo2PFf1iXRJxPuYg