### PR TITLE
Fix App Store original transaction key to support sandbox auto fallback

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -143,6 +143,7 @@ def _verify_appstore_purchase(transaction_info: dict, receipt_data: str | None):
     original_transaction_id = (
         (transaction_info.get("original_transaction_id") or "").strip()
         or (transaction_info.get("originalTransactionId") or "").strip()
+        or (transaction_info.get("original_id") or "").strip()
     )
 
     if _appstore_stub_verification_enabled():

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/BillingAPI.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/BillingAPI.swift
@@ -3,7 +3,7 @@ import Foundation
 struct AppStoreVerificationPayload: Encodable {
     struct TransactionPayload: Encodable {
         let id: String
-        let original_id: String
+        let original_transaction_id: String
         let product_id: String
         let purchase_date: String
         let expiry_date: String?

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -104,7 +104,7 @@ final class StoreKitSubscriptionManager: ObservableObject {
             expiry_date: expiryISO,
             transaction: .init(
                 id: String(transaction.id),
-                original_id: String(transaction.originalID),
+                original_transaction_id: String(transaction.originalID),
                 product_id: transaction.productID,
                 purchase_date: Self.isoDate(transaction.purchaseDate),
                 expiry_date: expiryISO,

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -142,6 +142,29 @@ def test_appstore_verification_stub_mode_can_activate_owner(flask_app, client):
         assert user.is_active is True
 
 
+def test_appstore_verification_stub_mode_accepts_original_id_alias(flask_app, client):
+    with flask_app.app_context():
+        flask_app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = True
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com"
+
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-stub-alias@test.local",
+            "receipt_data": "dummy-receipt",
+            "transaction": {"original_id": "ios_txn_alias_1"},
+        },
+    )
+    assert resp.status_code == 200
+    body = _json(resp)["data"]
+    assert body["verification_status"] == "verified_stub"
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="ios-stub-alias@test.local").first()
+        assert user is not None
+        assert user.subscription_id == "ios_txn_alias_1"
+
+
 def test_appstore_existing_user_subscription_update_no_duplicate(
     flask_app, client, monkeypatch, billing_routes_module
 ):


### PR DESCRIPTION
### Motivation
- `APPLE_ENVIRONMENT=auto` already tries production then sandbox, so the auto mode itself was not failing.  
- The iOS client sent `transaction.original_id` while the backend expected `transaction.original_transaction_id`/`originalTransactionId`, causing verification to miss the original transaction id and fail before environment fallback could occur.  
- Restore compatibility with older iOS payloads so sandbox fallback and local stub verification do not break.

### Description
- Update the iOS payload shape to send `transaction.original_transaction_id` from the StoreKit manager and the Billing API payload struct (files: `StoreKitSubscriptionManager.swift`, `BillingAPI.swift`).  
- Make the backend tolerant of the legacy alias by accepting `transaction.original_id` as a fallback when extracting the original transaction id (file: `app/api/routes/billing.py`).  
- Add a regression test to ensure stub-mode App Store verification accepts the `original_id` alias (file: `tests/test_billing.py`).

### Testing
- Ran `python -m pytest -q tests/test_billing.py -k appstore` and observed `9 passed, 17 deselected`, indicating billing-related tests for App Store flows passed.  
- Ran `python -m pytest -q tests/test_appstore_verification.py` and observed `2 passed`, indicating unit tests for production/sandbox fallback behavior passed.  
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3936cf248320adfc0752155a4ce1)