### PR TITLE
Allow reviewer-linked inactive users to refresh /billing/status

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -385,10 +385,11 @@ def api_billing_status():
     if not user.is_global_admin and not user.is_active:
         # Keep manual/admin deactivation checks, but allow expired users to
         # retrieve billing status when payments enforcement is enabled.
-        if (
+        # Reviewer-linked accounts always pass through so the client can refresh
+        # and discover the bypass even when leftover is_active=False persists.
+        if not owner_is_review_user and (
             not payments_enabled()
             or owner_is_global_admin
-            or owner_is_review_user
             or subscription_is_current(owner)
         ):
             return unauthorized("Invalid credentials or account is not active")

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -1033,6 +1033,55 @@ def test_billing_status_allows_inactive_users_for_refresh(flask_app, client):
         flask_app.config["PAYMENTS_ENABLED"] = original_toggle
 
 
+def test_billing_status_allows_inactive_reviewer_user_for_refresh(flask_app, client):
+    original_toggle = flask_app.config["PAYMENTS_ENABLED"]
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = True
+        owner = User(
+            email="billing-reviewer-owner@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="ReviewerOwner",
+            admin=True,
+            is_account_owner=True,
+            is_active=False,
+            is_review_user=True,
+        )
+        db.session.add(owner)
+        db.session.commit()
+        guest = User(
+            email="billing-reviewer-guest@test.local",
+            password=generate_password_hash("pass12345", method="scrypt"),
+            name="ReviewerGuest",
+            admin=False,
+            is_account_owner=False,
+            account_owner_id=owner.id,
+            owner_user_id=owner.id,
+            is_active=False,
+        )
+        db.session.add(guest)
+        db.session.add(
+            Subscription(
+                user_id=owner.id,
+                source="stripe",
+                status="expired",
+                external_subscription_id="sub_billing_reviewer_1",
+                expires_at=datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=1),
+            )
+        )
+        db.session.commit()
+        raw, _ = create_token_for_user(guest)
+
+    resp = client.get("/api/v1/billing/status", headers={"Authorization": f"Bearer {raw}"})
+    assert resp.status_code == 200
+    body = _json(resp)["data"]
+    assert body["is_active"] is False
+    assert body["effective_is_active"] is True
+    assert body["is_guest"] is True
+
+    with flask_app.app_context():
+        flask_app.config["PAYMENTS_ENABLED"] = original_toggle
+
+
 def test_appstore_same_original_transaction_id_different_user_rejected(
     flask_app, client, monkeypatch, billing_routes_module
 ):


### PR DESCRIPTION
Adding owner_is_review_user to the unauthorized gate caused 401s for
guests whose is_active=False persisted from a prior expiry under an
owner that was newly marked as a reviewer. Reviewer accounts are meant
to bypass subscription enforcement, so the refresh path must let the
client retrieve the exemption state instead of being blocked.