### PR TITLE
Fix guest iOS navigation so dashboard remains reachable

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -31,7 +31,7 @@ struct RootView: View {
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     if shouldShowBottomBar {
                         if session.user?.is_guest == true {
-                            GuestSettingsButton()
+                            GuestSettingsButton(selectedSection: $selectedSection)
                         } else {
                             FloatingNavBar(items: navItems, selectedSection: $selectedSection)
                         }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -42,22 +42,28 @@ struct FloatingNavBar: View {
 /// Small circular Liquid Glass button anchored to the bottom-right, used
 /// as the only navigation affordance for guest users (Settings access).
 struct GuestSettingsButton: View {
+    @Binding var selectedSection: AppSection
+
     var body: some View {
-        HStack {
-            Spacer()
-            NavigationLink {
-                SettingsView()
-            } label: {
-                Image(systemName: "gearshape")
-                    .font(.system(size: 20, weight: .semibold))
-                    .foregroundStyle(AppTheme.textPrimary)
-                    .frame(width: 48, height: 48)
-            }
-            .buttonStyle(FloatingNavButtonStyle())
-            .glassEffect(.regular.interactive(), in: Circle())
+        HStack(spacing: 12) {
+            guestButton(systemImage: "house", section: .dashboard)
+            guestButton(systemImage: "gearshape", section: .settings)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 8)
+    }
+
+    private func guestButton(systemImage: String, section: AppSection) -> some View {
+        Button {
+            selectedSection = section
+        } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: 20, weight: .semibold))
+                .foregroundStyle(AppTheme.textPrimary)
+                .frame(width: 48, height: 48)
+        }
+        .buttonStyle(FloatingNavButtonStyle())
+        .glassEffect(.regular.interactive(), in: Circle())
     }
 }
 


### PR DESCRIPTION
### Motivation
- A recent iOS navigation change left guest users routed into Settings with no easy way to return to the Dashboard.  
- Guests should remain limited in functionality but still be able to view the Dashboard from the same root navigation state as authenticated users.  

### Description
- Pass the `selectedSection` binding from `RootView` into the guest control by updating `ios-app/.../App/RootView.swift` to call `GuestSettingsButton(selectedSection: $selectedSection)`.  
- Replace the one-way `NavigationLink` in `ios-app/.../Features/Dashboard/FloatingNavBar.swift` with a `GuestSettingsButton` that accepts `@Binding var selectedSection: AppSection` and provides two buttons that set `selectedSection` to `.dashboard` or `.settings`.  
- Add a small `guestButton(systemImage:section:)` helper to render the guest circular buttons and reuse the existing `FloatingNavButtonStyle` and `glassEffect`.  

### Testing
- Ran `python -m pytest -q tests/test_routes.py` and all tests passed (`35 passed`) with expected SQLAlchemy deprecation warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b301049c8320b5932c2994938b55)