### PR TITLE
Refactor navigation structure to conditionally wrap views

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -4,21 +4,25 @@ struct RootView: View {
     @EnvironmentObject var session: SessionManager
 
     var body: some View {
-        NavigationStack {
+        Group {
             if !session.isAuthenticated {
-                LoginView()
+                NavigationStack {
+                    LoginView()
+                }
             } else {
-                switch session.accessState {
-                case .unknown, .checking:
-                    ProgressView("Checking account status...")
-                        .foregroundStyle(AppTheme.textPrimary)
-                case .allowed:
-                    DashboardView()
-                case .blocked(let message):
-                    if session.appMode == .cloud {
-                        SubscriptionPaywallView(message: message)
-                    } else {
+                NavigationStack {
+                    switch session.accessState {
+                    case .unknown, .checking:
+                        ProgressView("Checking account status...")
+                            .foregroundStyle(AppTheme.textPrimary)
+                    case .allowed:
                         DashboardView()
+                    case .blocked(let message):
+                        if session.appMode == .cloud {
+                            SubscriptionPaywallView(message: message)
+                        } else {
+                            DashboardView()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Restructured the root navigation hierarchy to conditionally apply `NavigationStack` based on authentication state, rather than wrapping all views in a single navigation stack.

## Key Changes
- Replaced single outer `NavigationStack` with a `Group` container
- Moved `NavigationStack` inside the authenticated branch to wrap the access state logic
- Added `NavigationStack` wrapper around `LoginView` in the unauthenticated branch
- Consolidated the access state switch statement within the authenticated `NavigationStack`

## Implementation Details
This change improves the navigation architecture by:
- Ensuring each authentication state has its own independent navigation context
- Preventing potential navigation state conflicts between login and authenticated flows
- Maintaining clearer separation of concerns between unauthenticated and authenticated navigation hierarchies

https://claude.ai/code/session_01JwgmJfF9qRgY8L1FvEh1pM