### PR TITLE
Add required App Store subscription disclosures to iOS paywall

### DIFF
--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -288,9 +288,15 @@ For local testing, localhost-style HTTP addresses can be used. For remote server
 In **PyCashFlow Cloud** mode:
 
 1. Open **Activate or Restore Cloud Subscription**.
-2. Enter your cloud account email.
-3. Choose a subscription product and complete purchase, or use **Restore Purchases**.
-4. After verification, sign in (or complete emailed password setup if this is a new account email).
+2. Review the on-screen subscription details before purchase:
+   - **PyCashFlow Cloud Monthly**
+   - **$9.99/month**
+   - **Billed monthly. Auto-renewing subscription.**
+   - Renewal and cancellation notice for Apple ID billing
+   - Functional links to **Terms of Use** and **Privacy Policy**
+3. Enter your cloud account email.
+4. Choose a subscription product and complete purchase, or use **Restore Purchases**.
+5. After verification, sign in (or complete emailed password setup if this is a new account email).
 
 ### 6.4 What you can do in iOS
 

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/SubscriptionDisclosure.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/SubscriptionDisclosure.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum SubscriptionDisclosure {
+    static let title = "PyCashFlow Cloud Monthly"
+    static let price = "$9.99/month"
+    static let durationAndType = "Billed monthly. Auto-renewing subscription."
+    static let renewalNotice = "Payment will be charged to your Apple ID. " +
+        "Subscription automatically renews unless canceled at least 24 hours " +
+        "before the end of the current billing period. You can manage or " +
+        "cancel your subscription in Apple ID settings."
+
+    static let termsTitle = "Terms of Use"
+    static let privacyTitle = "Privacy Policy"
+    static let termsURL = URL(string: "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/")!
+    static let privacyURL = URL(string: "https://www.pycashflow.com/privacy")!
+}

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -17,6 +17,32 @@ struct SubscriptionPaywallView: View {
                     .foregroundStyle(AppTheme.textSecondary)
                     .cardRow()
 
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(SubscriptionDisclosure.title)
+                        .font(.headline)
+                        .foregroundStyle(AppTheme.textPrimary)
+
+                    Text(SubscriptionDisclosure.price)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(AppTheme.textPrimary)
+
+                    Text(SubscriptionDisclosure.durationAndType)
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(SubscriptionDisclosure.renewalNotice)
+                        .font(.footnote)
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    VStack(alignment: .leading, spacing: 6) {
+                        Link(SubscriptionDisclosure.termsTitle, destination: SubscriptionDisclosure.termsURL)
+                        Link(SubscriptionDisclosure.privacyTitle, destination: SubscriptionDisclosure.privacyURL)
+                    }
+                    .font(.footnote.weight(.semibold))
+                }
+                .cardRow()
+
                 TextField("Cloud account email", text: $cloudEmail)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()

--- a/ios-app/pycashflowTests/SubscriptionDisclosureTests.swift
+++ b/ios-app/pycashflowTests/SubscriptionDisclosureTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import pycashflow
+
+final class SubscriptionDisclosureTests: XCTestCase {
+    func testRequiredSubscriptionDisclosureCopy() {
+        XCTAssertEqual(SubscriptionDisclosure.title, "PyCashFlow Cloud Monthly")
+        XCTAssertEqual(SubscriptionDisclosure.price, "$9.99/month")
+        XCTAssertEqual(
+            SubscriptionDisclosure.durationAndType,
+            "Billed monthly. Auto-renewing subscription."
+        )
+        XCTAssertTrue(SubscriptionDisclosure.renewalNotice.contains("Apple ID"))
+        XCTAssertTrue(SubscriptionDisclosure.renewalNotice.contains("automatically renews"))
+    }
+
+    func testLegalLinksUseExpectedDestinations() {
+        XCTAssertEqual(
+            SubscriptionDisclosure.termsURL.absoluteString,
+            "https://www.apple.com/legal/internet-services/itunes/dev/stdeula/"
+        )
+        XCTAssertEqual(
+            SubscriptionDisclosure.privacyURL.absoluteString,
+            "https://www.pycashflow.com/privacy"
+        )
+    }
+}


### PR DESCRIPTION
### Motivation
- Ensure the iOS paywall complies with Apple Guideline 3.1.2(c) by showing subscription title, length, price, and functional legal links before purchase.
- Keep subscription copy and legal URLs consistent and centralized for auditability and future updates.
- Preserve existing backend purchase logic and product IDs while making only client-side UI and documentation changes.

### Description
- Added `SubscriptionDisclosure` helper containing the required title, price, duration/type copy, renewal notice, and canonical Terms/Privacy URLs to centralize disclosure content (`ios-app/pycashflow/PyCashFlowApp/Core/Billing/SubscriptionDisclosure.swift`).
- Updated the paywall UI (`SubscriptionPaywallView`) to render the subscription title, price, billing/duration text, renewal/cancellation notice, and visible `Link` controls for Terms of Use and Privacy Policy before any Subscribe action (`ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift`).
- Added unit tests that assert the disclosure copy and legal link destinations (`ios-app/pycashflowTests/SubscriptionDisclosureTests.swift`).
- Updated `USER_GUIDE.md` to document that the app shows the subscription disclosure and functional legal links before purchase.

### Testing
- Ran the full Python test suite with `python -m pytest -q` and all tests passed (`279 passed, 50 warnings`).
- Added XCTest test file for the iOS disclosure content, but running Xcode tests / `xcodebuild` could not be performed in this environment because `xcodebuild` is not available, so iOS unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01ad1bff08320b37237a7265fab5d)