### PR TITLE
Add email validation to subscription purchase and restore flows

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -30,7 +30,11 @@ final class StoreKitSubscriptionManager: ObservableObject {
 
     func purchase(_ product: Product, email: String, token: String?) async {
         guard !email.isEmpty else {
-            errorMessage = "Email is required to activate a hosted cloud account."
+            errorMessage = "Please enter an email address before activating your subscription."
+            return
+        }
+        guard Self.isValidEmail(email) else {
+            errorMessage = "Please enter a valid email address to activate your subscription."
             return
         }
 
@@ -62,7 +66,11 @@ final class StoreKitSubscriptionManager: ObservableObject {
 
     func restorePurchases(email: String, token: String?) async {
         guard !email.isEmpty else {
-            errorMessage = "Email is required to restore a hosted cloud account."
+            errorMessage = "Please enter an email address before restoring your subscription."
+            return
+        }
+        guard Self.isValidEmail(email) else {
+            errorMessage = "Please enter a valid email address to restore your subscription."
             return
         }
 
@@ -123,6 +131,11 @@ final class StoreKitSubscriptionManager: ObservableObject {
         case .verified(let safe):
             return safe
         }
+    }
+
+    private static func isValidEmail(_ email: String) -> Bool {
+        let pattern = #"^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$"#
+        return email.range(of: pattern, options: .regularExpression) != nil
     }
 
     private static func signedTransactionInfo(_ transaction: StoreKit.Transaction) -> String? {


### PR DESCRIPTION
## Summary
Enhanced the subscription management flow by adding email validation to both purchase and restore operations, along with improved user-facing error messages.

## Key Changes
- Added `isValidEmail()` helper method that validates email format using regex pattern matching
- Updated `purchase()` method to validate email format before processing, with clearer error messaging
- Updated `restorePurchases()` method to validate email format before processing, with clearer error messaging
- Improved error messages to be more user-friendly and action-oriented (e.g., "Please enter an email address before activating your subscription" instead of "Email is required to activate a hosted cloud account")

## Implementation Details
- Email validation uses a regex pattern that checks for standard email format: `^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$`
- Validation occurs after the empty string check, providing a two-tier validation approach
- Error messages are now consistent across both purchase and restore flows and clearly indicate what action the user needs to take

https://claude.ai/code/session_01VBr8BfjafmANhAzUximtNU