### PR TITLE
Upgrade iOS bottom navigation to polished glass-style morphing tab bar

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -1,62 +1,118 @@
 import SwiftUI
 
-/// Floating bottom navigation bar rendered with the iOS 26 Liquid Glass
-/// material so it matches the translucent back button SwiftUI renders in
-/// the navigation bar. Sizes to fit its buttons and stays horizontally
-/// centered, falling back to a horizontal scroll view only when the
-/// available width is too narrow to fit every button.
+/// Floating bottom navigation bar with a native-feeling glass treatment,
+/// springy morphing selection pill, and reduced-motion fallback.
 struct FloatingNavBar: View {
     let items: [FloatingNavItem]
     @Binding var selectedSection: AppSection
     let isDisabled: Bool
 
+    @Namespace private var selectionNamespace
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         ViewThatFits(in: .horizontal) {
-            navContent
-                .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                navContent
+            navContainer {
+                HStack(spacing: 6) {
+                    navButtons
+                }
             }
-            .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
+
+            navContainer {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 6) {
+                        navButtons
+                    }
+                    .padding(.horizontal, 4)
+                }
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.horizontal, 16)
+        .padding(.top, 8)
+        .padding(.bottom, 8)
     }
 
-    private var navContent: some View {
-        HStack(spacing: 4) {
-            ForEach(items) { item in
-                Button {
+    @ViewBuilder
+    private var navButtons: some View {
+        ForEach(items) { item in
+            let isSelected = selectedSection == item.section
+
+            Button {
+                withAnimation(tabSelectionAnimation) {
                     selectedSection = item.section
-                } label: {
-                    FloatingNavItemLabel(item: item)
                 }
-                .buttonStyle(FloatingNavButtonStyle(isSelected: selectedSection == item.section))
-                .disabled(isDisabled)
+            } label: {
+                FloatingNavItemLabel(item: item, isSelected: isSelected)
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 8)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .background {
+                if isSelected {
+                    selectionPill
+                } else {
+                    Capsule(style: .continuous)
+                        .fill(.clear)
+                }
+            }
+            .accessibilityLabel(item.title)
+            .disabled(isDisabled)
+            .animation(reduceMotion ? .easeOut(duration: 0.15) : tabSelectionAnimation, value: isSelected)
+        }
+    }
+
+    private var selectionPill: some View {
+        Capsule(style: .continuous)
+            .fill(.white.opacity(0.18))
+            .overlay {
+                Capsule(style: .continuous)
+                    .stroke(.white.opacity(0.24), lineWidth: 0.8)
+            }
+            .shadow(color: .black.opacity(0.18), radius: 8, x: 0, y: 4)
+            .matchedGeometryEffect(id: "tab-selection", in: selectionNamespace)
+    }
+
+    private var tabSelectionAnimation: Animation {
+        reduceMotion
+            ? .easeOut(duration: 0.14)
+            : .spring(response: 0.38, dampingFraction: 0.82, blendDuration: 0.12)
+    }
+
+    private func navContainer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+        content()
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .background {
+                RoundedRectangle(cornerRadius: 28, style: .continuous)
+                    .fill(.ultraThinMaterial)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 28, style: .continuous)
+                            .stroke(.white.opacity(0.12), lineWidth: 0.6)
+                    }
+                    .shadow(color: .black.opacity(0.18), radius: 16, x: 0, y: 6)
             }
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-    }
 }
 
