### PR TITLE
Simplify subscription paywall view

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -17,9 +17,9 @@ struct RootView: View {
                             .foregroundStyle(AppTheme.textPrimary)
                     case .allowed:
                         DashboardView()
-                    case .blocked(let message):
+                    case .blocked:
                         if session.appMode == .cloud {
-                            SubscriptionPaywallView(message: message)
+                            SubscriptionPaywallView()
                         } else {
                             DashboardView()
                         }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -155,7 +155,7 @@ struct LoginView: View {
                         Text("Using PyCashFlow Cloud hosted service.")
                             .foregroundStyle(AppTheme.textSecondary)
                         NavigationLink("Activate or Restore Cloud Subscription") {
-                            SubscriptionPaywallView(message: "Use App Store subscription to activate or restore your hosted PyCashFlow Cloud account.")
+                            SubscriptionPaywallView()
                         }
                         .buttonStyle(PrimaryButtonStyle())
                     }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -6,8 +6,6 @@ struct SubscriptionPaywallView: View {
     @StateObject private var manager = StoreKitSubscriptionManager()
     @State private var cloudEmail = ""
 
-    let message: String
-
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
@@ -15,11 +13,7 @@ struct SubscriptionPaywallView: View {
                     .font(.title.bold())
                     .foregroundStyle(AppTheme.textPrimary)
 
-                Text("App Store subscription is only for PyCashFlow Cloud account activation and maintenance.")
-                    .foregroundStyle(AppTheme.textSecondary)
-                    .cardRow()
-
-                Text(message)
+                Text("App Store subscription is only for PyCashFlow Cloud account activation.")
                     .foregroundStyle(AppTheme.textSecondary)
                     .cardRow()
 
@@ -88,12 +82,6 @@ struct SubscriptionPaywallView: View {
                 .buttonStyle(PrimaryButtonStyle())
                 .disabled(manager.isBusy)
 
-                Button("Re-check Account Status") {
-                    Task { await session.refreshSubscriptionState(forceProfileRefresh: true) }
-                }
-                .buttonStyle(PrimaryButtonStyle())
-                .disabled(manager.isBusy)
-
                 if let statusMessage = manager.statusMessage {
                     Text(statusMessage)
                         .foregroundStyle(AppTheme.textSecondary)
@@ -107,16 +95,6 @@ struct SubscriptionPaywallView: View {
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .fixedSize(horizontal: false, vertical: true)
                 }
-
-                Button("Logout", role: .destructive) {
-                    session.clear()
-                }
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button("Switch to Self-Hosted Mode") {
-                    session.switchMode(.selfHosted)
-                }
-                .buttonStyle(PrimaryButtonStyle())
             }
             .padding(20)
         }


### PR DESCRIPTION
Removes the redundant secondary message card, drops "and maintenance"
from the activation copy, and removes the Re-check Account Status,
Logout, and Switch to Self-Hosted Mode buttons.

https://claude.ai/code/session_011j686gorir8grVY6tKP3BW