### PR TITLE
Fix misleading AI insights error after refresh

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
@@ -146,7 +146,6 @@ struct AIInsightsView: View {
             )
             insights = response.data
             errorText = nil
-            await load()
         } catch {
             errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to refresh insights"
         }


### PR DESCRIPTION
### Motivation
- Avoid showing a misleading "Failed to load insights" error when a transient GET after a successful POST refresh fails.

### Description
- Remove the redundant `await load()` call in `refreshInsights()` in `ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift` so the UI retains the successful POST response (`insights`) and cleared `errorText`.

### Testing
- No automated tests were run for this trivial UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ba200fc48320b59682106f7e4614)