### PR TITLE
iOS: restore Dashboard navigation in bottom nav bar

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -59,6 +59,7 @@ private extension RootView {
 
     var navItems: [FloatingNavItem] {
         [
+            FloatingNavItem(title: "Dashboard", systemImage: "house", section: .dashboard),
             FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle", section: .balance),
             FloatingNavItem(title: "Schedules", systemImage: "calendar", section: .schedules),
             FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3", section: .scenarios),


### PR DESCRIPTION
### Motivation
- A recent navigation refactor switched to section selection but omitted any item mapping to `.dashboard`, preventing users from returning to `DashboardView` after navigating to other sections.

### Description
- Added `FloatingNavItem(title: "Dashboard", systemImage: "house", section: .dashboard)` to `navItems` in `ios-app/pycashflow/PyCashFlowApp/App/RootView.swift` to restore an explicit path back to `DashboardView`.

### Testing
- No automated tests were run for this UI-only change; change is additive and low-risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f623a6fd28832090cbb40a7f4b49c4)