### PR TITLE
Add user guide help icon to iOS Settings screen

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -75,6 +75,14 @@ struct SettingsView: View {
         .refreshable { await load() }
         .appBackground()
         .navigationTitle("Settings")
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Link(destination: URL(string: "https://pycashflow.com/user_guide")!) {
+                    Image(systemName: "questionmark.circle")
+                        .accessibilityLabel("User Guide")
+                }
+            }
+        }
     }
 
     private var moreSettingsURL: URL? {


### PR DESCRIPTION
### Motivation
- Provide a convenient, discoverable link to the PyCashFlow user guide from the mobile Settings screen. 
- Improve accessibility by adding an explicit control for help documentation in the app UI.

### Description
- Updated `ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift` to add a top-right toolbar item. 
- Added a `ToolbarItem(placement: .topBarTrailing)` containing a `Link` to `https://pycashflow.com/user_guide`. 
- The toolbar action displays the SF Symbol `questionmark.circle` and includes an accessibility label `"User Guide"` for VoiceOver support.

### Testing
- No automated tests were run for this UI-only SwiftUI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6184bdf8483209ea6fdbf41d7cbee)