### PR TITLE
Fix cascade delete integrity and block self-delete for global admins

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from flask import Blueprint, render_template
 from .models import (
     Schedule, Scenario, Balance, User, Settings, TextSettings, Email, Hold, Skip,
     GlobalEmailSettings, AISettings, PasskeyCredential, UserToken, PasswordSetupToken,
+    Subscription,
 )
 from app import db, limiter
 from datetime import datetime, timezone
@@ -820,46 +821,45 @@ def update_user():
         return redirect(url_for('main.manage_guests'))
 
 
+def _delete_user_owned_rows(user_ids):
+    # Bulk-delete every FK-linked row owned by the given user IDs.
+    # Bulk deletes bypass ORM cascades, so each table with a user_id FK
+    # must be cleared explicitly to avoid integrity errors.
+    if not user_ids:
+        return
+
+    for model in (
+        PasswordSetupToken,
+        UserToken,
+        PasskeyCredential,
+        AISettings,
+        Subscription,
+        Email,
+        Skip,
+        Hold,
+        Balance,
+        Scenario,
+        Schedule,
+    ):
+        db.session.query(model).filter(
+            model.user_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+
+
 def _cascade_delete_user(user):
     # Manually delete all related data before deleting the user, then commit.
     user_id = user.id
 
-    # Delete setup tokens for all guests before deleting guest rows
+    # Clear FK-linked rows for every guest before bulk-deleting guest User rows.
     guest_ids = [
         guest_id for (guest_id,) in db.session.query(User.id).filter_by(account_owner_id=user_id).all()
     ]
+    _delete_user_owned_rows(guest_ids)
     if guest_ids:
-        db.session.query(PasswordSetupToken).filter(
-            PasswordSetupToken.user_id.in_(guest_ids)
-        ).delete(synchronize_session=False)
+        db.session.query(User).filter(User.id.in_(guest_ids)).delete(synchronize_session=False)
 
-    # Delete all guest users for this admin user
-    db.session.query(User).filter_by(account_owner_id=user_id).delete()
-
-    # Delete all schedules for this user
-    db.session.query(Schedule).filter_by(user_id=user_id).delete()
-
-    # Delete all scenarios for this user
-    db.session.query(Scenario).filter_by(user_id=user_id).delete()
-
-    # Delete all balances for this user
-    db.session.query(Balance).filter_by(user_id=user_id).delete()
-
-    # Delete all holds for this user
-    db.session.query(Hold).filter_by(user_id=user_id).delete()
-
-    # Delete all skips for this user
-    db.session.query(Skip).filter_by(user_id=user_id).delete()
-
-    # Delete all email configs for this user
-    db.session.query(Email).filter_by(user_id=user_id).delete()
-
-    # Delete all passkey credentials for this user
-    db.session.query(PasskeyCredential).filter_by(user_id=user_id).delete()
-
-    # Delete all API tokens for this user
-    db.session.query(UserToken).filter_by(user_id=user_id).delete()
-    db.session.query(PasswordSetupToken).filter_by(user_id=user_id).delete()
+    # Clear FK-linked rows for the user themselves.
+    _delete_user_owned_rows([user_id])
 
     # Now delete the user
     db.session.delete(user)
@@ -902,6 +902,12 @@ def delete_user(id):
 @limiter.limit("5 per minute")
 def delete_my_account():
     # Account owners can permanently delete their own account, all guests, and all associated data.
+    # Global admins are blocked from this self-service path so the platform always retains
+    # at least one admin able to manage users; they must demote themselves first.
+    if current_user.is_global_admin:
+        flash('Global admins cannot delete their own account from this page')
+        return redirect(url_for('main.settings'))
+
     username = (request.form.get('username') or '').strip().lower()
     password = request.form.get('password') or ''
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -174,8 +174,8 @@
         </a>
     </div>
 
-    {% if not current_user.account_owner_id and not current_user.owner_user_id %}
-    <!-- Delete Account Card - Account Owners Only -->
+    {% if not current_user.account_owner_id and not current_user.owner_user_id and not current_user.is_global_admin %}
+    <!-- Delete Account Card - Account Owners Only (hidden for global admins) -->
     <div class="metric-card">
         <div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1rem;">
             <div style="width: 3rem; height: 3rem; background: linear-gradient(135deg, #ef4444, #f87171); border-radius: var(--radius-lg); display: flex; align-items: center; justify-content: center; font-size: 1.5rem;">
@@ -694,8 +694,8 @@
 </div>
 {% endif %}
 
-{% if not current_user.account_owner_id and not current_user.owner_user_id %}
-<!-- Delete Account Modal - Account Owners Only -->
+{% if not current_user.account_owner_id and not current_user.owner_user_id and not current_user.is_global_admin %}
+<!-- Delete Account Modal - Account Owners Only (hidden for global admins) -->
 <div class="modal fade modal-modern" id="deleteaccountmodal" tabindex="-1">
     <div class="modal-dialog">
         <div class="modal-content">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -383,6 +383,101 @@ def test_delete_owner_removes_guest_password_setup_tokens(
     assert password_setup_token_model.query.filter_by(id=token_id).first() is None
 
 
+def test_delete_owner_with_guest_passkey_does_not_break_integrity(
+    auth_client, app_ctx, user_model, passkey_credential_model
+):
+    """Regression: a guest passkey row must not block bulk-deletion of the
+    parent account owner via the /delete_user/<id> path."""
+    db = app_ctx
+    acting_admin = user_model.query.filter_by(email="admin@test.local").first()
+    acting_admin.is_global_admin = True
+    db.session.flush()
+
+    owner = user_model(
+        email="owner-with-guest-passkey@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Owner With Guest Passkey",
+        admin=True,
+        is_active=True,
+        account_owner_id=None,
+        is_global_admin=False,
+    )
+    db.session.add(owner)
+    db.session.flush()
+
+    guest = user_model(
+        email="guest-with-passkey@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Guest With Passkey",
+        admin=False,
+        is_active=True,
+        account_owner_id=owner.id,
+        is_global_admin=False,
+    )
+    db.session.add(guest)
+    db.session.flush()
+
+    guest_id = guest.id
+    credential = passkey_credential_model(
+        user_id=guest.id,
+        credential_id="guest-passkey-blocking-owner-delete",
+        public_key="pk",
+        sign_count=0,
+        label="Guest Key",
+    )
+    db.session.add(credential)
+    db.session.commit()
+
+    resp = auth_client.post(f"/delete_user/{owner.id}", follow_redirects=False)
+
+    assert resp.status_code in (301, 302)
+    assert user_model.query.filter_by(id=owner.id).first() is None
+    assert user_model.query.filter_by(id=guest_id).first() is None
+    assert passkey_credential_model.query.filter_by(
+        credential_id="guest-passkey-blocking-owner-delete"
+    ).first() is None
+
+
+def test_delete_my_account_blocks_global_admin(
+    flask_app, app_ctx, user_model
+):
+    """Regression: global admins must not be able to self-delete via the
+    user-facing /delete_my_account path, since it would orphan the platform."""
+    db = app_ctx
+
+    admin = user_model(
+        email="global-admin-self-delete@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Global Admin",
+        admin=True,
+        is_active=True,
+        account_owner_id=None,
+        is_global_admin=True,
+    )
+    db.session.add(admin)
+    db.session.commit()
+    admin_id = admin.id
+
+    c = flask_app.test_client()
+    with c.session_transaction() as sess:
+        sess["_user_id"] = str(admin_id)
+        sess["_fresh"] = True
+
+    resp = c.post(
+        "/delete_my_account",
+        data={
+            "username": "global-admin-self-delete@test.local",
+            "password": "testpass123",
+        },
+        follow_redirects=False,
+    )
+
+    assert resp.status_code in (301, 302)
+    assert "/settings" in resp.headers.get("Location", "")
+    # The admin account must still exist after the blocked self-delete attempt.
+    assert user_model.query.filter_by(id=admin_id).first() is not None
+
+
 class TestGuestOnboarding:
     def test_add_guest_sends_password_setup_email(
         self, auth_client, flask_app, app_ctx, user_model, password_setup_token_model, monkeypatch


### PR DESCRIPTION
- _cascade_delete_user now clears every FK-linked table for each guest
  (passkeys, API tokens, AI settings, subscriptions, schedules, etc.)
  before bulk-deleting guest User rows. Previously only PasswordSetupToken
  was cleaned up for guests, which caused IntegrityError on Postgres (or
  SQLite with FK enforcement) when guests had passkeys or API tokens.
  Subscription and AISettings rows are now also cleaned up for the parent
  user, fixing the same gap for owners.

- /delete_my_account and the Settings card/modal are now blocked for
  global admins. Previously @account_owner_required only excluded guests,
  letting the last global admin self-delete and orphan the platform.

Adds regression tests for both cases.

https://claude.ai/code/session_01AFPMci3MtKcwSfT3zrZxXo