### PR TITLE
Fix persistent iOS nav bar buttons not changing views

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct RootView: View {
     @EnvironmentObject var session: SessionManager
+    @State private var selectedSection: AppSection = .dashboard
 
     var body: some View {
         Group {
@@ -16,12 +17,12 @@ struct RootView: View {
                         ProgressView("Checking account status...")
                             .foregroundStyle(AppTheme.textPrimary)
                     case .allowed:
-                        DashboardView()
+                        selectedView
                     case .blocked:
                         if session.appMode == .cloud {
                             SubscriptionPaywallView()
                         } else {
-                            DashboardView()
+                            selectedView
                         }
                     }
                 }
@@ -30,7 +31,7 @@ struct RootView: View {
                         if session.user?.is_guest == true {
                             GuestSettingsButton()
                         } else {
-                            FloatingNavBar(items: navItems)
+                            FloatingNavBar(items: navItems, selectedSection: $selectedSection)
                         }
                     }
                 }
@@ -58,12 +59,42 @@ private extension RootView {
 
     var navItems: [FloatingNavItem] {
         [
-            FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle") { BalanceView() },
-            FloatingNavItem(title: "Schedules", systemImage: "calendar") { SchedulesView() },
-            FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3") { ScenariosView() },
-            FloatingNavItem(title: "Holds", systemImage: "pause.circle") { HoldsView() },
-            FloatingNavItem(title: "AI Insights", systemImage: "sparkles") { AIInsightsView() },
-            FloatingNavItem(title: "Settings", systemImage: "gearshape") { SettingsView() }
+            FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle", section: .balance),
+            FloatingNavItem(title: "Schedules", systemImage: "calendar", section: .schedules),
+            FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3", section: .scenarios),
+            FloatingNavItem(title: "Holds", systemImage: "pause.circle", section: .holds),
+            FloatingNavItem(title: "AI Insights", systemImage: "sparkles", section: .aiInsights),
+            FloatingNavItem(title: "Settings", systemImage: "gearshape", section: .settings)
         ]
     }
+
+    @ViewBuilder
+    var selectedView: some View {
+        switch selectedSection {
+        case .dashboard:
+            DashboardView()
+        case .balance:
+            BalanceView()
+        case .schedules:
+            SchedulesView()
+        case .scenarios:
+            ScenariosView()
+        case .holds:
+            HoldsView()
+        case .aiInsights:
+            AIInsightsView()
+        case .settings:
+            SettingsView()
+        }
+    }
+}
+
+enum AppSection {
+    case dashboard
+    case balance
+    case schedules
+    case scenarios
+    case holds
+    case aiInsights
+    case settings
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// available width is too narrow to fit every button.
 struct FloatingNavBar: View {
     let items: [FloatingNavItem]
+    @Binding var selectedSection: AppSection
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
@@ -25,8 +26,8 @@ struct FloatingNavBar: View {
     private var navContent: some View {
         HStack(spacing: 4) {
             ForEach(items) { item in
-                NavigationLink {
-                    item.destination
+                Button {
+                    selectedSection = item.section
                 } label: {
                     FloatingNavItemLabel(item: item)
                 }
@@ -64,13 +65,7 @@ struct FloatingNavItem: Identifiable {
     let id = UUID()
     let title: String
     let systemImage: String
-    let destination: AnyView
-
-    init<Destination: View>(title: String, systemImage: String, @ViewBuilder destination: () -> Destination) {
-        self.title = title
-        self.systemImage = systemImage
-        self.destination = AnyView(destination())
-    }
+    let section: AppSection
 }
 
 private struct FloatingNavItemLabel: View {


### PR DESCRIPTION
### Motivation
- The floating persistent bottom nav was rendered in a safe-area inset and used `NavigationLink` destinations there, which did not reliably push new views and left the app stuck on the dashboard.
- The change moves routing to a single root-level state so taps deterministically swap the active root content instead of relying on link pushes from the inset.

### Description
- Added a `@State` `selectedSection: AppSection` to `RootView` and a `@ViewBuilder` `selectedView` to render the active screen based on that state.
- Introduced the `AppSection` enum and changed `navItems` to create `FloatingNavItem` instances that carry a `section` identifier instead of destination views.
- Updated `FloatingNavBar` to accept `@Binding var selectedSection: AppSection` and replaced `NavigationLink` usages with `Button` actions that set the selected section.
- Removed the `AnyView` destination plumbing from `FloatingNavItem` and left the guest-only `GuestSettingsButton` unchanged (it still uses a `NavigationLink` to `SettingsView`).

### Testing
- No automated iOS/Xcode tests were executed in this environment because an iOS build/test target is not configured here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6221cc15c832092c50cb6b68a24af)