### PR TITLE
Harden self‑hosted URL validation, secure token storage, and networking; restrict passkey domain

### DIFF
--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -45,7 +45,9 @@ The iOS app supports **Apple App Store** purchase flow only. Stripe is intention
 These values are hardcoded in `PyCashFlowApp/Core/Config/Config.swift`:
 
 - `API_BASE_URL` => `https://app.pycashflow.com/api/v1`
-- `SELF_HOSTED_API_BASE_URL` => `https://localhost:5000`
-- `APP_STORE_PRODUCT_IDS` => empty string for now
+- `SELF_HOSTED_API_BASE_URL` => `http://127.0.0.1:5000/api/v1`
+- `APP_STORE_PRODUCT_IDS` => `com.h3consultingpartners.pycashflow.cloud.monthly`
 
 `APIClient` normalizes base URLs so host-only values automatically use `/api/v1`.
+For security, remote self-hosted servers must use HTTPS. Plain HTTP is only
+allowed for localhost development endpoints.

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -51,8 +51,6 @@ final class SessionManager: ObservableObject {
         self.user = user
         if TokenKeychainStore.saveToken(token) {
             UserDefaults.standard.removeObject(forKey: "api_token")
-        } else {
-            UserDefaults.standard.set(token, forKey: "api_token")
         }
     }
 
@@ -116,7 +114,7 @@ final class SessionManager: ObservableObject {
     @discardableResult
     func updateSelfHostedBaseURL(_ value: String) -> Bool {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let parsed = URL(string: trimmed), parsed.scheme != nil, parsed.host != nil else {
+        guard let parsed = Self.validatedSelfHostedURL(from: trimmed) else {
             return false
         }
         let canonical = Self.canonicalizedHostedURL(parsed)
@@ -147,9 +145,7 @@ final class SessionManager: ObservableObject {
 
     private static func loadSelfHostedURL() -> URL {
         if let raw = UserDefaults.standard.string(forKey: selfHostedURLKey),
-           let url = URL(string: raw),
-           url.scheme != nil,
-           url.host != nil {
+           let url = validatedSelfHostedURL(from: raw) {
             let canonical = canonicalizedHostedURL(url)
             if canonical != url {
                 UserDefaults.standard.set(canonical.absoluteString, forKey: selfHostedURLKey)
@@ -157,6 +153,26 @@ final class SessionManager: ObservableObject {
             return canonical
         }
         return AppEnvironment.defaultSelfHostedAPIBaseURL
+    }
+
+    private static func validatedSelfHostedURL(from raw: String) -> URL? {
+        guard let parsed = URL(string: raw), parsed.scheme != nil, parsed.host != nil else {
+            return nil
+        }
+        guard let scheme = parsed.scheme?.lowercased() else {
+            return nil
+        }
+        if scheme == "https" {
+            return parsed
+        }
+        if scheme == "http", let host = parsed.host?.lowercased(), isAllowedInsecureHost(host) {
+            return parsed
+        }
+        return nil
+    }
+
+    private static func isAllowedInsecureHost(_ host: String) -> Bool {
+        host == "localhost" || host == "127.0.0.1" || host == "::1"
     }
 
     private static func canonicalizedHostedURL(_ url: URL) -> URL {
@@ -180,7 +196,8 @@ private enum TokenKeychainStore {
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecValueData as String: data
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
         let addStatus = SecItemAdd(query as CFDictionary, nil)
         if addStatus == errSecSuccess {
@@ -218,8 +235,9 @@ private enum TokenKeychainStore {
 
         if saveToken(legacyToken) {
             defaults.removeObject(forKey: account)
+            return legacyToken
         }
-        return legacyToken
+        return nil
     }
 
     private static func readToken() -> String? {

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -4,6 +4,12 @@ final class APIClient {
     static let shared = APIClient()
 
     var baseURL: URL = AppEnvironment.cloudAPIBaseURL
+    private let session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral
+        config.requestCachePolicy = .reloadIgnoringLocalCacheData
+        config.urlCache = nil
+        return URLSession(configuration: config)
+    }()
 
     func request<T: Decodable>(
         _ path: String,
@@ -40,7 +46,7 @@ final class APIClient {
         let data: Data
         let response: URLResponse
         do {
-            (data, response) = try await URLSession.shared.data(for: request)
+            (data, response) = try await session.data(for: request)
         } catch {
             let urlError = error as? URLError
             throw APIErrorEnvelope(

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -129,14 +129,14 @@ struct LoginView: View {
                             .padding(12)
                             .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
                             .foregroundStyle(AppTheme.textPrimary)
-                        Text("For local dev use http://127.0.0.1:5000/api/v1 (not https).")
+                        Text("Use HTTPS for remote servers. HTTP is allowed only for localhost/127.0.0.1 during local development.")
                             .font(.caption)
                             .foregroundStyle(AppTheme.textMuted)
                         Button("Save Server URL") {
                             dismissKeyboard()
                             focusedField = nil
                             if !session.updateSelfHostedBaseURL(selfHostedURL) {
-                                selfHostedErrorText = "Please enter a valid URL, including /api/v1."
+                                selfHostedErrorText = "Enter a valid server URL. Use HTTPS for remote hosts; HTTP is only allowed for localhost."
                             } else {
                                 selfHostedErrorText = nil
                             }
@@ -274,6 +274,13 @@ struct LoginView: View {
         guard !rpId.isEmpty else {
             authErrorText = "Passkey sign-in is not available for this server"
             return
+        }
+        if session.appMode == .cloud {
+            let expectedCloudRPID = AppEnvironment.cloudAPIBaseURL.host?.lowercased() ?? ""
+            if rpId.lowercased() != expectedCloudRPID {
+                authErrorText = "Passkey sign-in is unavailable due to an unexpected cloud security domain."
+                return
+            }
         }
 
         let allowedCredentialIDs: [Data] = (optionsResponse.options.allowCredentials ?? [])


### PR DESCRIPTION
### Motivation
- Harden self-hosted server configuration by requiring HTTPS for remote hosts while allowing HTTP only for localhost development.  
- Improve token security by preferring Keychain storage and removing fallback to insecure `UserDefaults`.  
- Improve networking reliability and security and ensure passkey sign-in is only allowed for the expected cloud security domain in cloud mode.

### Description
- Update `ios-app/README.md` defaults to use `http://127.0.0.1:5000/api/v1` for local self-hosted development, set `APP_STORE_PRODUCT_IDS`, and add guidance requiring HTTPS for remote servers.  
- Add `validatedSelfHostedURL(from:)` and `isAllowedInsecureHost` in `SessionManager.swift` and use them in `updateSelfHostedBaseURL` and `loadSelfHostedURL` to enforce scheme/host rules and canonicalization.  
- Remove the fallback save to `UserDefaults` in `setSession`, add `kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly` to the Keychain save query, and only return a migrated legacy token when migration to Keychain succeeds.  
- Replace `URLSession.shared` usage with a dedicated ephemeral `URLSession` instance in `APIClient` to disable caching and improve request isolation.  
- In `LoginView`, tighten passkey login by rejecting assertions when `session.appMode == .cloud` and the server `rpId` does not match the expected cloud host.

### Testing
- Performed an Xcode build of the iOS target which completed successfully.  
- Ran the existing unit test suite in Xcode and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed255efaf083209bbc34e742c213d9)