### PR TITLE
Apply bottom safe-area padding in RootView when bottom bar is visible

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -18,11 +18,13 @@ struct RootView: View {
                             .foregroundStyle(AppTheme.textPrimary)
                     case .allowed:
                         selectedView
+                            .safeAreaPadding(.bottom, bottomContentInset)
                     case .blocked:
                         if session.appMode == .cloud {
                             SubscriptionPaywallView()
                         } else {
                             selectedView
+                                .safeAreaPadding(.bottom, bottomContentInset)
                         }
                     }
                 }
@@ -55,6 +57,10 @@ private extension RootView {
         case .unknown, .checking:
             return false
         }
+    }
+
+    var bottomContentInset: CGFloat {
+        shouldShowBottomBar ? 112 : 0
     }
 
     var navItems: [FloatingNavItem] {


### PR DESCRIPTION
### Motivation
- Ensure main content is not obscured by the floating bottom navigation or guest button by applying explicit bottom padding when the bottom bar is present.
- Keep consistent layout for both `.allowed` and `.blocked` access states where the bottom bar can appear.

### Description
- Added a computed property `bottomContentInset` that returns `112` when `shouldShowBottomBar` is true and `0` otherwise.
- Applied `.safeAreaPadding(.bottom, bottomContentInset)` to `selectedView` in the `.allowed` and `.blocked` UI flows to offset content above the bottom inset.
- Kept the existing `safeAreaInset(edge: .bottom, spacing: 0)` logic for rendering the floating navigation or guest button unchanged.

### Testing
- No automated tests were added for this UI spacing change.
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f624eb03088320bd1e628808dc3712)