### PR TITLE
Sort iOS cards by date in schedules/scenarios/skips

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Holds/HoldsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Holds/HoldsView.swift
@@ -9,6 +9,14 @@ struct HoldsView: View {
     @State private var skipsError: String?
     @State private var holdsStatus: String?
     @State private var skipsStatus: String?
+    private var sortedSkips: [SkipDTO] {
+        skips.sorted {
+            let lhsDate = Self.parseAPIDate($0.date)
+            let rhsDate = Self.parseAPIDate($1.date)
+            if lhsDate == rhsDate { return $0.id < $1.id }
+            return lhsDate < rhsDate
+        }
+    }
 
     private enum Tab: String, CaseIterable, Identifiable {
         case holds = "Holds"
@@ -126,7 +134,7 @@ struct HoldsView: View {
                     .listRowBackground(Color.clear)
             }
 
-            ForEach(skips) { skip in
+            ForEach(sortedSkips) { skip in
                 HStack(spacing: 12) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(skip.name)
@@ -267,5 +275,19 @@ struct HoldsView: View {
                 skipsStatus = nil
             }
         }
+    }
+
+    private static let apiDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    private static func parseAPIDate(_ value: String?) -> Date {
+        guard let value else { return .distantFuture }
+        return apiDateFormatter.date(from: value) ?? .distantFuture
     }
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Scenarios/ScenariosView.swift
@@ -19,6 +19,14 @@ struct ScenariosView: View {
 
     private let types = ["Expense", "Income"]
     private let frequencies = ["Monthly", "Quarterly", "Yearly", "Weekly", "BiWeekly", "Onetime"]
+    private var sortedScenarios: [ScenarioDTO] {
+        scenarios.sorted {
+            let lhsDate = Self.parseAPIDate($0.start_date)
+            let rhsDate = Self.parseAPIDate($1.start_date)
+            if lhsDate == rhsDate { return $0.id < $1.id }
+            return lhsDate < rhsDate
+        }
+    }
 
     var body: some View {
         List {
@@ -70,7 +78,7 @@ struct ScenariosView: View {
                         .foregroundStyle(AppTheme.textMuted)
                 }
 
-                ForEach(scenarios) { scenario in
+                ForEach(sortedScenarios) { scenario in
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(spacing: 12) {
                             VStack(alignment: .leading, spacing: 4) {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Schedules/SchedulesView.swift
@@ -20,6 +20,14 @@ struct SchedulesView: View {
 
     private let types = ["Expense", "Income"]
     private let frequencies = ["Monthly", "Quarterly", "Yearly", "Weekly", "BiWeekly", "Onetime"]
+    private var sortedSchedules: [ScheduleDTO] {
+        schedules.sorted {
+            let lhsDate = Self.parseAPIDate($0.start_date)
+            let rhsDate = Self.parseAPIDate($1.start_date)
+            if lhsDate == rhsDate { return $0.id < $1.id }
+            return lhsDate < rhsDate
+        }
+    }
 
     var body: some View {
         List {
@@ -79,7 +87,7 @@ struct SchedulesView: View {
                         .foregroundStyle(AppTheme.textMuted)
                 }
 
-                ForEach(schedules) { schedule in
+                ForEach(sortedSchedules) { schedule in
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(spacing: 12) {
                             VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
### Motivation
- User-facing lists for Schedules, Scenarios, and Skips were rendered in server/default order (effectively by ID) instead of chronological order, making the app's UI confusing for date-driven items.
- The change ensures cards appear in ascending date order so users see upcoming items first.

### Description
- Added `sortedSchedules` to `SchedulesView` and replaced `ForEach(schedules)` with `ForEach(sortedSchedules)` so schedules are ordered by `start_date` with `id` as a tiebreaker.
- Added `sortedScenarios` to `ScenariosView` and replaced `ForEach(scenarios)` with `ForEach(sortedScenarios)` so scenarios are ordered by `start_date` with `id` as a tiebreaker.
- Added `sortedSkips` to `HoldsView`, switched the skips tab to `ForEach(sortedSkips)`, and introduced `apiDateFormatter` + `parseAPIDate` helpers to safely parse optional API date strings and use `.distantFuture` for missing/invalid dates.
- Tie-breaking by `id` preserves a stable order when dates are equal and no server-side contract changes were required.

### Testing
- Ran repository sanity checks including `git diff --check`, which passed with no whitespace/diff errors.
- No automated iOS unit or UI tests were executed in this rollout; recommend running an Xcode build and the app's iOS test suite to validate UI ordering on device/simulator.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f638398b3c8320bc98e3ad15b8d74c)