### PR TITLE
Improve email validation regex pattern

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -134,7 +134,7 @@ final class StoreKitSubscriptionManager: ObservableObject {
     }
 
     private static func isValidEmail(_ email: String) -> Bool {
-        let pattern = #"^[^\s@]+@[^\s@]+\.[^\s@]+$"#
+        let pattern = #"^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$"#
         return email.range(of: pattern, options: .regularExpression) != nil
     }
 


### PR DESCRIPTION
## Summary
Updated the email validation regex pattern in `StoreKitSubscriptionManager` to be more strict and RFC-compliant.

## Key Changes
- Replaced the permissive email regex pattern with a more restrictive one that:
  - Validates the local part (before @) to only allow alphanumeric characters, dots, underscores, percent signs, plus signs, and hyphens
  - Validates the domain part to only allow alphanumeric characters, dots, and hyphens
  - Requires at least 2 characters for the top-level domain (TLD)
  - Prevents acceptance of invalid email formats that the previous pattern would have allowed

## Implementation Details
The new pattern `^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$` provides better email validation by:
- Being more specific about allowed characters in each part of the email address
- Ensuring a proper domain structure with a valid TLD
- Reducing false positives from the previous overly-permissive pattern

https://claude.ai/code/session_01MbRV7BdDUbvDbNuaTeQrBn