### PR TITLE
Adjust iOS nav bar More menu positioning and button sizing

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -13,45 +13,46 @@ struct FloatingNavBar: View {
     @State private var isMoreExpanded = false
 
     var body: some View {
-        VStack(spacing: 8) {
+        navContent
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 12)
+            .animation(.easeOut(duration: 0.2), value: isMoreExpanded)
+    }
+
+    private var navContent: some View {
+        ZStack(alignment: .topTrailing) {
+            HStack(spacing: 4) {
+                ForEach(primaryItems) { item in
+                    navButton(for: item)
+                }
+
+                if !overflowItems.isEmpty {
+                    Button {
+                        isMoreExpanded.toggle()
+                    } label: {
+                        FloatingNavItemLabel(item: FloatingNavItem(title: "More", systemImage: "ellipsis", section: selectedSection))
+                    }
+                    .buttonStyle(FloatingNavButtonStyle(isSelected: isMoreExpanded))
+                    .disabled(isDisabled)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .glassEffect(.regular.interactive().tint(.white.opacity(0.08)), in: Capsule(style: .continuous))
+
             if isMoreExpanded {
-                VStack(spacing: 4) {
+                VStack(spacing: 8) {
                     ForEach(overflowItems) { item in
                         navButton(for: item)
                     }
                 }
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 10)
                 .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
+                .offset(x: -6, y: -98)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
-
-            navContent
-                .glassEffect(.regular.interactive().tint(.white.opacity(0.08)), in: Capsule(style: .continuous))
         }
-        .frame(maxWidth: .infinity)
-        .padding(.horizontal, 12)
-        .animation(.easeOut(duration: 0.2), value: isMoreExpanded)
-    }
-
-    private var navContent: some View {
-        HStack(spacing: 4) {
-            ForEach(primaryItems) { item in
-                navButton(for: item)
-            }
-
-            if !overflowItems.isEmpty {
-                Button {
-                    isMoreExpanded.toggle()
-                } label: {
-                    FloatingNavItemLabel(item: FloatingNavItem(title: "More", systemImage: "ellipsis", section: selectedSection))
-                }
-                .buttonStyle(FloatingNavButtonStyle(isSelected: isMoreExpanded))
-                .disabled(isDisabled)
-            }
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
     }
 
     private func navButton(for item: FloatingNavItem) -> some View {
@@ -115,9 +116,9 @@ private struct FloatingNavItemLabel: View {
                 .lineLimit(1)
         }
         .foregroundStyle(AppTheme.textPrimary)
-        .frame(minWidth: 54)
+        .frame(minWidth: 54, minHeight: 42)
         .padding(.horizontal, 9)
-        .padding(.vertical, 5)
+        .padding(.vertical, 4)
     }
 }
 


### PR DESCRIPTION
### Motivation
- The More overflow menu should anchor above the More button on the right side of the nav bar rather than emerging from the center to match expected UX affordances.
- The More button must match the size/vertical alignment of the other nav buttons so the icon and label line up consistently.
- The expanded menu needs a slightly taller, narrower layout with extra internal padding so actions like Holds and Settings have visual buffer from the edges.

### Description
- Reworked the nav layout to use a `ZStack(alignment: .topTrailing)` so the expanded More menu is anchored to the top-right of the bar and placed above the More button (`FloatingNavBar.swift`).
- Moved the expanded menu into the `navContent` stack and adjusted its spacing/padding (`VStack(spacing: 8)`, `.padding(.horizontal, 10)`, `.padding(.vertical, 10)`) and applied an `offset(x: -6, y: -98)` to position it above the More button.
- Tuned nav item sizing by increasing the `FloatingNavItemLabel` to `.frame(minWidth: 54, minHeight: 42)` and reducing vertical padding to better match other buttons and center the ellipsis/icon with text.

### Testing
- No automated tests were run for this change because it is a UI-only SwiftUI layout update; manual verification via Xcode preview or device build is recommended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b7b7c94c832098c970471d91378e)