### PR TITLE
Clarify licensing: GPLv3 backend and separately licensed iOS app

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,9 +837,15 @@ H3 Consulting Partners specializes in enterprise deployments, custom feature dev
 
 ---
 
-## License
+## Licensing
 
-This project is licensed under the terms specified in the [LICENSE](LICENSE) file.
+This repository contains multiple components with separate licenses:
+
+- Backend / Flask server: GNU GPLv3, as provided in the root [LICENSE](LICENSE) file.
+- iOS application located in `/ios-app`: licensed separately under [`ios-app/LICENSE`](ios-app/LICENSE) and, when distributed through the Apple App Store, under Apple's Standard End User License Agreement (EULA):
+  https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+
+The root GPLv3 license applies to backend/server components and does not apply to the separately licensed iOS application in `/ios-app`.
 
 ---
 

--- a/ios-app/LICENSE
+++ b/ios-app/LICENSE
@@ -1,0 +1,9 @@
+This directory contains the PyCashFlow iOS application.
+
+The PyCashFlow iOS application is not licensed under the GNU General Public License v3.0.
+
+The iOS application is distributed under a separate proprietary license and, when downloaded through the Apple App Store, is licensed under Apple's Standard End User License Agreement (EULA):
+
+https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+
+All backend/server components of PyCashFlow remain licensed under GNU GPLv3 as described in the root LICENSE file.

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -51,3 +51,13 @@ These values are hardcoded in `PyCashFlowApp/Core/Config/Config.swift`:
 `APIClient` normalizes base URLs so host-only values automatically use `/api/v1`.
 For security, remote self-hosted servers must use HTTPS. Plain HTTP is only
 allowed for localhost development endpoints.
+
+## Licensing
+
+The iOS app in this directory is **not** licensed under the repository root GNU GPLv3 license.
+
+- iOS app license: see [`LICENSE`](LICENSE) in this directory.
+- App Store distributions are additionally licensed under Apple's Standard EULA:
+  https://www.apple.com/legal/internet-services/itunes/dev/stdeula/
+
+Backend/server components remain licensed under GNU GPLv3 per the root [`../LICENSE`](../LICENSE) file.


### PR DESCRIPTION
### Motivation

- Clearly separate the licensing of the backend (GNU GPLv3) from the iOS SwiftUI client so the iOS app is explicitly carved out as separately/proprietarily licensed and subject to Apple’s App Store EULA.

### Description

- Added a new `ios-app/LICENSE` explaining that the iOS application is not covered by the root GPLv3 and is distributed under a separate proprietary license and, when distributed via the App Store, Apple’s Standard EULA; updated the root `README.md` with a `## Licensing` section that documents component-level licensing and links to `ios-app/LICENSE` and the App Store EULA; and added a short `## Licensing` note to `ios-app/README.md` pointing to the new license file and the root GPLv3.

### Testing

- No automated tests were executed because these are documentation-only changes that do not modify runtime code or behavior and therefore do not affect the existing test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2e525784c8320a73af337d7447b40)