### PR TITLE
Simplify email validation regex pattern

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -134,7 +134,7 @@ final class StoreKitSubscriptionManager: ObservableObject {
     }
 
     private static func isValidEmail(_ email: String) -> Bool {
-        let pattern = #"^[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}$"#
+        let pattern = #"^[^\s@]+@[^\s@]+\.[^\s@]+$"#
         return email.range(of: pattern, options: .regularExpression) != nil
     }
 


### PR DESCRIPTION
## Summary
Updated the email validation regex pattern in `StoreKitSubscriptionManager` to use a simpler and more permissive approach.

## Changes
- Replaced the complex email validation regex with a simplified pattern that checks for:
  - At least one non-whitespace, non-@ character before the @ symbol
  - At least one non-whitespace, non-@ character after the @ symbol
  - At least one non-whitespace, non-@ character after the final dot

## Details
The new pattern `^[^\s@]+@[^\s@]+\.[^\s@]+$` is more lenient than the previous one, which had strict character class restrictions. This change:
- Reduces regex complexity and improves readability
- Accepts a broader range of valid email formats
- Maintains basic email structure validation (local@domain.extension)
- May accept some technically invalid email addresses, but prioritizes user experience over strict RFC compliance

https://claude.ai/code/session_01A6XAsL8Wgn6kRGBa7R2ZAM