### PR TITLE
iOS: collapse change password fields behind a toggle

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -6,6 +6,7 @@ struct SettingsView: View {
     @State private var currentPassword = ""
     @State private var newPassword = ""
     @State private var errorText: String?
+    @State private var showPasswordFields = false
 
     var body: some View {
         ScrollView {
@@ -30,11 +31,17 @@ struct SettingsView: View {
                 }
 
                 VStack(spacing: 8) {
-                    Text("Change Password").foregroundStyle(AppTheme.textPrimary)
-                    SecureField("Current password", text: $currentPassword).fieldStyle()
-                    SecureField("New password", text: $newPassword).fieldStyle()
-                    Button("Update Password") { Task { await changePassword() } }
-                        .buttonStyle(PrimaryButtonStyle())
+                    Button("Change Password") {
+                        withAnimation { showPasswordFields.toggle() }
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+
+                    if showPasswordFields {
+                        SecureField("Current password", text: $currentPassword).fieldStyle()
+                        SecureField("New password", text: $newPassword).fieldStyle()
+                        Button("Update Password") { Task { await changePassword() } }
+                            .buttonStyle(PrimaryButtonStyle())
+                    }
                 }
                 .surfaceCard()
 


### PR DESCRIPTION
Hide the current/new password fields by default in Settings; tapping the
Change Password button expands them along with the Update Password action.