### PR TITLE
Add guest-only Settings button to Dashboard navigation

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -69,7 +69,11 @@ struct DashboardView: View {
         .appBackground()
         .navigationTitle("Dashboard")
         .safeAreaInset(edge: .bottom, spacing: 0) {
-            FloatingNavBar(items: navItems)
+            if session.user?.is_guest == true {
+                GuestSettingsButton()
+            } else {
+                FloatingNavBar(items: navItems)
+            }
         }
     }
 

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -26,6 +26,28 @@ struct FloatingNavBar: View {
     }
 }
 
+/// Small circular Liquid Glass button anchored to the bottom-right, used
+/// as the only navigation affordance for guest users (Settings access).
+struct GuestSettingsButton: View {
+    var body: some View {
+        HStack {
+            Spacer()
+            NavigationLink {
+                SettingsView()
+            } label: {
+                Image(systemName: "gearshape")
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(AppTheme.textPrimary)
+                    .frame(width: 48, height: 48)
+            }
+            .buttonStyle(FloatingNavButtonStyle())
+            .glassEffect(.regular.interactive(), in: Circle())
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 8)
+    }
+}
+
 struct FloatingNavItem: Identifiable {
     let id = UUID()
     let title: String


### PR DESCRIPTION
## Summary
This PR adds a dedicated navigation UI for guest users, providing access to Settings through a floating glass-morphism button instead of the full navigation bar available to authenticated users.

## Key Changes
- **New `GuestSettingsButton` component**: A small circular liquid glass button anchored to the bottom-right corner that navigates to Settings. This serves as the sole navigation affordance for guest users.
- **Conditional navigation rendering in `DashboardView`**: The bottom navigation now conditionally displays either the `GuestSettingsButton` (for guest users) or the standard `FloatingNavBar` (for authenticated users) based on the `session.user?.is_guest` flag.

## Implementation Details
- The `GuestSettingsButton` uses a gear icon (`gearshape`) styled with the app's primary text color and applies the glass effect with interactive behavior
- The button is wrapped in an `HStack` with a `Spacer()` to position it on the right side
- Padding is applied to maintain consistent spacing from the screen edges
- The conditional logic in `DashboardView` ensures guest users have a simplified navigation experience while maintaining full navigation for authenticated users

https://claude.ai/code/session_01CnPLeiVDYyeSM9pYzM9Wtp