### PR TITLE
Compact iOS floating nav bar with overflow “More” menu

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -33,7 +33,7 @@ struct RootView: View {
                         if session.user?.is_guest == true {
                             GuestSettingsButton(selectedSection: $selectedSection, isDisabled: session.isNavigationInteractionLocked)
                         } else {
-                            FloatingNavBar(items: navItems, selectedSection: $selectedSection, isDisabled: session.isNavigationInteractionLocked)
+                            FloatingNavBar(primaryItems: navItems, overflowItems: moreNavItems, selectedSection: $selectedSection, isDisabled: session.isNavigationInteractionLocked)
                         }
                     }
                 }
@@ -65,7 +65,7 @@ private extension RootView {
     }
 
     var bottomContentInset: CGFloat {
-        shouldShowBottomBar ? 112 : 0
+        shouldShowBottomBar ? 78 : 0
     }
 
     var navItems: [FloatingNavItem] {
@@ -73,10 +73,15 @@ private extension RootView {
             FloatingNavItem(title: "Dashboard", systemImage: "house", section: .dashboard),
             FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle", section: .balance),
             FloatingNavItem(title: "Schedules", systemImage: "calendar", section: .schedules),
+            FloatingNavItem(title: "Settings", systemImage: "gearshape", section: .settings)
+        ]
+    }
+
+    var moreNavItems: [FloatingNavItem] {
+        [
             FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3", section: .scenarios),
             FloatingNavItem(title: "Holds", systemImage: "pause.circle", section: .holds),
-            FloatingNavItem(title: "AI Insights", systemImage: "sparkles", section: .aiInsights),
-            FloatingNavItem(title: "Settings", systemImage: "gearshape", section: .settings)
+            FloatingNavItem(title: "AI Insights", systemImage: "sparkles", section: .aiInsights)
         ]
     }
 

--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -73,15 +73,15 @@ private extension RootView {
             FloatingNavItem(title: "Dashboard", systemImage: "house", section: .dashboard),
             FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle", section: .balance),
             FloatingNavItem(title: "Schedules", systemImage: "calendar", section: .schedules),
-            FloatingNavItem(title: "Settings", systemImage: "gearshape", section: .settings)
+            FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3", section: .scenarios)
         ]
     }
 
     var moreNavItems: [FloatingNavItem] {
         [
-            FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3", section: .scenarios),
             FloatingNavItem(title: "Holds", systemImage: "pause.circle", section: .holds),
-            FloatingNavItem(title: "AI Insights", systemImage: "sparkles", section: .aiInsights)
+            FloatingNavItem(title: "AI Insights", systemImage: "sparkles", section: .aiInsights),
+            FloatingNavItem(title: "Settings", systemImage: "gearshape", section: .settings)
         ]
     }
 

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -15,12 +15,12 @@ struct FloatingNavBar: View {
     var body: some View {
         VStack(spacing: 8) {
             if isMoreExpanded {
-                HStack(spacing: 4) {
+                VStack(spacing: 4) {
                     ForEach(overflowItems) { item in
                         navButton(for: item)
                     }
                 }
-                .padding(.horizontal, 10)
+                .padding(.horizontal, 8)
                 .padding(.vertical, 6)
                 .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
                 .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -6,38 +6,63 @@ import SwiftUI
 /// centered, falling back to a horizontal scroll view only when the
 /// available width is too narrow to fit every button.
 struct FloatingNavBar: View {
-    let items: [FloatingNavItem]
+    let primaryItems: [FloatingNavItem]
+    let overflowItems: [FloatingNavItem]
     @Binding var selectedSection: AppSection
     let isDisabled: Bool
+    @State private var isMoreExpanded = false
 
     var body: some View {
-        ViewThatFits(in: .horizontal) {
-            navContent
+        VStack(spacing: 8) {
+            if isMoreExpanded {
+                HStack(spacing: 4) {
+                    ForEach(overflowItems) { item in
+                        navButton(for: item)
+                    }
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
                 .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
-
-            ScrollView(.horizontal, showsIndicators: false) {
-                navContent
+                .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-            .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
+
+            navContent
+                .glassEffect(.regular.interactive().tint(.white.opacity(0.08)), in: Capsule(style: .continuous))
         }
         .frame(maxWidth: .infinity)
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 12)
+        .animation(.easeOut(duration: 0.2), value: isMoreExpanded)
     }
 
     private var navContent: some View {
         HStack(spacing: 4) {
-            ForEach(items) { item in
+            ForEach(primaryItems) { item in
+                navButton(for: item)
+            }
+
+            if !overflowItems.isEmpty {
                 Button {
-                    selectedSection = item.section
+                    isMoreExpanded.toggle()
                 } label: {
-                    FloatingNavItemLabel(item: item)
+                    FloatingNavItemLabel(item: FloatingNavItem(title: "More", systemImage: "ellipsis", section: selectedSection))
                 }
-                .buttonStyle(FloatingNavButtonStyle(isSelected: selectedSection == item.section))
+                .buttonStyle(FloatingNavButtonStyle(isSelected: isMoreExpanded))
                 .disabled(isDisabled)
             }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 8)
+        .padding(.vertical, 5)
+    }
+
+    private func navButton(for item: FloatingNavItem) -> some View {
+        Button {
+            selectedSection = item.section
+            isMoreExpanded = false
+        } label: {
+            FloatingNavItemLabel(item: item)
+        }
+        .buttonStyle(FloatingNavButtonStyle(isSelected: selectedSection == item.section))
+        .disabled(isDisabled)
     }
 }
 
@@ -84,15 +109,15 @@ private struct FloatingNavItemLabel: View {
     var body: some View {
         VStack(spacing: 2) {
             Image(systemName: item.systemImage)
-                .font(.system(size: 20, weight: .semibold))
+                .font(.system(size: 18, weight: .semibold))
             Text(item.title)
                 .font(.caption2.weight(.medium))
                 .lineLimit(1)
         }
         .foregroundStyle(AppTheme.textPrimary)
-        .frame(minWidth: 64)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
+        .frame(minWidth: 54)
+        .padding(.horizontal, 9)
+        .padding(.vertical, 5)
     }
 }
 


### PR DESCRIPTION
### Motivation
- Reduce the floating bottom nav height and density so a fifth affordance can be exposed while keeping existing styling and selection behavior.
- Replace the horizontal scroll fallback with a compact fixed bar and an explicit overflow so users can access the remaining sections without a swipeable bar.
- Ensure the nav sits snug to the bottom safe area with less vertical padding and a slightly more translucent background.

### Description
- Split the nav items into `primaryItems` (shown in-bar) and `overflowItems` (shown in the More menu) and add a `More` (`ellipsis`) button that toggles an oval overflow menu above the bar in `FloatingNavBar.swift`.
- Removed the scroll-fallback layout and implemented an inline overflow HStack that animates in/out; added `isMoreExpanded` state to control the menu.
- Reduced icon and button sizing and tightened horizontal/vertical paddings to make buttons slightly smaller and denser, and applied a lighter tint to the glass effect for increased translucency.
- Adjusted `bottomContentInset` in `RootView.swift` and updated the `FloatingNavBar` call site to pass `primaryItems` and `overflowItems` so the bar sits closer to the safe-area bottom.

### Testing
- No automated unit or UI tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b4c0d2208320aae805aa06d46c43)