### PR TITLE
Show bottom nav across authenticated iOS views

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -25,11 +25,35 @@ struct RootView: View {
                         }
                     }
                 }
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    if session.accessState == .allowed || (session.accessState == .blocked && session.appMode != .cloud) {
+                        if session.user?.is_guest == true {
+                            GuestSettingsButton()
+                        } else {
+                            FloatingNavBar(items: navItems)
+                        }
+                    }
+                }
             }
         }
         .task {
             await session.bootstrap()
         }
         .preferredColorScheme(.dark)
+    }
+}
+
+
+private extension RootView {
+    var navItems: [FloatingNavItem] {
+        [
+            FloatingNavItem(title: "Dashboard", systemImage: "house") { DashboardView() },
+            FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle") { BalanceView() },
+            FloatingNavItem(title: "Schedules", systemImage: "calendar") { SchedulesView() },
+            FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3") { ScenariosView() },
+            FloatingNavItem(title: "Holds", systemImage: "pause.circle") { HoldsView() },
+            FloatingNavItem(title: "AI Insights", systemImage: "sparkles") { AIInsightsView() },
+            FloatingNavItem(title: "Settings", systemImage: "gearshape") { SettingsView() }
+        ]
     }
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -68,24 +68,6 @@ struct DashboardView: View {
         .refreshable { await loadAll() }
         .appBackground()
         .navigationTitle("Dashboard")
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            if session.user?.is_guest == true {
-                GuestSettingsButton()
-            } else {
-                FloatingNavBar(items: navItems)
-            }
-        }
-    }
-
-    private var navItems: [FloatingNavItem] {
-        [
-            FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle") { BalanceView() },
-            FloatingNavItem(title: "Schedules", systemImage: "calendar") { SchedulesView() },
-            FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3") { ScenariosView() },
-            FloatingNavItem(title: "Holds", systemImage: "pause.circle") { HoldsView() },
-            FloatingNavItem(title: "AI Insights", systemImage: "sparkles") { AIInsightsView() },
-            FloatingNavItem(title: "Settings", systemImage: "gearshape") { SettingsView() }
-        ]
     }
 
     private func metricsGrid<Content: View>(@ViewBuilder content: () -> Content) -> some View {


### PR DESCRIPTION
### Motivation
- Ensure the bottom navigation is visible across all authenticated app screens while remaining hidden for pre-login and subscription-paywall flows.

### Description
- Move the bottom navigation `safeAreaInset` from `DashboardView` into `RootView` so the nav is injected at the app root for authenticated sessions.
- Add a `private extension RootView` that defines shared `navItems`, including a new "Dashboard" entry, and use those items for the `FloatingNavBar`.
- Conditionally render the inset only when `session.accessState` allows the main app (and for self-hosted blocked mode), keeping it hidden for login and cloud paywall screens.
- Remove the duplicated nav inset and `navItems` definition from `DashboardView` to centralize navigation behavior.

### Testing
- Attempted to run `xcodebuild -list -project pycashflow.xcodeproj` to validate the iOS workspace, but the command failed because `xcodebuild` is not installed in this environment.
- No additional automated iOS build or unit tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f61f848e70832085f9f6f0fbda6003)