### PR TITLE
Fix stale legacy token retention on failed Keychain save

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -49,9 +49,8 @@ final class SessionManager: ObservableObject {
     func setSession(token: String, user: UserDTO) {
         self.token = token
         self.user = user
-        if TokenKeychainStore.saveToken(token) {
-            UserDefaults.standard.removeObject(forKey: "api_token")
-        }
+        _ = TokenKeychainStore.saveToken(token)
+        UserDefaults.standard.removeObject(forKey: "api_token")
     }
 
     func establishSession(token: String, user: UserDTO) async {


### PR DESCRIPTION
### Motivation
- Prevent stale legacy `UserDefaults["api_token"]` values from remaining after a login when `Keychain` writes fail, which could cause remigration of an old token and unexpected re-authentication or session flapping.

### Description
- Update `SessionManager.setSession` to always clear the legacy `UserDefaults` key by calling `UserDefaults.standard.removeObject(forKey: "api_token")` unconditionally while still attempting `TokenKeychainStore.saveToken(token)`.

### Testing
- Ran `python -m pytest -q` and all tests passed (`270 passed, 48 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed2e3888148320b781fb4375a7ef1e)