### PR TITLE
Fix RootView compile error with AccessState.blocked associated value

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -26,7 +26,7 @@ struct RootView: View {
                     }
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {
-                    if session.accessState == .allowed || (session.accessState == .blocked && session.appMode != .cloud) {
+                    if shouldShowBottomBar {
                         if session.user?.is_guest == true {
                             GuestSettingsButton()
                         } else {
@@ -45,6 +45,17 @@ struct RootView: View {
 
 
 private extension RootView {
+    var shouldShowBottomBar: Bool {
+        switch session.accessState {
+        case .allowed:
+            return true
+        case .blocked:
+            return session.appMode != .cloud
+        case .unknown, .checking:
+            return false
+        }
+    }
+
     var navItems: [FloatingNavItem] {
         [
             FloatingNavItem(title: "Dashboard", systemImage: "house") { DashboardView() },


### PR DESCRIPTION
### Motivation
- Fix a compile break caused by treating `AccessState.blocked` as an equatable case after it was changed to include an associated `message` value, which made `session.accessState == .blocked` invalid.

### Description
- Replace the inline equality check in `ios-app/pycashflow/PyCashFlowApp/App/RootView.swift` with a computed `shouldShowBottomBar` property that pattern-matches `session.accessState` via an exhaustive `switch`, and update the `.safeAreaInset` to use `shouldShowBottomBar`.

### Testing
- Attempted to validate with `xcodebuild -list -project ios-app/pycashflow.xcodeproj`, which failed in this environment because `xcodebuild` is not installed, so no iOS build or automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f620b329ac8320b7eb5699a1fdd54d)