### PR TITLE
Fix FloatingNavBar ShapeStyle type mismatch

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -124,7 +124,7 @@ struct GuestSettingsButton: View {
         .buttonStyle(.plain)
         .background(
             Circle()
-                .fill(selectedSection == section ? .white.opacity(0.2) : .ultraThinMaterial)
+                .fill(selectedSection == section ? AnyShapeStyle(.white.opacity(0.2)) : AnyShapeStyle(.ultraThinMaterial))
                 .overlay(Circle().stroke(.white.opacity(0.14), lineWidth: 0.8))
         )
         .shadow(color: .black.opacity(0.16), radius: 10, x: 0, y: 4)


### PR DESCRIPTION
### Motivation
- Resolve a SwiftUI build break where a ternary expression in the guest nav button mixed `Color` and `Material` shape styles, preventing the compiler from inferring a single `ShapeStyle` type.
- Keep the visual appearance identical while making the expression compile reliably across Swift toolchains.

### Description
- Updated `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift` to wrap both ternary branches in `AnyShapeStyle`.
- Replaced `.fill(selectedSection == section ? .white.opacity(0.2) : .ultraThinMaterial)` with `.fill(selectedSection == section ? AnyShapeStyle(.white.opacity(0.2)) : AnyShapeStyle(.ultraThinMaterial))` to provide a consistent `ShapeStyle` type.
- No UI behavior changes were made beyond making the style type explicit.

### Testing
- Attempted an iOS build with `xcodebuild -project ios-app/pycashflow.xcodeproj -scheme pycashflow -sdk iphonesimulator -configuration Debug -quiet build`, which failed because `xcodebuild` is not available in this environment (`/bin/bash: xcodebuild: command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f762a8d6508320b54f53f5c3818e83)