-/// Small circular Liquid Glass button anchored to the bottom-right, used
-/// as the only navigation affordance for guest users (Settings access).
+/// Small circular button cluster used as the navigation affordance for
+/// guest users (Dashboard + Settings).
 struct GuestSettingsButton: View {
     @Binding var selectedSection: AppSection
     let isDisabled: Bool
 
     var body: some View {
         HStack(spacing: 12) {
-            guestButton(systemImage: "house", section: .dashboard)
-            guestButton(systemImage: "gearshape", section: .settings)
+            guestButton(systemImage: "house", label: "Dashboard", section: .dashboard)
+            guestButton(systemImage: "gearshape", label: "Settings", section: .settings)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 8)
     }
 
-    private func guestButton(systemImage: String, section: AppSection) -> some View {
+    private func guestButton(systemImage: String, label: String, section: AppSection) -> some View {
         Button {
             selectedSection = section
         } label: {
@@ -65,9 +121,15 @@ struct GuestSettingsButton: View {
                 .foregroundStyle(AppTheme.textPrimary)
                 .frame(width: 48, height: 48)
         }
-        .buttonStyle(FloatingNavButtonStyle(isSelected: selectedSection == section))
+        .buttonStyle(.plain)
+        .background(
+            Circle()
+                .fill(selectedSection == section ? .white.opacity(0.2) : .ultraThinMaterial)
+                .overlay(Circle().stroke(.white.opacity(0.14), lineWidth: 0.8))
+        )
+        .shadow(color: .black.opacity(0.16), radius: 10, x: 0, y: 4)
         .disabled(isDisabled)
-        .glassEffect(.regular.interactive(), in: Circle())
+        .accessibilityLabel(label)
     }
 }
 
@@ -80,44 +142,17 @@ struct FloatingNavItem: Identifiable {
 
 private struct FloatingNavItemLabel: View {
     let item: FloatingNavItem
+    let isSelected: Bool
 
     var body: some View {
         VStack(spacing: 2) {
             Image(systemName: item.systemImage)
-                .font(.system(size: 20, weight: .semibold))
+                .font(.system(size: 18, weight: isSelected ? .semibold : .medium))
             Text(item.title)
-                .font(.caption2.weight(.medium))
+                .font(.caption2.weight(isSelected ? .semibold : .medium))
                 .lineLimit(1)
         }
-        .foregroundStyle(AppTheme.textPrimary)
-        .frame(minWidth: 64)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
-    }
-}
-
-private struct FloatingNavButtonStyle: ButtonStyle {
-    let isSelected: Bool
-
-    func makeBody(configuration: Configuration) -> some View {
-        let pressed = configuration.isPressed
-
-        configuration.label
-            .background(
-                ZStack {
-                    if isSelected || pressed {
-                        Capsule(style: .continuous)
-                            .fill(AppTheme.accent.opacity(pressed ? 0.30 : 0.22))
-                            .overlay(
-                                Capsule(style: .continuous)
-                                    .stroke(.white.opacity(pressed ? 0.28 : 0.18), lineWidth: 1)
-                            )
-                            .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
-                    }
-                }
-            )
-            .scaleEffect(pressed ? 0.96 : 1)
-            .animation(.easeOut(duration: 0.12), value: pressed)
-            .animation(.easeOut(duration: 0.18), value: isSelected)
+        .foregroundStyle(isSelected ? AppTheme.textPrimary : AppTheme.textSecondary.opacity(0.9))
+        .frame(minWidth: 64, minHeight: 44)
     }
 }


### PR DESCRIPTION
### Motivation
- Modernize the app's bottom navigation to a polished, native-feeling glass-style control with a morphing selection indicator to improve perceived quality and match current iOS design language.
- Preserve all existing navigation destinations and behavior driven by the `selectedSection` binding so app routing and semantics remain unchanged.
- Respect accessibility and platform conventions by supporting `Reduce Motion`, safe-area placement, and readable tap targets.

### Description
- Reworked `FloatingNavBar` to render a rounded translucent container using SwiftUI material (`.ultraThinMaterial`) with subtle border and shadow for elevation while keeping the existing item list and layout semantics.
- Added a morphing selection pill implemented with `@Namespace` + `matchedGeometryEffect` and a spring `Animation` to smoothly transition the selected tab without abrupt jumps.
- Plumbed `@Environment(\.accessibilityReduceMotion)` to select a restrained ease-out animation when Reduce Motion is enabled, and limited animation amplitude accordingly.
- Improved per-item visuals and accessibility by adjusting icon/label weights, enforcing 44pt+ hit areas, and adding explicit `accessibilityLabel`s; also simplified guest button styling while preserving functionality.

### Testing
- Attempted an automated iOS build with `cd ios-app && xcodebuild -scheme pycashflow -destination 'generic/platform=iOS Simulator' build`, which failed due to the environment lacking `xcodebuild` (`command not found`).
- No other automated iOS tests were run in this environment; the change is UI-only and scoped to `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift` so runtime verification should be performed locally on macOS with Xcode (build + run in simulator) where the tab switching, selection morph, Reduce Motion behavior, and state persistence can be validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f76162cfb08320a1ef2df635de3f0b)