### PR TITLE
Normalize subscriptions into a dedicated Subscription table and enforce Apple ownership

### DIFF
--- a/MOBILE_API_REFERENCE.md
+++ b/MOBILE_API_REFERENCE.md
@@ -959,6 +959,19 @@ Additional behavior updates:
 
 ## 2026-04-10 Payments Update
 
+## 2026-04-25 Subscription Ownership Update
+
+Backend subscription ownership is now normalized in a dedicated `subscription`
+table. Existing user-facing API fields remain backward-compatible.
+
+### Backend ownership rules
+
+- Apple lifecycle identity is `originalTransactionId`.
+- `transactionId` is tracked as latest transaction id separately.
+- One Apple lifecycle id cannot activate multiple owners in the same environment.
+- Sandbox and production are independent ownership namespaces.
+- Guests always inherit access from their account owner.
+
 ### User object additions
 
 `POST /api/v1/auth/login` and `GET /api/v1/auth/me` now include:
@@ -1025,6 +1038,10 @@ Server endpoint for iOS subscription verification against Apple App Store Server
 - `transaction.original_transaction_id` is required for real verification.
 - `APPLE_ENVIRONMENT=auto` enables production-first with sandbox fallback.
 - Response `data.environment` indicates which environment resolved the transaction.
+- Ownership is enforced by `(source=apple, environment, original_transaction_id)`:
+  - first verification creates an owner-linked subscription
+  - repeat verification by same owner is idempotent
+  - different owner with same lifecycle id is rejected
 - If verification fails, backend returns `401 unauthorized` and no account activation occurs.
 - Local development may opt into `APPSTORE_ALLOW_STUB_VERIFICATION=true` (non-production).
 
