### PR TITLE
Use DatePicker for start date in Schedules and Scenarios add forms

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -8,7 +8,7 @@ struct ScenariosView: View {
     @State private var amount = ""
     @State private var type = "Expense"
     @State private var frequency = "Monthly"
-    @State private var startDate = defaultStartDate()
+    @State private var startDate = Date()
     @State private var editingID: Int?
     @State private var editName = ""
     @State private var editAmount = ""
@@ -44,7 +44,9 @@ struct ScenariosView: View {
                         TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()
                         pickerRow(label: "Type", selection: $type, options: types)
                         pickerRow(label: "Frequency", selection: $frequency, options: frequencies)
-                        TextField("Start date (YYYY-MM-DD)", text: $startDate).fieldStyle()
+                        DatePicker("Start date", selection: $startDate, displayedComponents: .date)
+                            .datePickerStyle(.compact)
+                            .fieldStyle()
                         Button("Save Scenario") { Task { await addScenario() } }
                             .buttonStyle(PrimaryButtonStyle())
                     }
@@ -167,10 +169,6 @@ struct ScenariosView: View {
         return formatter
     }()
 
-    private static func defaultStartDate() -> String {
-        apiDateFormatter.string(from: Date())
-    }
-
     private static func parseAPIDate(_ value: String) -> Date {
         apiDateFormatter.date(from: value) ?? Date()
     }
@@ -184,7 +182,7 @@ struct ScenariosView: View {
         amount = ""
         type = "Expense"
         frequency = "Monthly"
-        startDate = Self.defaultStartDate()
+        startDate = Date()
         errorText = nil
     }
 
@@ -229,7 +227,7 @@ struct ScenariosView: View {
                 "scenarios",
                 method: "POST",
                 token: token,
-                body: Payload(name: name, amount: amount, type: type, frequency: frequency, start_date: startDate),
+                body: Payload(name: name, amount: amount, type: type, frequency: frequency, start_date: Self.formatAPIDate(startDate)),
                 as: APIEnvelope<ScenarioDTO>.self
             )
             await load()

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -8,7 +8,7 @@ struct SchedulesView: View {
     @State private var amount = ""
     @State private var type = "Expense"
     @State private var frequency = "Monthly"
-    @State private var startDate = defaultStartDate()
+    @State private var startDate = Date()
     @State private var editingID: Int?
     @State private var editName = ""
     @State private var editAmount = ""
@@ -45,7 +45,9 @@ struct SchedulesView: View {
                         TextField("Amount", text: $amount).keyboardType(.decimalPad).fieldStyle()
                         pickerRow(label: "Type", selection: $type, options: types)
                         pickerRow(label: "Frequency", selection: $frequency, options: frequencies)
-                        TextField("Start date (YYYY-MM-DD)", text: $startDate).fieldStyle()
+                        DatePicker("Start date", selection: $startDate, displayedComponents: .date)
+                            .datePickerStyle(.compact)
+                            .fieldStyle()
                         Button("Save Schedule") { Task { await addSchedule() } }
                             .buttonStyle(PrimaryButtonStyle())
                     }
@@ -190,10 +192,6 @@ struct SchedulesView: View {
         return formatter
     }()
 
-    private static func defaultStartDate() -> String {
-        apiDateFormatter.string(from: Date())
-    }
-
     private static func parseAPIDate(_ value: String) -> Date {
         apiDateFormatter.date(from: value) ?? Date()
     }
@@ -207,7 +205,7 @@ struct SchedulesView: View {
         amount = ""
         type = "Expense"
         frequency = "Monthly"
-        startDate = Self.defaultStartDate()
+        startDate = Date()
         errorText = nil
     }
 
@@ -252,7 +250,7 @@ struct SchedulesView: View {
                 "schedules",
                 method: "POST",
                 token: token,
-                body: Payload(name: name, amount: amount, type: type, frequency: frequency, start_date: startDate),
+                body: Payload(name: name, amount: amount, type: type, frequency: frequency, start_date: Self.formatAPIDate(startDate)),
                 as: APIEnvelope<ScheduleDTO>.self
             )
             await load()


### PR DESCRIPTION
### Motivation
- The add forms for Schedules and Scenarios used free-text date entry which is error-prone and a poor UX on iOS, so the start date input should be a native date picker. 

### Description
- Replaced the free-text `TextField(

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61c6e50488320a9764a3e75a3870a)