### PR TITLE
Disable iOS bottom nav interactions during AI Insights refresh

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -31,9 +31,9 @@ struct RootView: View {
                 .safeAreaInset(edge: .bottom, spacing: 0) {
                     if shouldShowBottomBar {
                         if session.user?.is_guest == true {
-                            GuestSettingsButton(selectedSection: $selectedSection)
+                            GuestSettingsButton(selectedSection: $selectedSection, isDisabled: session.isNavigationInteractionLocked)
                         } else {
-                            FloatingNavBar(items: navItems, selectedSection: $selectedSection)
+                            FloatingNavBar(items: navItems, selectedSection: $selectedSection, isDisabled: session.isNavigationInteractionLocked)
                         }
                     }
                 }

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Auth/SessionManager.swift
@@ -30,6 +30,7 @@ final class SessionManager: ObservableObject {
     @Published var accessState: AccessState = .unknown
     @Published var appMode: AppMode = SessionManager.loadMode()
     @Published var selfHostedBaseURLText: String = SessionManager.loadSelfHostedURL().absoluteString
+    @Published var isNavigationInteractionLocked = false
 
     var isAuthenticated: Bool { token != nil }
     var currentBaseURL: URL { APIClient.shared.baseURL }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -8,6 +8,7 @@ import SwiftUI
 struct FloatingNavBar: View {
     let items: [FloatingNavItem]
     @Binding var selectedSection: AppSection
+    let isDisabled: Bool
 
     var body: some View {
         ViewThatFits(in: .horizontal) {
@@ -32,6 +33,7 @@ struct FloatingNavBar: View {
                     FloatingNavItemLabel(item: item)
                 }
                 .buttonStyle(FloatingNavButtonStyle())
+                .disabled(isDisabled)
             }
         }
         .padding(.horizontal, 10)
@@ -43,6 +45,7 @@ struct FloatingNavBar: View {
 /// as the only navigation affordance for guest users (Settings access).
 struct GuestSettingsButton: View {
     @Binding var selectedSection: AppSection
+    let isDisabled: Bool
 
     var body: some View {
         HStack(spacing: 12) {
@@ -63,6 +66,7 @@ struct GuestSettingsButton: View {
                 .frame(width: 48, height: 48)
         }
         .buttonStyle(FloatingNavButtonStyle())
+        .disabled(isDisabled)
         .glassEffect(.regular.interactive(), in: Circle())
     }
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Insights/AIInsightsView.swift
@@ -82,6 +82,11 @@ struct AIInsightsView: View {
         .refreshable { await load() }
         .appBackground()
         .navigationTitle("AI Insights")
+        .onDisappear {
+            if isRefreshing == false {
+                session.isNavigationInteractionLocked = false
+            }
+        }
     }
 
     private func infoRow(label: String, value: String) -> some View {
@@ -136,7 +141,11 @@ struct AIInsightsView: View {
     private func refreshInsights() async {
         guard let token = session.token else { return }
         isRefreshing = true
-        defer { isRefreshing = false }
+        session.isNavigationInteractionLocked = true
+        defer {
+            isRefreshing = false
+            session.isNavigationInteractionLocked = false
+        }
         do {
             let response: APIEnvelope<InsightsDTO> = try await APIClient.shared.request(
                 "insights/refresh",


### PR DESCRIPTION
### Motivation
- While the AI Insights refresh spinner overlay is visible, the bottom navigation buttons remained tappable which could navigate away mid-refresh and lead to confusing UI state.

### Description
- Added a published UI lock flag `isNavigationInteractionLocked` to `SessionManager` so views can opt into a global temporary navigation lock. 
- Updated `RootView` to pass the lock state into `FloatingNavBar` and `GuestSettingsButton` via a new `isDisabled` parameter. 
- Applied `.disabled(isDisabled)` to nav button targets in `FloatingNavBar` and `GuestSettingsButton` so taps are ignored when locked. 
- Updated `AIInsightsView.refreshInsights()` to set `session.isNavigationInteractionLocked = true` at start and clear it in `defer`, and added an `.onDisappear` defensive unlock when not actively refreshing. 

### Testing
- Attempted iOS build tooling verification with `cd ios-app && xcodebuild -list -project pycashflow.xcodeproj`, which failed because `xcodebuild` is not available in this environment (no build performed). 
- No automated unit or UI tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6bbf9a31083208a53295602bfb804)