### PR TITLE
Fix iOS bottom-nav dashboard self-push regression

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -58,7 +58,6 @@ private extension RootView {
 
     var navItems: [FloatingNavItem] {
         [
-            FloatingNavItem(title: "Dashboard", systemImage: "house") { DashboardView() },
             FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle") { BalanceView() },
             FloatingNavItem(title: "Schedules", systemImage: "calendar") { SchedulesView() },
             FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3") { ScenariosView() },


### PR DESCRIPTION
### Motivation

- The root-level floating navigation included a `Dashboard` item that created a `NavigationLink` to `DashboardView`, which allowed pushing the same view onto the navigation stack when the authenticated home screen was already `DashboardView`.

### Description

- Removed the `Dashboard` `FloatingNavItem` from `navItems` in `ios-app/pycashflow/PyCashFlowApp/App/RootView.swift` to prevent self-push behavior.

### Testing

- Ran the full test suite with `python -m pytest -q`, and it passed with `280 passed, 50 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6213f0f2c832094eace7ee5cbfe28)