### PR TITLE
Refine iOS AI insights and settings summary cards

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
@@ -11,13 +11,9 @@ struct AIInsightsView: View {
             ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 if let insights {
-                    if let model = insights.model, !model.isEmpty {
-                        infoRow(label: "Model", value: model)
-                    }
                     if let lastUpdated = insights.last_updated, !lastUpdated.isEmpty {
                         infoRow(label: "Last Updated", value: Self.formatLastUpdated(lastUpdated))
                     }
-                    infoRow(label: "AI Configured", value: insights.configured ? "Yes" : "No")
                 }
 
                 if let items = insights?.insights, !items.isEmpty {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -14,11 +14,10 @@ struct SettingsView: View {
                 if let settings {
                     infoRow(label: "Signed in as", value: settings.user.email)
                     infoRow(label: "Backend Version", value: settings.app.version)
-                    infoRow(label: "AI Configured", value: settings.ai.configured ? "Yes" : "No")
+                    infoRow(label: "AI Configured", value: aiConfiguredValue(settings.ai))
                 }
 
                 infoRow(label: "Mode", value: session.appMode.label)
-                infoRow(label: "API", value: session.currentBaseURL.absoluteString)
 
                 if let billing = session.billingStatus {
                     infoRow(
@@ -26,7 +25,7 @@ struct SettingsView: View {
                         value: "\(billing.subscription_status ?? "inactive") via \(billing.subscription_source ?? "none")"
                     )
                     if let expiry = billing.subscription_expiry {
-                        infoRow(label: "Subscription expiry", value: expiry)
+                        infoRow(label: "Subscription expiry", value: Self.formatFriendlyDateTime(expiry))
                     }
                 }
 
@@ -106,6 +105,36 @@ struct SettingsView: View {
                 .fixedSize(horizontal: false, vertical: true)
         }
         .cardRow()
+    }
+
+
+    private func aiConfiguredValue(_ ai: SettingsDTO.SettingsAIDTO) -> String {
+        guard ai.configured else { return "No" }
+        if let model = ai.model, !model.isEmpty {
+            return "Yes, \(model)"
+        }
+        return "Yes"
+    }
+
+    private static let dateTimeParser: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let friendlyDateTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.doesRelativeDateFormatting = true
+        formatter.locale = .autoupdatingCurrent
+        formatter.timeZone = .autoupdatingCurrent
+        return formatter
+    }()
+
+    static func formatFriendlyDateTime(_ raw: String) -> String {
+        guard let date = dateTimeParser.date(from: raw) else { return raw }
+        return friendlyDateTimeFormatter.string(from: date)
     }
 
     private func load() async {


### PR DESCRIPTION
### Motivation
- Simplify the AI Insights UI by removing redundant fields so the page focuses on human-readable insights and the friendly "Last Updated" stamp.
- Reduce noise on the Settings screen by removing the raw `API` URL exposure and making subscription expiry more user-friendly.
- Surface the configured AI model succinctly in Settings so users can see both configuration state and the active model (e.g., `Yes, gpt-5.5`).

### Description
- Removed the `Model` and `AI Configured` info cards from `AIInsightsView` so only `Last Updated` remains (`ios-app/.../AIInsightsView.swift`).
- Removed the `API` info card from `SettingsView` and replaced the `AI Configured` text with a helper `aiConfiguredValue(_:)` that returns `No`, `Yes`, or `Yes, <model>` as appropriate (`ios-app/.../SettingsView.swift`).
- Rendered `Subscription expiry` using a localized friendly date/time formatter by adding `dateTimeParser`, `friendlyDateTimeFormatter`, and `formatFriendlyDateTime(_:)` helpers with safe fallback to the raw server value when parsing fails (`ios-app/.../SettingsView.swift`).
- Kept changes localized to the two SwiftUI view files and reused the existing `infoRow` card layout for consistent appearance.

### Testing
- No automated tests were executed for this change set; edits are limited to client-side Swift UI code.
- Changes were implemented as localized, low-risk UI modifications and include parsing fallback to preserve backward compatibility with existing API payloads.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6b9a6fb3883209011be9e1d4b1580)