### PR TITLE
LoginView: inline environment selector and progressive reveal for login/passkey fields

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -19,6 +19,8 @@ struct LoginView: View {
     @State private var selfHostedErrorText: String?
     @State private var isLoading = false
     @State private var isPasskeyLoading = false
+    @State private var showPasswordLoginFields = false
+    @State private var showPasskeyEmailField = false
     @FocusState private var focusedField: Field?
 
     var body: some View {
@@ -33,34 +35,31 @@ struct LoginView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
-                Picker("App Mode", selection: Binding(
-                    get: { session.appMode },
-                    set: { newValue in
-                        // Route through `switchMode` directly instead of a
-                        // `$session.appMode` two-way binding + `.onChange`: the
-                        // binding pattern mutates `appMode` before `onChange`
-                        // fires, so `switchMode`'s equality guard would
-                        // short-circuit and leave the base URL pointed at the
-                        // previous environment.
-                        guard newValue != session.appMode else { return }
-                        // Resign any active text field before the self-hosted
-                        // card appears/disappears; otherwise the keyboard layout
-                        // constraints conflict with the view hierarchy change.
-                        dismissKeyboard()
-                        focusedField = nil
-                        session.switchMode(newValue)
-                        authErrorText = nil
-                        selfHostedErrorText = nil
+                HStack(spacing: 4) {
+                    Text("Logging in on:")
+                        .foregroundStyle(AppTheme.textSecondary)
+                    Picker("App Mode", selection: Binding(
+                        get: { session.appMode },
+                        set: { newValue in
+                            guard newValue != session.appMode else { return }
+                            dismissKeyboard()
+                            focusedField = nil
+                            session.switchMode(newValue)
+                            authErrorText = nil
+                            selfHostedErrorText = nil
+                        }
+                    )) {
+                        ForEach(SessionManager.AppMode.allCases) { mode in
+                            Text(mode.label).tag(mode)
+                        }
                     }
-                )) {
-                    ForEach(SessionManager.AppMode.allCases) { mode in
-                        Text(mode.label).tag(mode)
-                    }
+                    .pickerStyle(.menu)
+                    .tint(AppTheme.accent)
                 }
-                .surfaceCard()
+                .frame(maxWidth: .infinity, alignment: .leading)
 
                 VStack(spacing: 12) {
-                    if challenge == nil {
+                    if challenge == nil && showPasswordLoginFields {
                         TextField("Email", text: $email)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()
@@ -102,8 +101,26 @@ struct LoginView: View {
                     .buttonStyle(PrimaryButtonStyle())
                     .disabled(isLoading || isPasskeyLoading)
 
+                    if challenge == nil && showPasskeyEmailField && !showPasswordLoginFields {
+                        TextField("Email", text: $email)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                            .submitLabel(.go)
+                            .focused($focusedField, equals: .email)
+                            .onSubmit { startPasskeyLogin() }
+                            .padding(12)
+                            .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+                            .foregroundStyle(AppTheme.textPrimary)
+                    }
+
                     if challenge == nil {
                         Button {
+                            if !showPasskeyEmailField {
+                                showPasskeyEmailField = true
+                                showPasswordLoginFields = false
+                                focusedField = .email
+                                return
+                            }
                             startPasskeyLogin()
                         } label: {
                             HStack(spacing: 8) {
@@ -188,6 +205,12 @@ struct LoginView: View {
         dismissKeyboard()
         focusedField = nil
         guard !isLoading else { return }
+        if challenge == nil && !showPasswordLoginFields {
+            showPasswordLoginFields = true
+            showPasskeyEmailField = false
+            focusedField = .email
+            return
+        }
         Task { @MainActor in
             await Task.yield()
             guard !isLoading else { return }


### PR DESCRIPTION
### Motivation
- Reduce visual weight of the environment selector by replacing the large boxed picker with an inline text selector prefixed by "Logging in on:". 
- Minimize initial UI clutter on the login screen by hiding email/password fields until the user intentionally starts login. 
- Make the passkey flow less noisy by revealing only the email field on first press and performing passkey auth only after the email is provided. 

### Description
- Replaced the card-style app-mode picker with an inline `HStack` that shows `Text("Logging in on:")` and a `Picker` using `.pickerStyle(.menu)` to act like a compact link. (`ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift`) 
- Added two state flags: `@State private var showPasswordLoginFields = false` and `@State private var showPasskeyEmailField = false` to drive progressive disclosure of input fields. (`LoginView.swift`) 
- Changed conditional rendering so the email/password fields are shown only when `showPasswordLoginFields` is true, and the passkey email field is shown only when `showPasskeyEmailField` is true and password fields are hidden. (`LoginView.swift`) 
- Updated `submitFromKeyboard()` so the first tap of the `Login` button reveals the username/password fields (focusing `email`) instead of immediately submitting, and updated the `Sign in with Passkey` button to reveal the email on first tap and trigger passkey login on the subsequent tap/submit. (`LoginView.swift`) 
- Preserved existing 2FA flow, self-hosted base-URL handling, and mode-switching cleanup behavior; mode changes still clear `authErrorText`/`selfHostedErrorText`. (`LoginView.swift`) 

### Testing
- No automated tests were executed in this environment because this is a SwiftUI UI change that requires an Xcode build/iOS runtime; no iOS simulator or CI build was run here. Tests to run locally or in CI: run an Xcode build and the app UI in Simulator, and run any platform unit/UI tests to verify interaction flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60d37feec83209eaf2b9b34df32c4)