### PR TITLE
iOS: Ensure users land on Dashboard after login

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -42,6 +42,11 @@ struct RootView: View {
         .task {
             await session.bootstrap()
         }
+        .onChange(of: session.isAuthenticated) { _, isAuthenticated in
+            if isAuthenticated {
+                selectedSection = .dashboard
+            }
+        }
         .preferredColorScheme(.dark)
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent users (including account owners) from being left on a previously-selected tab (e.g., `Settings`) after completing login by forcing the app to show the Dashboard on authentication.

### Description
- Add an `onChange` handler in `RootView` to watch `session.isAuthenticated` and set `selectedSection = .dashboard` when it becomes `true`, implemented in `ios-app/pycashflow/PyCashFlowApp/App/RootView.swift`.

### Testing
- Attempted to run an Xcode project check with `xcodebuild -list -project ios-app/pycashflow.xcodeproj`, but it could not be executed in this environment because `xcodebuild` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b57668688320a3de407bf780b808)