### PR TITLE
Hide duplicate balance details in getemail logs

### DIFF
--- a/app/getemail.py
+++ b/app/getemail.py
@@ -261,10 +261,8 @@ def process_email_balances():
 
                 if existing_balance:
                     logger.info(
-                        "Duplicate balance ignored for user %s (date=%s, amount=%s)",
+                        "Duplicate balance ignored for user %s",
                         user_id,
-                        balance_date.isoformat(),
-                        f"{new_balance:.2f}",
                     )
                 else:
                     # Insert balance WITH user_id using SQLAlchemy ORM


### PR DESCRIPTION
### Motivation
- Prevent writing sensitive financial details (balance date and amount) to logs when duplicate balances are detected.

### Description
- Update `app/getemail.py` to change the duplicate-balance log call to `logger.info("Duplicate balance ignored for user %s", user_id)` so the date and amount are no longer recorded.

### Testing
- Ran `python -m pytest -q` and all tests passed (`270 passed, 48 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eccf0b70a4832095bfe1394f25da6c)