### PR TITLE
Add Delete Account settings card for account owners

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,7 @@
 from flask import (
     request, redirect, url_for, send_from_directory, flash, send_file, Response, session, current_app
 )
-from flask_login import login_required, current_user
+from flask_login import login_required, current_user, logout_user
 from flask import Blueprint, render_template
 from .models import (
     Schedule, Scenario, Balance, User, Settings, TextSettings, Email, Hold, Skip,
@@ -820,6 +820,52 @@ def update_user():
         return redirect(url_for('main.manage_guests'))
 
 
+def _cascade_delete_user(user):
+    # Manually delete all related data before deleting the user, then commit.
+    user_id = user.id
+
+    # Delete setup tokens for all guests before deleting guest rows
+    guest_ids = [
+        guest_id for (guest_id,) in db.session.query(User.id).filter_by(account_owner_id=user_id).all()
+    ]
+    if guest_ids:
+        db.session.query(PasswordSetupToken).filter(
+            PasswordSetupToken.user_id.in_(guest_ids)
+        ).delete(synchronize_session=False)
+
+    # Delete all guest users for this admin user
+    db.session.query(User).filter_by(account_owner_id=user_id).delete()
+
+    # Delete all schedules for this user
+    db.session.query(Schedule).filter_by(user_id=user_id).delete()
+
+    # Delete all scenarios for this user
+    db.session.query(Scenario).filter_by(user_id=user_id).delete()
+
+    # Delete all balances for this user
+    db.session.query(Balance).filter_by(user_id=user_id).delete()
+
+    # Delete all holds for this user
+    db.session.query(Hold).filter_by(user_id=user_id).delete()
+
+    # Delete all skips for this user
+    db.session.query(Skip).filter_by(user_id=user_id).delete()
+
+    # Delete all email configs for this user
+    db.session.query(Email).filter_by(user_id=user_id).delete()
+
+    # Delete all passkey credentials for this user
+    db.session.query(PasskeyCredential).filter_by(user_id=user_id).delete()
+
+    # Delete all API tokens for this user
+    db.session.query(UserToken).filter_by(user_id=user_id).delete()
+    db.session.query(PasswordSetupToken).filter_by(user_id=user_id).delete()
+
+    # Now delete the user
+    db.session.delete(user)
+    db.session.commit()
+
+
 @main.route('/delete_user/<id>', methods=['POST'])
 @login_required
 @admin_required
@@ -838,49 +884,7 @@ def delete_user(id):
                 else:
                     return redirect(url_for('main.manage_guests'))
 
-            # Manually delete all related data before deleting the user
-            user_id = user.id
-
-            # Delete setup tokens for all guests before deleting guest rows
-            guest_ids = [
-                guest_id for (guest_id,) in db.session.query(User.id).filter_by(account_owner_id=user_id).all()
-            ]
-            if guest_ids:
-                db.session.query(PasswordSetupToken).filter(
-                    PasswordSetupToken.user_id.in_(guest_ids)
-                ).delete(synchronize_session=False)
-
-            # Delete all guest users for this admin user
-            db.session.query(User).filter_by(account_owner_id=user_id).delete()
-
-            # Delete all schedules for this user
-            db.session.query(Schedule).filter_by(user_id=user_id).delete()
-
-            # Delete all scenarios for this user
-            db.session.query(Scenario).filter_by(user_id=user_id).delete()
-
-            # Delete all balances for this user
-            db.session.query(Balance).filter_by(user_id=user_id).delete()
-
-            # Delete all holds for this user
-            db.session.query(Hold).filter_by(user_id=user_id).delete()
-
-            # Delete all skips for this user
-            db.session.query(Skip).filter_by(user_id=user_id).delete()
-
-            # Delete all email configs for this user
-            db.session.query(Email).filter_by(user_id=user_id).delete()
-
-            # Delete all passkey credentials for this user
-            db.session.query(PasskeyCredential).filter_by(user_id=user_id).delete()
-
-            # Delete all API tokens for this user
-            db.session.query(UserToken).filter_by(user_id=user_id).delete()
-            db.session.query(PasswordSetupToken).filter_by(user_id=user_id).delete()
-
-            # Now delete the user
-            db.session.delete(user)
-            db.session.commit()
+            _cascade_delete_user(user)
             flash("Deleted Successfully")
         else:
             flash("You don't have permission to delete this user")
@@ -890,6 +894,31 @@ def delete_user(id):
         return redirect(url_for('main.global_admin_panel'))
     else:
         return redirect(url_for('main.manage_guests'))
+
+
+@main.route('/delete_my_account', methods=['POST'])
+@login_required
+@account_owner_required
+@limiter.limit("5 per minute")
+def delete_my_account():
+    # Account owners can permanently delete their own account, all guests, and all associated data.
+    username = (request.form.get('username') or '').strip().lower()
+    password = request.form.get('password') or ''
+
+    user = User.query.filter_by(id=current_user.id).first()
+
+    if not user or not username or not password \
+            or username != (user.email or '').lower() \
+            or not check_password_hash(user.password, password):
+        flash('Username or password is incorrect')
+        return redirect(url_for('main.settings'))
+
+    _cascade_delete_user(user)
+
+    session.clear()
+    logout_user()
+    flash('Your account has been deleted')
+    return redirect(url_for('auth.login'))
 
 
 @main.route('/activate_user/<id>', methods=['POST'])

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -174,6 +174,25 @@
         </a>
     </div>
 
+    {% if not current_user.account_owner_id and not current_user.owner_user_id %}
+    <!-- Delete Account Card - Account Owners Only -->
+    <div class="metric-card">
+        <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
+            <div style="width: 3rem; height: 3rem; background: linear-gradient(135deg, #ef4444, #f87171); border-radius: var(--radius-lg); display: flex; align-items: center; justify-content: center; font-size: 1.5rem;">
+                <i class="fa-solid fa-user-xmark"></i>
+            </div>
+            <div>
+                <h3 style="margin: 0; font-size: 1.1rem; color: var(--text-primary);">Delete Account</h3>
+                <p style="margin: 0; font-size: 0.875rem; color: var(--text-secondary);">Permanently delete your account and all associated data</p>
+            </div>
+        </div>
+        <button class="btn-modern" style="width: 100%; background: linear-gradient(135deg, #ef4444, #f87171); color: white; border: none;"
+                data-bs-toggle="modal" data-bs-target="#deleteaccountmodal">
+            <i class="fa-solid fa-trash"></i> Delete Account
+        </button>
+    </div>
+    {% endif %}
+
     <!-- About Card - Available to all users -->
     <div class="metric-card" style="cursor: pointer;" data-bs-toggle="modal" data-bs-target="#aboutmodal">
         <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
@@ -663,6 +682,64 @@
                         <button class="btn-modern" type="submit"
                                 style="flex: 1; background: linear-gradient(135deg, #ef4444, #f87171); color: white; border: none;">
                             <i class="fa-solid fa-shield-xmark"></i> Disable 2FA
+                        </button>
+                        <button type="button" class="btn-outline-modern btn-modern" data-bs-dismiss="modal">
+                            <i class="fa-solid fa-xmark"></i> Cancel
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+{% if not current_user.account_owner_id and not current_user.owner_user_id %}
+<!-- Delete Account Modal - Account Owners Only -->
+<div class="modal fade modal-modern" id="deleteaccountmodal" tabindex="-1">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">
+                    <i class="fa-solid fa-user-xmark"></i> Delete Account
+                </h5>
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <div style="background-color: rgba(239,68,68,0.08); border-left: 4px solid var(--danger);
+                            padding: 1rem; margin-bottom: 1.5rem; border-radius: var(--radius-md);">
+                    <p style="margin: 0 0 0.5rem 0; color: var(--text-primary); font-size: 0.95rem; font-weight: 600;">
+                        <i class="fa-solid fa-triangle-exclamation" style="color: var(--danger);"></i>
+                        This action is not reversible.
+                    </p>
+                    <p style="margin: 0; color: var(--text-secondary); font-size: 0.875rem;">
+                        Deleting your account will permanently remove your account, all guest accounts
+                        associated with it, and all related data (schedules, scenarios, balances, holds,
+                        skips, email configurations, passkeys, and API tokens). This cannot be undone.
+                    </p>
+                </div>
+                <form action="{{ url_for('main.delete_my_account') }}" method="POST">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <div class="form-group-modern">
+                        <label class="form-label-modern">
+                            <i class="fa-solid fa-user"></i> Username <span style="color: var(--danger);">*</span>
+                        </label>
+                        <input class="form-control-modern" type="text" name="username"
+                               placeholder="Your account username" required autocomplete="username">
+                    </div>
+
+                    <div class="form-group-modern">
+                        <label class="form-label-modern">
+                            <i class="fa-solid fa-lock"></i> Password <span style="color: var(--danger);">*</span>
+                        </label>
+                        <input class="form-control-modern" type="password" name="password"
+                               placeholder="Your account password" required autocomplete="current-password">
+                    </div>
+
+                    <div style="display: flex; gap: 0.5rem; margin-top: 1.5rem;">
+                        <button class="btn-modern" type="submit"
+                                style="flex: 1; background: linear-gradient(135deg, #ef4444, #f87171); color: white; border: none;">
+                            <i class="fa-solid fa-trash"></i> Delete Account
                         </button>
                         <button type="button" class="btn-outline-modern btn-modern" data-bs-dismiss="modal">
                             <i class="fa-solid fa-xmark"></i> Cancel


### PR DESCRIPTION
Lets account owners permanently delete their own account, all associated
guests, and all related data from the Settings page. The modal requires
re-entering username (email) and password, which are verified before the
existing cascade-delete logic (extracted into _cascade_delete_user) runs.
After deletion the session is cleared and the user is logged out.