### PR TITLE
Use DatePicker for schedule and scenario edit start dates in iOS app

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -14,7 +14,7 @@ struct ScenariosView: View {
     @State private var editAmount = ""
     @State private var editType = "Expense"
     @State private var editFrequency = "Monthly"
-    @State private var editStartDate = defaultStartDate()
+    @State private var editStartDate = Date()
     @State private var errorText: String?
 
     private let types = ["Expense", "Income"]
@@ -97,7 +97,9 @@ struct ScenariosView: View {
                                 TextField("Amount", text: $editAmount).keyboardType(.decimalPad).fieldStyle()
                                 pickerRow(label: "Type", selection: $editType, options: types)
                                 pickerRow(label: "Frequency", selection: $editFrequency, options: frequencies)
-                                TextField("Start date (YYYY-MM-DD)", text: $editStartDate).fieldStyle()
+                                DatePicker("Start date", selection: $editStartDate, displayedComponents: .date)
+                                    .datePickerStyle(.compact)
+                                    .fieldStyle()
                                 HStack(spacing: 8) {
                                     Button("Save") { Task { await saveEdit(scenario.id) } }
                                         .buttonStyle(PrimaryButtonStyle())
@@ -156,13 +158,25 @@ struct ScenariosView: View {
         .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
     }
 
-    private static func defaultStartDate() -> String {
+    private static let apiDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: Date())
+        return formatter
+    }()
+
+    private static func defaultStartDate() -> String {
+        apiDateFormatter.string(from: Date())
+    }
+
+    private static func parseAPIDate(_ value: String) -> Date {
+        apiDateFormatter.date(from: value) ?? Date()
+    }
+
+    private static func formatAPIDate(_ value: Date) -> String {
+        apiDateFormatter.string(from: value)
     }
 
     private func resetAddForm() {
@@ -180,7 +194,7 @@ struct ScenariosView: View {
         editAmount = scenario.amount
         editType = scenario.type
         editFrequency = scenario.frequency
-        editStartDate = scenario.start_date
+        editStartDate = Self.parseAPIDate(scenario.start_date)
     }
 
     private func load() async {
@@ -242,7 +256,7 @@ struct ScenariosView: View {
                 "scenarios/\(id)",
                 method: "PUT",
                 token: token,
-                body: Payload(name: editName, amount: editAmount, type: editType, frequency: editFrequency, start_date: editStartDate),
+                body: Payload(name: editName, amount: editAmount, type: editType, frequency: editFrequency, start_date: Self.formatAPIDate(editStartDate)),
                 as: APIEnvelope<ScenarioDTO>.self
             )
             await load()

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -14,7 +14,7 @@ struct SchedulesView: View {
     @State private var editAmount = ""
     @State private var editType = "Expense"
     @State private var editFrequency = "Monthly"
-    @State private var editStartDate = defaultStartDate()
+    @State private var editStartDate = Date()
     @State private var errorText: String?
     @State private var statusText: String?
 
@@ -106,7 +106,9 @@ struct SchedulesView: View {
                                 TextField("Amount", text: $editAmount).keyboardType(.decimalPad).fieldStyle()
                                 pickerRow(label: "Type", selection: $editType, options: types)
                                 pickerRow(label: "Frequency", selection: $editFrequency, options: frequencies)
-                                TextField("Start date (YYYY-MM-DD)", text: $editStartDate).fieldStyle()
+                                DatePicker("Start date", selection: $editStartDate, displayedComponents: .date)
+                                    .datePickerStyle(.compact)
+                                    .fieldStyle()
                                 HStack(spacing: 8) {
                                     Button("Save") { Task { await saveEdit(schedule.id) } }
                                         .buttonStyle(PrimaryButtonStyle())
@@ -179,13 +181,25 @@ struct SchedulesView: View {
         .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
     }
 
-    private static func defaultStartDate() -> String {
+    private static let apiDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
         formatter.calendar = Calendar(identifier: .gregorian)
         formatter.timeZone = .current
         formatter.dateFormat = "yyyy-MM-dd"
-        return formatter.string(from: Date())
+        return formatter
+    }()
+
+    private static func defaultStartDate() -> String {
+        apiDateFormatter.string(from: Date())
+    }
+
+    private static func parseAPIDate(_ value: String) -> Date {
+        apiDateFormatter.date(from: value) ?? Date()
+    }
+
+    private static func formatAPIDate(_ value: Date) -> String {
+        apiDateFormatter.string(from: value)
     }
 
     private func resetAddForm() {
@@ -203,7 +217,7 @@ struct SchedulesView: View {
         editAmount = schedule.amount
         editType = schedule.type
         editFrequency = schedule.frequency
-        editStartDate = schedule.start_date
+        editStartDate = Self.parseAPIDate(schedule.start_date)
     }
 
     private func load() async {
@@ -265,7 +279,7 @@ struct SchedulesView: View {
                 "schedules/\(id)",
                 method: "PUT",
                 token: token,
-                body: Payload(name: editName, amount: editAmount, type: editType, frequency: editFrequency, start_date: editStartDate),
+                body: Payload(name: editName, amount: editAmount, type: editType, frequency: editFrequency, start_date: Self.formatAPIDate(editStartDate)),
                 as: APIEnvelope<ScheduleDTO>.self
             )
             await load()


### PR DESCRIPTION
### Motivation
- Prevent invalid manual date entry and improve UX on the schedule and scenario edit cards by using a native date picker instead of free-text input. 
- Preserve the backend API contract which expects dates as `yyyy-MM-dd` strings while making the client-editing experience safer. 
- Keep changes scoped to the edit flow so adding new schedules/scenarios remains unchanged.

### Description
- Replaced the `TextField("Start date (YYYY-MM-DD)", ...)` used in the edit cards with a `DatePicker("Start date", selection: ..., displayedComponents: .date)` (compact style) in both `SchedulesView` and `ScenariosView`. 
- Converted `editStartDate` from a `String` to a `Date` state and added a shared `apiDateFormatter: DateFormatter` plus helper functions `parseAPIDate(_:)` and `formatAPIDate(_:)` to translate between API strings and `Date`. 
- Updated `beginEdit(...)` to parse the incoming API `start_date` into the `Date` edit state and updated `saveEdit(...)` to send `start_date` back to the API as a `yyyy-MM-dd` string using the formatter, preserving API compatibility. 
- Left the add-new-item forms' start-date input unchanged (still a textual ISO date) to minimize scope and risk.

### Testing
- Attempted to run an iOS build with `xcodebuild -project ios-app/pycashflow.xcodeproj -scheme pycashflow -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO`, but the environment does not provide `xcodebuild` and the command failed with `command not found`. 
- No automated unit or UI tests were executed in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f60f872cfc8320a5948198a4b83b5e)