### PR TITLE
Show blocking spinner and auto-reload during AI Insights refresh

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
@@ -7,7 +7,8 @@ struct AIInsightsView: View {
     @State private var isRefreshing = false
 
     var body: some View {
-        ScrollView {
+        ZStack {
+            ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 if let insights {
                     if let model = insights.model, !model.isEmpty {
@@ -65,7 +66,22 @@ struct AIInsightsView: View {
             }
             .frame(maxWidth: .infinity, alignment: .topLeading)
             .padding(20)
+            }
+            .disabled(isRefreshing)
+
+            if isRefreshing {
+                ZStack {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+
+                    ProgressView("Refreshing AI insights...")
+                        .padding(20)
+                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 12))
+                }
+                .transition(.opacity)
+            }
         }
+        .animation(.easeInOut(duration: 0.2), value: isRefreshing)
         .task { await load() }
         .refreshable { await load() }
         .appBackground()
@@ -134,6 +150,7 @@ struct AIInsightsView: View {
             )
             insights = response.data
             errorText = nil
+            await load()
         } catch {
             errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to refresh insights"
         }


### PR DESCRIPTION
### Motivation
- Prevent the AI Insights view from getting stuck or accepting interactions while a long-running refresh is in progress by clearly indicating loading state and blocking input.
- Ensure the view reflects the server-persisted insights immediately after a refresh completes so users do not need to manually refresh again.

### Description
- Wrap the existing `ScrollView` in a `ZStack` and add a full-screen dimmed overlay with a centered `ProgressView("Refreshing AI insights...")` that appears while `isRefreshing` is true.
- Disable the underlying content during refresh by binding `.disabled(isRefreshing)` to the main content container so taps and scrolls are blocked while the overlay is visible.
- Add an `await load()` call after a successful `insights/refresh` `POST` so the view automatically fetches the latest persisted insights when the refresh finishes.
- Add a short `.animation(.easeInOut(duration: 0.2), value: isRefreshing)` to animate showing and hiding the overlay.

### Testing
- Attempted to run an iOS project build listing with `xcodebuild -list -project pycashflow.xcodeproj`, but `xcodebuild` is not available in the container environment so no automated iOS build or tests were executed (failed).
- No other automated tests were run in this environment after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b7e888d08320be50ec6006c9698c)