### PR TITLE
Fix app mode picker to properly reset base URL on mode switch

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -33,20 +33,29 @@ struct LoginView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                Picker("App Mode", selection: $session.appMode) {
+                Picker("App Mode", selection: Binding(
+                    get: { session.appMode },
+                    set: { newValue in
+                        // Route through `switchMode` directly instead of a
+                        // `$session.appMode` two-way binding + `.onChange`: the
+                        // binding pattern mutates `appMode` before `onChange`
+                        // fires, so `switchMode`'s equality guard would
+                        // short-circuit and leave the base URL pointed at the
+                        // previous environment.
+                        guard newValue != session.appMode else { return }
+                        // Resign any active text field before the self-hosted
+                        // card appears/disappears; otherwise the keyboard layout
+                        // constraints conflict with the view hierarchy change.
+                        dismissKeyboard()
+                        focusedField = nil
+                        session.switchMode(newValue)
+                        authErrorText = nil
+                        selfHostedErrorText = nil
+                    }
+                )) {
                     ForEach(SessionManager.AppMode.allCases) { mode in
                         Text(mode.label).tag(mode)
                     }
-                }
-                .onChange(of: session.appMode) { _, newValue in
-                    // Resign any active text field before the self-hosted
-                    // card appears/disappears; otherwise the keyboard layout
-                    // constraints conflict with the view hierarchy change.
-                    dismissKeyboard()
-                    focusedField = nil
-                    session.switchMode(newValue)
-                    authErrorText = nil
-                    selfHostedErrorText = nil
                 }
                 .surfaceCard()
 

--- a/ios-app/pycashflow/PyCashFlowAppTests/SessionManagerModeTests.swift
+++ b/ios-app/pycashflow/PyCashFlowAppTests/SessionManagerModeTests.swift
@@ -36,6 +36,18 @@ final class SessionManagerModeTests: XCTestCase {
         XCTAssertFalse(session.isAuthenticated)
     }
 
+    func testSwitchBackToCloudResetsBaseURLFromSelfHosted() async {
+        let session = SessionManager()
+        _ = session.updateSelfHostedBaseURL("https://self-hosted.example.com/api/v1")
+        session.switchMode(.selfHosted)
+        XCTAssertEqual(session.currentBaseURL.absoluteString, "https://self-hosted.example.com/api/v1")
+
+        session.switchMode(.cloud)
+
+        XCTAssertEqual(session.appMode, .cloud)
+        XCTAssertEqual(session.currentBaseURL, AppEnvironment.cloudAPIBaseURL)
+    }
+
     func testInvalidSelfHostedURLRejected() async {
         let session = SessionManager()
         let ok = session.updateSelfHostedBaseURL("not-a-url")


### PR DESCRIPTION
## Summary
Fixed a bug in the LoginView where switching app modes would not properly reset the base URL due to timing issues with SwiftUI's binding and onChange modifier interaction.

## Key Changes
- **LoginView.swift**: Replaced the `Picker` binding + `.onChange` pattern with a custom `Binding` that directly calls `session.switchMode()` in its setter. This ensures the mode switch logic executes immediately when the picker selection changes, before any state mutations occur.
  - The custom binding includes an equality guard to prevent redundant calls
  - Keyboard dismissal and error state clearing are now part of the binding setter
  - Removed the separate `.onChange` modifier that was previously handling this logic

- **SessionManagerModeTests.swift**: Added `testSwitchBackToCloudResetsBaseURLFromSelfHosted()` test to verify that switching from self-hosted mode back to cloud mode properly resets the base URL to the cloud API endpoint.

## Implementation Details
The original implementation had a race condition: the `$session.appMode` two-way binding would mutate `appMode` before the `.onChange` modifier fired, causing `switchMode`'s equality guard to short-circuit and skip the base URL reset. By moving the logic into the binding's setter, we ensure it executes synchronously when the selection changes, preventing the state from being partially updated before the mode switch logic runs.

https://claude.ai/code/session_01Ck9v1nWxYj9qjJK8tHiztW