@@ -1054,6 +1071,15 @@ Server endpoint for iOS subscription verification against Apple App Store Server
   }
 }
 ```
+
+### Cancel / renew behavior
+
+- If Apple status becomes non-active, account becomes inactive when payments
+  enforcement is enabled.
+- Renewal on the same Apple lifecycle id updates expiry/latest transaction and
+  reactivates the same owner.
+- A new Apple lifecycle id for the same user creates an additional subscription
+  row; historical rows may remain expired/canceled.
 
 ### Access enforcement
 

--- a/PAYMENTS.md
+++ b/PAYMENTS.md
@@ -8,9 +8,33 @@ PyCashFlow supports three activation sources:
 2. **Apple App Store subscriptions** (server-side verification via App Store Server API JWT auth)
 3. **Self-hosted/manual** activation when `PAYMENTS_ENABLED=false`
 
-All subscription state is stored on `User` and enforced centrally for both web and API auth paths.
+Subscription truth is normalized into a dedicated `subscription` table and
+enforced centrally for both web and API auth paths. Legacy `User`
+subscription columns remain as compatibility mirrors during transition.
 
-## User Subscription Fields
+## Subscription Table (Source of Truth)
+
+- `user_id` (owner `user.id`, non-null)
+- `source` (`apple | stripe | manual`)
+- `environment` (`production | sandbox | null/manual`)
+- `product_id` (provider product SKU/id)
+- `original_transaction_id` (Apple lifecycle identity)
+- `latest_transaction_id` (latest Apple transaction id)
+- `external_subscription_id` (Stripe subscription id or provider id)
+- `status` (`active | trial | grace_period | expired | canceled | inactive`)
+- `expires_at`
+- `raw_last_verified_at`
+- `created_at`, `updated_at`
+
+### Uniqueness and ownership constraints
+
+- Apple ownership lock: unique (`source`, `environment`, `original_transaction_id`)
+- Stripe uniqueness: unique (`source`, `external_subscription_id`)
+
+This prevents one Apple original transaction lifecycle from activating more
+than one account owner in the same environment.
+
+## Legacy User Compatibility Fields
 
 - `subscription_status`: `active | inactive | trial | expired`
 - `subscription_source`: `stripe | app_store | manual | none`
@@ -57,9 +81,16 @@ Default behavior in this repository is `PAYMENTS_ENABLED=false`.
 - Supports `APPLE_ENVIRONMENT=production|sandbox|auto` (`auto` tries production then sandbox).
 - Optionally validates `APPLE_BUNDLE_ID` against Apple-signed transaction payload.
 - Applies subscription lifecycle transitions from Apple truth source:
-  - Active statuses (`1`, `3`, `4`) => `subscription_status=active`, `is_active=true`
-  - Non-active statuses => `subscription_status=expired`, `is_active=false`
-- Creates/updates account owner by email and stores source `app_store`.
+  - Active statuses (`1`, `3`, `4`) => `status=active`, owner active
+  - Non-active statuses => `status=expired`, owner inactive
+- Uses `originalTransactionId` as the Apple lifecycle identity.
+- Stores `transactionId` as `latest_transaction_id`.
+- Ownership enforcement:
+  - If no matching subscription exists, create one for the owner.
+  - If the same owner re-verifies, update idempotently.
+  - If another owner attempts same `originalTransactionId` + environment,
+    verification is rejected and no activation occurs.
+- Creates/updates account owner by email and mirrors source `app_store` on `User`.
 - For first-time paid users only, creates a one-time password setup token and
   sends an onboarding email. Existing users do not receive setup email.
 - Optional local/dev stub mode remains available with
@@ -94,6 +125,16 @@ updated silently and no password setup email is sent.
 
 Guest users inherit access from their owner (`owner_user_id` or legacy `account_owner_id`).
 If owner subscription expires (and payments are enabled), guests are denied and marked inactive.
+
+## Cancel / Expire / Resubscribe Behavior
+
+- Same user + same Apple `originalTransactionId`: update existing row and
+  reactivate when Apple status returns active.
+- Same user + new Apple `originalTransactionId`: create a new row; older rows
+  may remain expired/canceled for history.
+- Same Apple lifecycle id + different user: rejected by ownership rule.
+- Sandbox and production are treated separately by the `(source, environment, original_transaction_id)`
+  unique constraint.
 
 ## Admin Behavior
 

--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -11,10 +11,11 @@ import secrets
 from datetime import datetime, timezone
 
 from flask import current_app, request
+from sqlalchemy.exc import IntegrityError
 from werkzeug.security import generate_password_hash
 
 from app import db
-from app.models import User
+from app.models import Subscription, User
 from app.getemail import send_password_setup_email
 from app.password_setup import (
     create_password_setup_link,
@@ -27,6 +28,8 @@ from app.subscription import (
     SUB_ACTIVE,
     SUB_EXPIRED,
     apply_subscription_status,
+    get_effective_subscription,
+    upsert_subscription,
     owner_for_user,
     payments_enabled,
     subscription_is_current,
@@ -162,8 +165,10 @@ def _verify_appstore_purchase(transaction_info: dict, receipt_data: str | None):
             "verification_status": "verified_stub",
             "is_active": True,
             "expiry": None,
-            "subscription_id": original_transaction_id,
+            "original_transaction_id": original_transaction_id,
+            "latest_transaction_id": original_transaction_id,
             "environment": "stub",
+            "product_id": None,
         }
 
     if not original_transaction_id:
@@ -208,10 +213,12 @@ def _verify_appstore_purchase(transaction_info: dict, receipt_data: str | None):
         "verification_status": "verified",
         "is_active": verification.is_active,
         "expiry": verification.expiry,
-        "subscription_id": verification.original_transaction_id,
+        "original_transaction_id": verification.original_transaction_id,
+        "latest_transaction_id": verification.transaction_id,
         "environment": verification.environment,
         "status_code": verification.status_code,
         "bundle_id": verification.bundle_id,
+        "product_id": None,
     }
 
 
@@ -234,7 +241,16 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
             subscription_id=obj.get("subscription") or obj.get("id"),
             expiry=expiry,
             activate=True,
+            commit=False,
         )
+        upsert_subscription(
+            user,
+            source="stripe",
+            status=SUB_ACTIVE,
+            external_subscription_id=obj.get("subscription") or obj.get("id"),
+            expires_at=expiry,
+        )
+        db.session.commit()
         _send_setup_email_for_new_user(user, created)
         return api_ok({"processed": event_type, "user_id": user.id})
 
@@ -245,7 +261,14 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
         subscription_id = obj.get("id")
         user = None
         if subscription_id:
-            user = User.query.filter_by(subscription_id=subscription_id).first()
+            existing_subscription = Subscription.query.filter_by(
+                source="stripe",
+                external_subscription_id=subscription_id,
+            ).first()
+            if existing_subscription is not None:
+                user = db.session.get(User, existing_subscription.user_id)
+            if user is None:
+                user = User.query.filter_by(subscription_id=subscription_id).first()
         created = False
         if user is None and email:
             if not _can_create_paid_user(email):
@@ -277,7 +300,16 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
             subscription_id=subscription_id,
             expiry=expires_at,
             activate=activate,
+            commit=False,
         )
+        upsert_subscription(
+            user,
+            source="stripe",
+            status=next_status,
+            external_subscription_id=subscription_id,
+            expires_at=expires_at,
+        )
+        db.session.commit()
         _send_setup_email_for_new_user(user, created)
         return api_ok({"processed": event_type, "user_id": user.id})
 
@@ -288,6 +320,13 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
 
         user = User.query.filter_by(subscription_id=sub_id).first()
         if not user:
+            existing_subscription = Subscription.query.filter_by(
+                source="stripe",
+                external_subscription_id=sub_id,
+            ).first()
+            if existing_subscription is not None:
+                user = db.session.get(User, existing_subscription.user_id)
+        if not user:
             return api_ok({"processed": event_type, "ignored": True})
 
         apply_subscription_status(
@@ -297,7 +336,16 @@ def _apply_stripe_event(event_type: str, obj: dict) -> tuple[dict, int]:
             subscription_id=sub_id,
             expiry=datetime.now(timezone.utc).replace(tzinfo=None),
             activate=False,
+            commit=False,
         )
+        upsert_subscription(
+            user,
+            source="stripe",
+            status=SUB_EXPIRED,
+            external_subscription_id=sub_id,
+            expires_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+        db.session.commit()
         return api_ok({"processed": event_type, "user_id": user.id})
 
     return api_ok({"processed": event_type, "ignored": True})
@@ -356,7 +404,26 @@ def api_billing_status():
             effective_is_active = bool(user.is_active)
 
     subscription_subject = owner or user
-    expiry = subscription_subject.subscription_expiry
+    effective_subscription = get_effective_subscription(subscription_subject)
+    status = (
+        effective_subscription.status
+        if effective_subscription is not None
+        else subscription_subject.subscription_status
+    )
+    source = (
+        "app_store"
+        if effective_subscription is not None and effective_subscription.source == "apple"
+        else (
+            effective_subscription.source
+            if effective_subscription is not None
+            else subscription_subject.subscription_source
+        )
+    )
+    expiry = (
+        effective_subscription.expires_at
+        if effective_subscription is not None
+        else subscription_subject.subscription_expiry
+    )
     if expiry and expiry.tzinfo is None:
         expiry = expiry.replace(tzinfo=timezone.utc)
 
@@ -365,8 +432,8 @@ def api_billing_status():
             "user_id": user.id,
             "is_active": bool(user.is_active),
             "effective_is_active": effective_is_active,
-            "subscription_status": subscription_subject.subscription_status,
-            "subscription_source": subscription_subject.subscription_source,
+            "subscription_status": status,
+            "subscription_source": source,
             "subscription_expiry": expiry.strftime("%Y-%m-%dT%H:%M:%SZ") if expiry else None,
             "payments_enabled": payments_enabled(),
             "is_global_admin": bool(user.is_global_admin),
@@ -416,21 +483,74 @@ def api_verify_appstore():
     expiry = verification.get("expiry")
     is_active = bool(verification.get("is_active"))
     subscription_status = SUB_ACTIVE if is_active else SUB_EXPIRED
+    appstore_env = verification.get("environment")
+    original_txn_id = (verification.get("original_transaction_id") or "").strip() or None
+    latest_txn_id = (verification.get("latest_transaction_id") or "").strip() or None
 
     if not _can_create_paid_user(email):
         return validation_error(
             {"frontend_base_url": "FRONTEND_BASE_URL is required to onboard new paid users"}
         )
 
+    existing_subscription = None
+    if original_txn_id:
+        existing_subscription = Subscription.query.filter_by(
+            source="apple",
+            environment=appstore_env,
+            original_transaction_id=original_txn_id,
+        ).first()
+        if existing_subscription is not None:
+            existing_owner = db.session.get(User, existing_subscription.user_id)
+            if existing_owner is None or existing_owner.email != email:
+                logger.warning(
+                    "App Store original transaction ownership conflict original_txn=%s env=%s email=%s owner_id=%s",
+                    original_txn_id,
+                    appstore_env,
+                    email,
+                    existing_subscription.user_id,
+                )
+                return unauthorized(
+                    "App Store subscription is already linked to another account"
+                )
+
     user, created = _create_or_get_owner(email)
+    if existing_subscription is not None and existing_subscription.user_id != user.id:
+            logger.warning(
+                "App Store original transaction ownership conflict original_txn=%s env=%s user_id=%s owner_id=%s",
+                original_txn_id,
+                appstore_env,
+                user.id,
+                existing_subscription.user_id,
+            )
+            return unauthorized(
+                "App Store subscription is already linked to another account"
+            )
+
     apply_subscription_status(
         user,
         status=subscription_status,
-        source="app_store",
-        subscription_id=verification.get("subscription_id"),
+        source="apple",
+        subscription_id=original_txn_id,
         expiry=expiry,
         activate=is_active,
+        commit=False,
     )
+    try:
+        upsert_subscription(
+            user,
+            source="apple",
+            status=subscription_status,
+            environment=appstore_env,
+            product_id=verification.get("product_id"),
+            original_transaction_id=original_txn_id,
+            latest_transaction_id=latest_txn_id,
+            expires_at=expiry,
+            raw_last_verified_at=datetime.now(timezone.utc).replace(tzinfo=None),
+        )
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+        return unauthorized("App Store subscription is already linked to another account")
     _send_setup_email_for_new_user(user, created)
 
     return api_ok(

--- a/app/models.py
+++ b/app/models.py
@@ -34,6 +34,25 @@ class User(UserMixin, db.Model):
         foreign_keys='User.account_owner_id',
         backref=db.backref('account_owner', remote_side=[id]),
     )
+    subscriptions = db.relationship(
+        'Subscription',
+        back_populates='user',
+        cascade='all, delete-orphan',
+        lazy='dynamic',
+    )
+
+    @property
+    def active_subscription(self):
+        """Return the most recent currently-active subscription, if any."""
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        return (
+            self.subscriptions.filter(
+                Subscription.status.in_(["active", "trial", "grace_period"]),
+                db.or_(Subscription.expires_at.is_(None), Subscription.expires_at >= now),
+            )
+            .order_by(Subscription.updated_at.desc(), Subscription.id.desc())
+            .first()
+        )
 
     # Constraints
     __table_args__ = (
@@ -230,3 +249,51 @@ class PasswordSetupToken(db.Model):
 
     # Relationships
     user = db.relationship('User', backref='password_setup_tokens')
+
+
+class Subscription(db.Model):
+    """Normalized provider subscription state tied to account owner users."""
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False, index=True)
+    source = db.Column(db.String(20), nullable=False)
+    environment = db.Column(db.String(20), nullable=True)
+    product_id = db.Column(db.String(255), nullable=True)
+    original_transaction_id = db.Column(db.String(255), nullable=True)
+    latest_transaction_id = db.Column(db.String(255), nullable=True)
+    external_subscription_id = db.Column(db.String(255), nullable=True)
+    status = db.Column(
+        db.String(20),
+        nullable=False,
+        default='inactive',
+        server_default='inactive',
+    )
+    expires_at = db.Column(db.DateTime, nullable=True)
+    raw_last_verified_at = db.Column(db.DateTime, nullable=True)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+    updated_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+        onupdate=lambda: datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+    user = db.relationship('User', back_populates='subscriptions')
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            'source',
+            'environment',
+            'original_transaction_id',
+            name='uq_subscription_apple_original',
+        ),
+        db.UniqueConstraint(
+            'source',
+            'external_subscription_id',
+            name='uq_subscription_external_source_id',
+        ),
+    )

--- a/app/subscription.py
+++ b/app/subscription.py
@@ -12,7 +12,7 @@ import logging
 from flask import current_app
 
 from app import db
-from app.models import User
+from app.models import Subscription, User
 
 
 logger = logging.getLogger(__name__)
@@ -20,10 +20,20 @@ logger = logging.getLogger(__name__)
 SUB_ACTIVE = "active"
 SUB_INACTIVE = "inactive"
 SUB_TRIAL = "trial"
+SUB_GRACE_PERIOD = "grace_period"
 SUB_EXPIRED = "expired"
+SUB_CANCELED = "canceled"
 
 
-VALID_SUBSCRIPTION_STATUSES = {SUB_ACTIVE, SUB_INACTIVE, SUB_TRIAL, SUB_EXPIRED}
+VALID_SUBSCRIPTION_STATUSES = {
+    SUB_ACTIVE,
+    SUB_INACTIVE,
+    SUB_TRIAL,
+    SUB_GRACE_PERIOD,
+    SUB_EXPIRED,
+    SUB_CANCELED,
+}
+ACTIVE_SUBSCRIPTION_STATUSES = {SUB_ACTIVE, SUB_TRIAL, SUB_GRACE_PERIOD}
 
 
 def payments_enabled() -> bool:
@@ -46,15 +56,129 @@ def subscription_is_current(user: User | None) -> bool:
     """Return True when user subscription status/expiry is currently valid."""
     if user is None:
         return False
-    if user.subscription_status not in {SUB_ACTIVE, SUB_TRIAL}:
+    subscription = get_effective_subscription(user)
+    if subscription is None:
         return False
-    if user.subscription_expiry is None:
+    if subscription.status not in ACTIVE_SUBSCRIPTION_STATUSES:
+        return False
+    if subscription.expires_at is None:
         return True
 
-    expiry = user.subscription_expiry
+    expiry = subscription.expires_at
     if expiry.tzinfo is None:
         expiry = expiry.replace(tzinfo=timezone.utc)
     return expiry >= datetime.now(timezone.utc)
+
+
+def get_effective_subscription(user: User | None) -> Subscription | None:
+    """Return a user's most recently-updated subscription record, if present."""
+    if user is None:
+        return None
+
+    latest_active = (
+        Subscription.query.filter_by(user_id=user.id)
+        .filter(Subscription.status.in_(tuple(ACTIVE_SUBSCRIPTION_STATUSES)))
+        .order_by(Subscription.expires_at.desc(), Subscription.updated_at.desc())
+        .first()
+    )
+    if latest_active is not None:
+        return latest_active
+
+    latest = (
+        Subscription.query.filter_by(user_id=user.id)
+        .order_by(Subscription.updated_at.desc(), Subscription.id.desc())
+        .first()
+    )
+    if latest is not None:
+        return latest
+    return _legacy_user_subscription(user)
+
+
+def _legacy_user_subscription(user: User) -> Subscription | None:
+    """Build a transient subscription view from legacy user columns."""
+    if not user.subscription_source or user.subscription_source == "none":
+        return None
+    return Subscription(
+        user_id=user.id,
+        source=_canonical_source(user.subscription_source),
+        status=user.subscription_status or SUB_INACTIVE,
+        external_subscription_id=user.subscription_id if user.subscription_source == "stripe" else None,
+        original_transaction_id=user.subscription_id if user.subscription_source == "app_store" else None,
+        latest_transaction_id=user.subscription_id if user.subscription_source == "app_store" else None,
+        expires_at=user.subscription_expiry,
+    )
+
+
+def _canonical_source(source: str) -> str:
+    source = (source or "").strip().lower()
+    if source in {"app_store", "apple"}:
+        return "apple"
+    return source or "manual"
+
+
+def _legacy_source(source: str) -> str:
+    if source == "apple":
+        return "app_store"
+    return source
+
+
+def upsert_subscription(
+    user: User,
+    *,
+    source: str,
+    status: str,
+    environment: str | None = None,
+    product_id: str | None = None,
+    original_transaction_id: str | None = None,
+    latest_transaction_id: str | None = None,
+    external_subscription_id: str | None = None,
+    expires_at: datetime | None = None,
+    raw_last_verified_at: datetime | None = None,
+) -> Subscription:
+    """Create or update a provider subscription for a user."""
+    canonical_source = _canonical_source(source)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    raw_last_verified_at = raw_last_verified_at or now
+    if status not in VALID_SUBSCRIPTION_STATUSES:
+        raise ValueError(f"Invalid subscription status: {status}")
+
+    query = Subscription.query.filter_by(user_id=user.id, source=canonical_source)
+    if canonical_source == "apple" and original_transaction_id:
+        query = query.filter_by(
+            environment=environment,
+            original_transaction_id=original_transaction_id,
+        )
+    elif canonical_source == "stripe" and external_subscription_id:
+        query = query.filter_by(external_subscription_id=external_subscription_id)
+
+    subscription = query.order_by(Subscription.id.desc()).first()
+    if subscription is None:
+        subscription = Subscription(
+            user_id=user.id,
+            source=canonical_source,
+            environment=environment,
+            product_id=product_id,
+            original_transaction_id=original_transaction_id,
+            latest_transaction_id=latest_transaction_id,
+            external_subscription_id=external_subscription_id,
+            status=status,
+            expires_at=expires_at,
+            raw_last_verified_at=raw_last_verified_at,
+        )
+    else:
+        subscription.environment = environment
+        subscription.product_id = product_id
+        subscription.original_transaction_id = original_transaction_id or subscription.original_transaction_id
+        subscription.latest_transaction_id = latest_transaction_id or subscription.latest_transaction_id
+        subscription.external_subscription_id = external_subscription_id or subscription.external_subscription_id
+        subscription.status = status
+        subscription.expires_at = expires_at
+        subscription.raw_last_verified_at = raw_last_verified_at
+        subscription.updated_at = now
+
+    db.session.add(subscription)
+    db.session.flush()
+    return subscription
 
 
 def _expire_user(user: User) -> bool:
@@ -77,6 +201,7 @@ def apply_subscription_status(
     subscription_id: str | None = None,
     expiry: datetime | None = None,
     activate: bool = True,
+    commit: bool = True,
 ) -> None:
     """Apply a subscription mutation and persist audit log entry."""
     old_status = user.subscription_status
@@ -86,7 +211,7 @@ def apply_subscription_status(
         raise ValueError(f"Invalid subscription status: {status}")
 
     user.subscription_status = status
-    user.subscription_source = source
+    user.subscription_source = _legacy_source(_canonical_source(source))
     user.subscription_id = subscription_id
     user.subscription_expiry = expiry
     user.is_account_owner = True
@@ -102,7 +227,8 @@ def apply_subscription_status(
         user.is_active = False
 
     db.session.add(user)
-    db.session.commit()
+    if commit:
+        db.session.commit()
     logger.info(
         "Subscription change user_id=%s status=%s->%s active=%s->%s source=%s sub_id=%s expiry=%s",
         user.id,

--- a/migrations/versions/92d6f98b8d33_add_subscriptions_table.py
+++ b/migrations/versions/92d6f98b8d33_add_subscriptions_table.py
@@ -1,0 +1,145 @@
+"""add subscriptions table
+
+Revision ID: 92d6f98b8d33
+Revises: b3c4d5e6f7a8
+Create Date: 2026-04-25 23:58:09.112622
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from datetime import datetime
+
+
+# revision identifiers, used by Alembic.
+revision = '92d6f98b8d33'
+down_revision = 'b3c4d5e6f7a8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table('subscription',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('user_id', sa.Integer(), nullable=False),
+    sa.Column('source', sa.String(length=20), nullable=False),
+    sa.Column('environment', sa.String(length=20), nullable=True),
+    sa.Column('product_id', sa.String(length=255), nullable=True),
+    sa.Column('original_transaction_id', sa.String(length=255), nullable=True),
+    sa.Column('latest_transaction_id', sa.String(length=255), nullable=True),
+    sa.Column('external_subscription_id', sa.String(length=255), nullable=True),
+    sa.Column('status', sa.String(length=20), server_default='inactive', nullable=False),
+    sa.Column('expires_at', sa.DateTime(), nullable=True),
+    sa.Column('raw_last_verified_at', sa.DateTime(), nullable=True),
+    sa.Column('created_at', sa.DateTime(), nullable=False),
+    sa.Column('updated_at', sa.DateTime(), nullable=False),
+    sa.ForeignKeyConstraint(['user_id'], ['user.id'], name='fk_subscription_user_id_user'),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('source', 'environment', 'original_transaction_id', name='uq_subscription_apple_original'),
+    sa.UniqueConstraint('source', 'external_subscription_id', name='uq_subscription_external_source_id')
+    )
+    with op.batch_alter_table('subscription', schema=None) as batch_op:
+        batch_op.create_index(batch_op.f('ix_subscription_user_id'), ['user_id'], unique=False)
+
+    _migrate_legacy_user_subscription_fields()
+
+
+def downgrade():
+    with op.batch_alter_table('subscription', schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f('ix_subscription_user_id'))
+
+    op.drop_table('subscription')
+
+
+def _migrate_legacy_user_subscription_fields():
+    bind = op.get_bind()
+    user_table = sa.table(
+        'user',
+        sa.column('id', sa.Integer()),
+        sa.column('subscription_status', sa.String()),
+        sa.column('subscription_source', sa.String()),
+        sa.column('subscription_id', sa.String()),
+        sa.column('subscription_expiry', sa.DateTime()),
+    )
+    subscription_table = sa.table(
+        'subscription',
+        sa.column('user_id', sa.Integer()),
+        sa.column('source', sa.String()),
+        sa.column('environment', sa.String()),
+        sa.column('product_id', sa.String()),
+        sa.column('original_transaction_id', sa.String()),
+        sa.column('latest_transaction_id', sa.String()),
+        sa.column('external_subscription_id', sa.String()),
+        sa.column('status', sa.String()),
+        sa.column('expires_at', sa.DateTime()),
+        sa.column('raw_last_verified_at', sa.DateTime()),
+        sa.column('created_at', sa.DateTime()),
+        sa.column('updated_at', sa.DateTime()),
+    )
+
+    now = datetime.utcnow()
+    rows = bind.execute(
+        sa.select(
+            user_table.c.id,
+            user_table.c.subscription_status,
+            user_table.c.subscription_source,
+            user_table.c.subscription_id,
+            user_table.c.subscription_expiry,
+        )
+    ).fetchall()
+
+    seen_apple = set()
+    seen_stripe = set()
+    inserts = []
+    for row in rows:
+        source = (row.subscription_source or '').strip().lower()
+        if source in {'', 'none'}:
+            continue
+
+        status = (row.subscription_status or 'inactive').strip().lower() or 'inactive'
+        subscription_id = (row.subscription_id or '').strip() or None
+        if source in {'app_store', 'apple'}:
+            source = 'apple'
+            environment = None
+            original_transaction_id = subscription_id
+            latest_transaction_id = subscription_id
+            external_subscription_id = None
+            apple_key = (source, environment, original_transaction_id)
+            if original_transaction_id and apple_key in seen_apple:
+                continue
+            if original_transaction_id:
+                seen_apple.add(apple_key)
+        elif source == 'stripe':
+            environment = None
+            original_transaction_id = None
+            latest_transaction_id = None
+            external_subscription_id = subscription_id
+            stripe_key = (source, external_subscription_id)
+            if external_subscription_id and stripe_key in seen_stripe:
+                continue
+            if external_subscription_id:
+                seen_stripe.add(stripe_key)
+        else:
+            environment = None
+            original_transaction_id = None
+            latest_transaction_id = None
+            external_subscription_id = subscription_id
+
+        inserts.append(
+            {
+                'user_id': row.id,
+                'source': source,
+                'environment': environment,
+                'product_id': None,
+                'original_transaction_id': original_transaction_id,
+                'latest_transaction_id': latest_transaction_id,
+                'external_subscription_id': external_subscription_id,
+                'status': status,
+                'expires_at': row.subscription_expiry,
+                'raw_last_verified_at': now,
+                'created_at': now,
+                'updated_at': now,
+            }
+        )
+
+    if inserts:
+        bind.execute(subscription_table.insert(), inserts)

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from werkzeug.security import generate_password_hash
 
 from app import db
-from app.models import PasswordSetupToken, User
+from app.models import PasswordSetupToken, Subscription, User
 from app.api.auth_utils import create_token_for_user
 
 
@@ -214,7 +214,8 @@ def test_appstore_existing_user_subscription_update_no_duplicate(
             "verification_status": "verified",
             "is_active": True,
             "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=40),
-            "subscription_id": "orig_txn_renewed",
+            "original_transaction_id": "orig_txn_renewed",
+            "latest_transaction_id": "ios_latest_renew_1",
             "environment": "production",
         },
     )
@@ -238,6 +239,13 @@ def test_appstore_existing_user_subscription_update_no_duplicate(
         assert user.subscription_source == "app_store"
         assert user.subscription_id == "orig_txn_renewed"
         assert user.is_active is True
+        sub = Subscription.query.filter_by(
+            source="apple",
+            environment="production",
+            original_transaction_id="orig_txn_renewed",
+        ).first()
+        assert sub is not None
+        assert sub.latest_transaction_id == "ios_latest_renew_1"
 
 
 def test_appstore_expired_subscription_deactivates_owner_and_guest(
@@ -280,7 +288,8 @@ def test_appstore_expired_subscription_deactivates_owner_and_guest(
             "verification_status": "verified",
             "is_active": False,
             "expiry": datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1),
-            "subscription_id": "orig_expire",
+            "original_transaction_id": "orig_expire",
+            "latest_transaction_id": "ios_latest_expire_1",
             "environment": "production",
         },
     )
@@ -343,7 +352,8 @@ def test_appstore_renewed_subscription_reactivates_deactivated_owner(
             "verification_status": "verified",
             "is_active": True,
             "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=25),
-            "subscription_id": "orig_renew",
+            "original_transaction_id": "orig_renew",
+            "latest_transaction_id": "ios_latest_renew_2",
             "environment": "sandbox",
         },
     )
@@ -697,6 +707,12 @@ def test_subscription_webhook_update_without_email_uses_existing_subscription_id
         user = User.query.filter_by(email="sub-update@test.local").first()
         assert user.subscription_status == "active"
         assert user.is_active is True
+        assert (
+            Subscription.query.filter_by(
+                source="stripe", external_subscription_id="sub_existing_123"
+            ).count()
+            == 1
+        )
 
 
 def test_guest_of_global_admin_is_subscription_exempt(flask_app, client):
@@ -975,3 +991,153 @@ def test_billing_status_allows_inactive_users_for_refresh(flask_app, client):
 
     with flask_app.app_context():
         flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
+def test_appstore_same_original_transaction_id_different_user_rejected(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    with flask_app.app_context():
+        flask_app.config["FRONTEND_BASE_URL"] = "https://app.example.com"
+        first = User(
+            email="ios-owner-a@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="Owner A",
+            admin=True,
+            is_account_owner=True,
+            is_active=True,
+        )
+        db.session.add(first)
+        db.session.commit()
+        first_id = first.id
+
+    monkeypatch.setattr(
+        billing_routes_module,
+        "_verify_appstore_purchase",
+        lambda *_args, **_kwargs: {
+            "verification_status": "verified",
+            "is_active": True,
+            "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=30),
+            "original_transaction_id": "orig_unique_lock_1",
+            "latest_transaction_id": "latest_unique_lock_1",
+            "environment": "production",
+        },
+    )
+    resp_a = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-owner-a@test.local",
+            "receipt_data": "receipt-a",
+            "transaction": {"original_transaction_id": "orig_unique_lock_1"},
+        },
+    )
+    assert resp_a.status_code == 200
+
+    resp_b = client.post(
+        "/api/v1/billing/verify-appstore",
+        json={
+            "email": "ios-owner-b@test.local",
+            "receipt_data": "receipt-b",
+            "transaction": {"original_transaction_id": "orig_unique_lock_1"},
+        },
+    )
+    assert resp_b.status_code == 401
+
+    with flask_app.app_context():
+        sub = Subscription.query.filter_by(
+            source="apple",
+            environment="production",
+            original_transaction_id="orig_unique_lock_1",
+        ).one()
+        assert sub.user_id == first_id
+        user_b = User.query.filter_by(email="ios-owner-b@test.local").first()
+        assert user_b is None
+
+
+def test_appstore_idempotent_reverify_does_not_duplicate_subscription(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    monkeypatch.setattr(
+        billing_routes_module,
+        "_verify_appstore_purchase",
+        lambda *_args, **_kwargs: {
+            "verification_status": "verified",
+            "is_active": True,
+            "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=15),
+            "original_transaction_id": "orig_idempotent_1",
+            "latest_transaction_id": "latest_idempotent_1",
+            "environment": "sandbox",
+        },
+    )
+    payload = {
+        "email": "ios-idempotent@test.local",
+        "receipt_data": "receipt",
+        "transaction": {"original_transaction_id": "orig_idempotent_1"},
+    }
+    assert client.post("/api/v1/billing/verify-appstore", json=payload).status_code == 200
+    assert client.post("/api/v1/billing/verify-appstore", json=payload).status_code == 200
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="ios-idempotent@test.local").one()
+        subs = Subscription.query.filter_by(
+            user_id=user.id,
+            source="apple",
+            environment="sandbox",
+            original_transaction_id="orig_idempotent_1",
+        ).all()
+        assert len(subs) == 1
+
+
+def test_appstore_same_original_transaction_id_different_environment_allowed(
+    flask_app, client, monkeypatch, billing_routes_module
+):
+    responses = [
+        {
+            "verification_status": "verified",
+            "is_active": True,
+            "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=15),
+            "original_transaction_id": "orig_env_dual_1",
+            "latest_transaction_id": "latest_env_prod",
+            "environment": "production",
+        },
+        {
+            "verification_status": "verified",
+            "is_active": True,
+            "expiry": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=15),
+            "original_transaction_id": "orig_env_dual_1",
+            "latest_transaction_id": "latest_env_sandbox",
+            "environment": "sandbox",
+        },
+    ]
+
+    def _mock_verify(*_args, **_kwargs):
+        return responses.pop(0)
+
+    monkeypatch.setattr(billing_routes_module, "_verify_appstore_purchase", _mock_verify)
+    payload = {
+        "email": "ios-env@test.local",
+        "receipt_data": "receipt",
+        "transaction": {"original_transaction_id": "orig_env_dual_1"},
+    }
+    assert client.post("/api/v1/billing/verify-appstore", json=payload).status_code == 200
+    assert client.post("/api/v1/billing/verify-appstore", json=payload).status_code == 200
+
+    with flask_app.app_context():
+        user = User.query.filter_by(email="ios-env@test.local").one()
+        assert (
+            Subscription.query.filter_by(
+                user_id=user.id,
+                source="apple",
+                environment="production",
+                original_transaction_id="orig_env_dual_1",
+            ).count()
+            == 1
+        )
+        assert (
+            Subscription.query.filter_by(
+                user_id=user.id,
+                source="apple",
+                environment="sandbox",
+                original_transaction_id="orig_env_dual_1",
+            ).count()
+            == 1
+        )


### PR DESCRIPTION
### Motivation
- Replace ad-hoc per-User subscription columns with a first-class `Subscription` table so provider lifecycles (especially Apple `originalTransactionId`) are owned by a single account and cannot be reused across accounts.
- Preserve backward compatibility during transition by mirroring legacy `User.subscription_*` fields and making migrations additive and SQLite/Postgres-safe.
- Centralise subscription logic so both Stripe webhooks and App Store verification use the same normalized data for access enforcement.

### Description
- Added a new `Subscription` SQLAlchemy model with fields: `user_id`, `source`, `environment`, `product_id`, `original_transaction_id`, `latest_transaction_id`, `external_subscription_id`, `status`, `expires_at`, `raw_last_verified_at`, `created_at`, and `updated_at`, plus named foreign key and uniqueness constraints for Apple and external/provider IDs, and an index on `user_id`.
- Added `User.subscriptions` relationship and an `active_subscription` helper to locate the current active subscription.
- Implemented normalized subscription helpers in `app/subscription.py`: `get_effective_subscription`, `_legacy_user_subscription` (legacy fallback), `upsert_subscription`, and expanded status set (including `grace_period`/`canceled`) while preserving legacy `User` columns via `apply_subscription_status(commit=False)` when composing normalized updates.
- Updated billing flows in `app/api/routes/billing.py` to write/read normalized `Subscription` rows: Stripe webhook handlers now upsert `Subscription` rows (and resolve users by `external_subscription_id` when present), and App Store verification now treats `originalTransactionId` as the lifecycle identity, stores `transactionId` as `latest_transaction_id`, idempotently updates same-owner verifications, and rejects cross-account reuse of the same `(source, environment, original_transaction_id)`.
- Added Alembic migration `92d6f98b8d33_add_subscriptions_table.py` that creates the `subscription` table with named constraints (SQLite-compatible) and backfills existing `User.subscription_*` rows into `subscription` rows in an additive, safe manner.
- Expanded and added tests in `tests/test_billing.py` to cover Apple ownership conflict rejection, idempotent re-verification, sandbox vs production separation, and Stripe normalized uniqueness; updated existing App Store tests to assert normalized subscription fields.
- Documentation updates to `PAYMENTS.md` and `MOBILE_API_REFERENCE.md` describing the `subscription` table, Apple `originalTransactionId` ownership rule, environment behavior, and cancel/renew semantics.

### Testing
- Database/migrations: ran `flask db heads`, `flask db upgrade`, and `flask db current` successfully with the new migration added and applied on top of the current head.
- Unit/integration tests: ran `python -m pytest -q`, including `tests/test_billing.py` and `tests/test_appstore_verification.py` and the full test suite; all tests passed locally (`277 passed`, warnings about SQLAlchemy `Query.get()` are expected).
- Verified Stripe and App Store webhook/verification flows via the updated tests which assert normalized `Subscription` rows are created/updated and ownership conflicts are rejected (all billing tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed547da6848320aadbc6dcb9e6259e)