### PR TITLE
iOS: format AI Insights last updated date in user's local time

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
@@ -14,7 +14,7 @@ struct AIInsightsView: View {
                         infoRow(label: "Model", value: model)
                     }
                     if let lastUpdated = insights.last_updated, !lastUpdated.isEmpty {
-                        infoRow(label: "Last Updated", value: lastUpdated)
+                        infoRow(label: "Last Updated", value: Self.formatLastUpdated(lastUpdated))
                     }
                     infoRow(label: "AI Configured", value: insights.configured ? "Yes" : "No")
                 }
@@ -98,6 +98,27 @@ struct AIInsightsView: View {
         } catch {
             errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to load insights"
         }
+    }
+
+    private static let lastUpdatedParser: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let lastUpdatedDisplayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.doesRelativeDateFormatting = true
+        formatter.locale = .autoupdatingCurrent
+        formatter.timeZone = .autoupdatingCurrent
+        return formatter
+    }()
+
+    static func formatLastUpdated(_ raw: String) -> String {
+        guard let date = lastUpdatedParser.date(from: raw) else { return raw }
+        return lastUpdatedDisplayFormatter.string(from: date)
     }
 
     private func refreshInsights() async {


### PR DESCRIPTION
Parse the UTC ISO 8601 timestamp returned by the insights API and render
it with a localized medium date / short time style that respects the
user's locale, time zone, and "Today/Yesterday" relative formatting,
instead of showing the raw UTC string.