### PR TITLE
Widen login environment picker for full cloud label visibility

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -54,6 +54,7 @@ struct LoginView: View {
                         }
                     }
                     .pickerStyle(.menu)
+                    .frame(minWidth: 190, alignment: .leading)
                     .tint(AppTheme.accent)
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
### Motivation
- The app-mode picker on the iOS login screen could wrap the "PyCashFlow Cloud" label to multiple lines, so increase the control width so the option fits on a single line for better readability.

### Description
- Added `.frame(minWidth: 190, alignment: .leading)` to the `Picker` in `ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift` to widen the environment selector.

### Testing
- No automated tests were run for this UI-only sizing tweak.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f616b932508320bb267706d65c202b)