### PR TITLE
Guard App Store original_id alias against non-string payloads

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -140,17 +140,21 @@ def _verify_appstore_purchase(transaction_info: dict, receipt_data: str | None):
 
     Stub verification can be enabled for local development/testing only.
     """
+    def _strip_if_string(value) -> str:
+        return value.strip() if isinstance(value, str) else ""
+
     original_transaction_id = (
-        (transaction_info.get("original_transaction_id") or "").strip()
-        or (transaction_info.get("originalTransactionId") or "").strip()
-        or (transaction_info.get("original_id") or "").strip()
+        _strip_if_string(transaction_info.get("original_transaction_id"))
+        or _strip_if_string(transaction_info.get("originalTransactionId"))
+        or _strip_if_string(transaction_info.get("original_id"))
     )
 
     if _appstore_stub_verification_enabled():
         if not original_transaction_id:
             original_transaction_id = (
-                (transaction_info.get("id") or "").strip()
-                or (receipt_data or "stub-receipt").strip()
+                _strip_if_string(transaction_info.get("id"))
+                or _strip_if_string(receipt_data)
+                or "stub-receipt"
             )
         if not original_transaction_id:
             raise AppStoreVerificationError("missing original transaction id")

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -165,6 +165,29 @@ def test_appstore_verification_stub_mode_accepts_original_id_alias(flask_app, cl
         assert user.subscription_id == "ios_txn_alias_1"
 
 
+def test_appstore_verification_stub_mode_rejects_non_string_original_id(flask_app, client):
+    with flask_app.app_context():
+        flask_app.config["APPSTORE_ALLOW_STUB_VERIFICATION"] = True
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com"
+
+    resp = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-stub-alias-nonstr@test.local",
+            "receipt_data": "dummy-receipt",
+            "transaction": {"original_id": 123},
+        },
+    )
+    assert resp.status_code == 200
+    body = _json(resp)["data"]
+    assert body["verification_status"] == "verified_stub"
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="ios-stub-alias-nonstr@test.local").first()
+        assert user is not None
+        assert user.subscription_id == "dummy-receipt"
+
+
 def test_appstore_existing_user_subscription_update_no_duplicate(
     flask_app, client, monkeypatch, billing_routes_module
 ):


### PR DESCRIPTION
### Motivation

- Prevent unhandled `AttributeError`/500 when `transaction.original_id` (or other transaction alias fields) is provided as a non-string in `/api/v1/billing/verify-appstore` by making the normalization robust to non-string payloads.

### Description

- Add a local helper ` _strip_if_string` inside `_verify_appstore_purchase` and use it to safely normalize `original_transaction_id`, `transaction.id`, and `receipt_data` so `.strip()` is only called on strings.
- Preserve existing stub verification fallback behavior by falling back to `transaction.id`, `receipt_data`, or the literal `"stub-receipt"` when appropriate.
- Add `test_appstore_verification_stub_mode_rejects_non_string_original_id` to `tests/test_billing.py` to cover the regression where `transaction.original_id` is an integer and verify the endpoint still succeeds in stub mode and uses `receipt_data` as the subscription id.

### Testing

- Ran `python -m pytest -q tests/test_billing.py` and the suite completed successfully with `27 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed3b4211a88320a0f49b3dc111983f)