### PR TITLE
Add reviewer account flag for App Store review exemption

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -380,16 +380,24 @@ def api_billing_status():
     owner = owner_for_user(user)
 
     owner_is_global_admin = bool(owner and owner.is_global_admin)
+    owner_is_review_user = bool(owner and getattr(owner, "is_review_user", False))
 
     if not user.is_global_admin and not user.is_active:
         # Keep manual/admin deactivation checks, but allow expired users to
         # retrieve billing status when payments enforcement is enabled.
-        if not payments_enabled() or owner_is_global_admin or subscription_is_current(owner):
+        if (
+            not payments_enabled()
+            or owner_is_global_admin
+            or owner_is_review_user
+            or subscription_is_current(owner)
+        ):
             return unauthorized("Invalid credentials or account is not active")
 
     owner_id = user.owner_user_id or user.account_owner_id
 
-    effective_is_active = bool(user.is_global_admin) or owner_is_global_admin
+    effective_is_active = (
+        bool(user.is_global_admin) or owner_is_global_admin or owner_is_review_user
+    )
     if not effective_is_active:
         if payments_enabled():
             effective_is_active = subscription_is_current(owner)

--- a/app/main.py
+++ b/app/main.py
@@ -988,6 +988,39 @@ def deactivate_user(id):
         return redirect(url_for('main.manage_guests'))
 
 
+@main.route('/toggle_review_user/<id>', methods=['POST'])
+@login_required
+@global_admin_required
+def toggle_review_user(id):
+    """Mark/unmark an account owner as an Apple-review test account.
+
+    Reviewer accounts bypass payment-subscription enforcement and remain
+    active so the App Store review team can exercise the app without a
+    purchased subscription.
+    """
+    user = User.query.filter_by(id=int(id)).first()
+
+    if not user:
+        flash("User not found")
+        return redirect(url_for('main.global_admin_panel'))
+
+    if user.account_owner_id is not None:
+        flash("Reviewer flag can only be toggled on account owners")
+        return redirect(url_for('main.global_admin_panel'))
+
+    user.is_review_user = not bool(user.is_review_user)
+    if user.is_review_user:
+        user.is_active = True
+    db.session.commit()
+
+    if user.is_review_user:
+        flash(f"User {user.name} is now a reviewer account (subscription exempt)")
+    else:
+        flash(f"User {user.name} is no longer a reviewer account")
+
+    return redirect(url_for('main.global_admin_panel'))
+
+
 @main.route('/create_user', methods=('GET', 'POST'))
 @login_required
 @admin_required

--- a/app/models.py
+++ b/app/models.py
@@ -19,6 +19,11 @@ class User(UserMixin, db.Model):
     twofa_enabled = db.Column(db.Boolean, default=False, server_default=db.false(), nullable=False)
     twofa_secret = db.Column(db.String(500), nullable=True)   # Fernet-encrypted TOTP secret
     twofa_backup_codes = db.Column(db.Text, nullable=True)    # JSON array of scrypt-hashed backup codes
+    # Marks an account owner as an Apple/store reviewer test account. Reviewer
+    # accounts bypass payment-subscription enforcement and remain active.
+    is_review_user = db.Column(
+        db.Boolean, default=False, server_default=db.false(), nullable=False
+    )
 
     # Relationships
     guests = db.relationship(

--- a/app/static/css/improved.css
+++ b/app/static/css/improved.css
@@ -1283,6 +1283,12 @@ body.modal-open {
   border: 1px solid rgba(139, 92, 246, 0.3);
 }
 
+.badge-reviewer {
+  background-color: rgba(59, 130, 246, 0.15);
+  color: #60a5fa;
+  border: 1px solid rgba(59, 130, 246, 0.3);
+}
+
 /* ── Mobile: stacked card layout (≤640px) ── */
 @media (max-width: 640px) {
   /* Add bottom breathing room inside overflow:hidden table-card */

--- a/app/subscription.py
+++ b/app/subscription.py
@@ -240,6 +240,20 @@ def enforce_user_access(user: User | None) -> bool:
             db.session.commit()
         return True
 
+    # Reviewer accounts (used for App Store review) bypass subscription
+    # enforcement and remain active.
+    if getattr(owner, "is_review_user", False):
+        changed = False
+        if not owner.is_active:
+            owner.is_active = True
+            changed = True
+        if not user.is_active:
+            user.is_active = True
+            changed = True
+        if changed:
+            db.session.commit()
+        return True
+
     if subscription_is_current(owner):
         changed = False
         if not owner.is_global_admin and not owner.is_active:

--- a/app/templates/global_admin.html
+++ b/app/templates/global_admin.html
@@ -246,6 +246,9 @@
                 {% else %}
                 <span class="badge-modern badge-inactive"><i class="fa-solid fa-circle-xmark"></i> Inactive</span>
                 {% endif %}
+                {% if owner.is_review_user %}
+                <span class="badge-modern badge-reviewer"><i class="fa-solid fa-flask"></i> Reviewer</span>
+                {% endif %}
             </div>
             <div class="rc-cell rc-actions">
                 {% if not owner.is_active %}
@@ -263,6 +266,18 @@
                     </button>
                 </form>
                 {% endif %}
+                <form action="/toggle_review_user/{{owner.id}}" method="POST" style="display:inline;" onsubmit="return confirm('{% if owner.is_review_user %}Remove reviewer status from this account?{% else %}Mark this account as an Apple reviewer test account? It will be exempt from subscription requirements and remain active.{% endif %}')">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    {% if owner.is_review_user %}
+                    <button type="submit" class="btn-warning-modern btn-modern btn-sm-modern">
+                        <i class="fa-solid fa-flask-vial"></i> Unmark Reviewer
+                    </button>
+                    {% else %}
+                    <button type="submit" class="btn-outline-modern btn-modern btn-sm-modern">
+                        <i class="fa-solid fa-flask"></i> Mark Reviewer
+                    </button>
+                    {% endif %}
+                </form>
                 <button class="btn-primary-modern btn-modern btn-sm-modern" data-bs-toggle="modal" data-bs-target="#modaleditowner{{owner.id}}">
                     <i class="fa-solid fa-pen"></i> Edit
                 </button>

--- a/migrations/versions/d5f6a7b8c9d1_add_is_review_user_to_user.py
+++ b/migrations/versions/d5f6a7b8c9d1_add_is_review_user_to_user.py
@@ -1,0 +1,33 @@
+"""add is_review_user to user
+
+Revision ID: d5f6a7b8c9d1
+Revises: fc9e4136ef56
+Create Date: 2026-04-28 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'd5f6a7b8c9d1'
+down_revision = 'fc9e4136ef56'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                'is_review_user',
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('is_review_user')


### PR DESCRIPTION
Adds an is_review_user boolean to the User model so global admins can
mark an account owner as an Apple-review test account. Reviewer accounts
bypass payment-subscription enforcement and are kept active so the App
Store review team can exercise the app without a paid subscription.

- New is_review_user column with alembic migration
- enforce_user_access and /billing/status treat reviewer owners as active
- New /toggle_review_user/<id> route, restricted to global admins
- Global admin page gains a Mark/Unmark Reviewer button and badge per
  account-owner card