### PR TITLE
Fix OTP field rendering in iOS login flow

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -77,7 +77,7 @@ struct LoginView: View {
                             .padding(12)
                             .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
                             .foregroundStyle(AppTheme.textPrimary)
-                    } else {
+                    } else if challenge != nil {
                         TextField("6-digit code or backup code", text: $twoFACode)
                             .textInputAutocapitalization(.never)
                             .autocorrectionDisabled()


### PR DESCRIPTION
### Motivation
- Prevent the OTP / 2FA input from appearing on initial load or when password fields are collapsed by showing it only during an active 2FA challenge.

### Description
- Update `ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift` to render the 2FA code field only when `challenge != nil` by changing the fallback `else` to `else if challenge != nil`, preserving the expanded/collapsed email+password and passkey flows.

### Testing
- No automated tests were executed in this rollout; the fix was validated by static inspection of the modified `LoginView.swift` and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f614f4ccfc83209dc0101ea97a77c4)