### PR TITLE
Use StoreKit product metadata in subscription disclosure

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/SubscriptionDisclosure.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/SubscriptionDisclosure.swift
@@ -1,9 +1,62 @@
 import Foundation
+import StoreKit
+import SwiftUI
 
-enum SubscriptionDisclosure {
-    static let title = "PyCashFlow Cloud Monthly"
-    static let price = "$9.99/month"
-    static let durationAndType = "Billed monthly. Auto-renewing subscription."
+struct SubscriptionDisclosure: View {
+    let product: Product
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(product.displayName)
+                .font(.headline)
+                .foregroundStyle(AppTheme.textPrimary)
+                .lineLimit(2)
+                .minimumScaleFactor(0.85)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(product.displayPrice)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(AppTheme.textPrimary)
+
+            Text("Billed every \(Self.billingPeriodText(from: product.subscription?.subscriptionPeriod)). Auto-renewing subscription.")
+                .foregroundStyle(AppTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text(Self.renewalNotice)
+                .font(.footnote)
+                .foregroundStyle(AppTheme.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Link(Self.termsTitle, destination: Self.termsURL)
+                Link(Self.privacyTitle, destination: Self.privacyURL)
+            }
+            .font(.footnote.weight(.semibold))
+        }
+    }
+
+    static func billingPeriodText(from period: Product.SubscriptionPeriod?) -> String {
+        guard let period else { return "subscription period" }
+        let value = period.value
+        let unit = billingUnitText(period.unit, value: value)
+        return value == 1 ? unit : "\(value) \(unit)"
+    }
+
+    private static func billingUnitText(_ unit: Product.SubscriptionPeriod.Unit, value: Int) -> String {
+        switch unit {
+        case .day:
+            return value == 1 ? "day" : "days"
+        case .week:
+            return value == 1 ? "week" : "weeks"
+        case .month:
+            return value == 1 ? "month" : "months"
+        case .year:
+            return value == 1 ? "year" : "years"
+        @unknown default:
+            return "subscription period"
+        }
+    }
+
     static let renewalNotice = "Payment will be charged to your Apple ID. " +
         "Subscription automatically renews unless canceled at least 24 hours " +
         "before the end of the current billing period. You can manage or " +

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -17,32 +17,6 @@ struct SubscriptionPaywallView: View {
                     .foregroundStyle(AppTheme.textSecondary)
                     .cardRow()
 
-                VStack(alignment: .leading, spacing: 8) {
-                    Text(SubscriptionDisclosure.title)
-                        .font(.headline)
-                        .foregroundStyle(AppTheme.textPrimary)
-
-                    Text(SubscriptionDisclosure.price)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(AppTheme.textPrimary)
-
-                    Text(SubscriptionDisclosure.durationAndType)
-                        .foregroundStyle(AppTheme.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    Text(SubscriptionDisclosure.renewalNotice)
-                        .font(.footnote)
-                        .foregroundStyle(AppTheme.textSecondary)
-                        .fixedSize(horizontal: false, vertical: true)
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        Link(SubscriptionDisclosure.termsTitle, destination: SubscriptionDisclosure.termsURL)
-                        Link(SubscriptionDisclosure.privacyTitle, destination: SubscriptionDisclosure.privacyURL)
-                    }
-                    .font(.footnote.weight(.semibold))
-                }
-                .cardRow()
-
                 TextField("Cloud account email", text: $cloudEmail)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
@@ -69,12 +43,7 @@ struct SubscriptionPaywallView: View {
                 } else {
                     ForEach(manager.availableProducts, id: \.id) { product in
                         VStack(alignment: .leading, spacing: 8) {
-                            Text(product.displayName)
-                                .font(.headline)
-                                .foregroundStyle(AppTheme.textPrimary)
-                                .lineLimit(2)
-                                .minimumScaleFactor(0.85)
-                                .fixedSize(horizontal: false, vertical: true)
+                            SubscriptionDisclosure(product: product)
                             Text(product.description)
                                 .foregroundStyle(AppTheme.textSecondary)
                                 .fixedSize(horizontal: false, vertical: true)

--- a/ios-app/pycashflowTests/SubscriptionDisclosureTests.swift
+++ b/ios-app/pycashflowTests/SubscriptionDisclosureTests.swift
@@ -1,14 +1,43 @@
 import XCTest
+import StoreKit
 @testable import pycashflow
 
 final class SubscriptionDisclosureTests: XCTestCase {
-    func testRequiredSubscriptionDisclosureCopy() {
-        XCTAssertEqual(SubscriptionDisclosure.title, "PyCashFlow Cloud Monthly")
-        XCTAssertEqual(SubscriptionDisclosure.price, "$9.99/month")
+    func testBillingPeriodTextSupportsSupportedStoreKitCadences() {
         XCTAssertEqual(
-            SubscriptionDisclosure.durationAndType,
-            "Billed monthly. Auto-renewing subscription."
+            SubscriptionDisclosure.billingPeriodText(
+                from: Product.SubscriptionPeriod(value: 1, unit: .day)
+            ),
+            "day"
         )
+        XCTAssertEqual(
+            SubscriptionDisclosure.billingPeriodText(
+                from: Product.SubscriptionPeriod(value: 2, unit: .week)
+            ),
+            "2 weeks"
+        )
+        XCTAssertEqual(
+            SubscriptionDisclosure.billingPeriodText(
+                from: Product.SubscriptionPeriod(value: 1, unit: .month)
+            ),
+            "month"
+        )
+        XCTAssertEqual(
+            SubscriptionDisclosure.billingPeriodText(
+                from: Product.SubscriptionPeriod(value: 3, unit: .year)
+            ),
+            "3 years"
+        )
+    }
+
+    func testBillingPeriodTextFallsBackWhenSubscriptionPeriodIsUnavailable() {
+        XCTAssertEqual(
+            SubscriptionDisclosure.billingPeriodText(from: nil),
+            "subscription period"
+        )
+    }
+
+    func testRequiredSubscriptionDisclosureCopy() {
         XCTAssertTrue(SubscriptionDisclosure.renewalNotice.contains("Apple ID"))
         XCTAssertTrue(SubscriptionDisclosure.renewalNotice.contains("automatically renews"))
     }


### PR DESCRIPTION
### Motivation
- Remove hardcoded subscription title/price/cadence in the paywall so the UI shows the live, localized StoreKit metadata (title, price, billing cadence) and supports multiple configured products.
- Ensure the disclosure remains compliant with Apple guideline copy requirements while avoiding fragile, hardcoded price tiers.
- Provide a safe fallback when StoreKit does not expose a subscription period so the UI never displays misleading cadence text.

### Description
- Replaced the old `SubscriptionDisclosure` enum with a SwiftUI `SubscriptionDisclosure` view that accepts a `StoreKit.Product` and renders `product.displayName`, `product.displayPrice`, the auto-renew notice, and the Terms/Privacy links (files changed: `SubscriptionDisclosure.swift`).
- Implemented `billingPeriodText(from:)` with singular/plural handling for day/week/month/year and an `@unknown default` fallback to return `"subscription period"` when metadata is missing.
- Updated the paywall to render `SubscriptionDisclosure(product: product)` inside each product card so each `manager.availableProducts` entry shows its own title/price/cadence (file changed: `SubscriptionPaywallView.swift`).
- Updated unit tests to validate cadence formatting and fallback behavior and preserved tests that assert required legal/renewal copy and link destinations (file changed: `SubscriptionDisclosureTests.swift`).

### Testing
- Updated XCTest cases in `pycashflowTests/SubscriptionDisclosureTests.swift` to cover supported cadence formatting (day/week/month/year) and the fallback for nil subscription period; these tests are present but were not executed in this environment.
- Attempted to run Xcode build/test tooling, but `xcodebuild` is not available in this CI environment so Swift tests could not be executed here (`command not found`).
- Verified statically that legacy hardcoded strings (`PyCashFlow Cloud Monthly`, `$9.99/month`, `Billed monthly`) were removed from the iOS source and tests using a repository search.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f01d682ae88320bdae1c31f30b7258)