### PR TITLE
Fix floating 'More' menu anchoring and button alignment

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -20,26 +20,27 @@ struct FloatingNavBar: View {
     }
 
     private var navContent: some View {
-        ZStack(alignment: .topTrailing) {
-            HStack(spacing: 4) {
-                ForEach(primaryItems) { item in
-                    navButton(for: item)
-                }
-
-                if !overflowItems.isEmpty {
-                    Button {
-                        isMoreExpanded.toggle()
-                    } label: {
-                        FloatingNavItemLabel(item: FloatingNavItem(title: "More", systemImage: "ellipsis", section: selectedSection))
-                    }
-                    .buttonStyle(FloatingNavButtonStyle(isSelected: isMoreExpanded))
-                    .disabled(isDisabled)
-                }
+        HStack(spacing: 4) {
+            ForEach(primaryItems) { item in
+                navButton(for: item)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .glassEffect(.regular.interactive().tint(.white.opacity(0.08)), in: Capsule(style: .continuous))
 
+            if !overflowItems.isEmpty {
+                Button {
+                    isMoreExpanded.toggle()
+                } label: {
+                    FloatingNavItemLabel(
+                        item: FloatingNavItem(title: "More", systemImage: "ellipsis", section: selectedSection)
+                    )
+                }
+                .buttonStyle(FloatingNavButtonStyle(isSelected: isMoreExpanded))
+                .disabled(isDisabled)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
+        .glassEffect(.regular.interactive().tint(.white.opacity(0.08)), in: Capsule(style: .continuous))
+        .overlay(alignment: .topTrailing) {
             if isMoreExpanded {
                 VStack(spacing: 8) {
                     ForEach(overflowItems) { item in
@@ -49,8 +50,9 @@ struct FloatingNavBar: View {
                 .padding(.horizontal, 10)
                 .padding(.vertical, 10)
                 .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
-                .offset(x: -6, y: -98)
+                .offset(x: -6, y: -104)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
+                .zIndex(1)
             }
         }
     }
@@ -111,9 +113,11 @@ private struct FloatingNavItemLabel: View {
         VStack(spacing: 2) {
             Image(systemName: item.systemImage)
                 .font(.system(size: 18, weight: .semibold))
+                .frame(height: 18, alignment: .center)
             Text(item.title)
                 .font(.caption2.weight(.medium))
                 .lineLimit(1)
+                .frame(height: 11, alignment: .center)
         }
         .foregroundStyle(AppTheme.textPrimary)
         .frame(minWidth: 54, minHeight: 42)


### PR DESCRIPTION
### Motivation
- The overflow "More" menu was expanding both above and below the More button and pushing the floating nav bar upward when opened. 
- The More button visually differed from other nav buttons because the ellipsis icon and label were not vertically normalized, causing misalignment.

### Description
- Render the overflow menu as an `.overlay(alignment: .topTrailing)` on the nav capsule instead of inside the main `ZStack`, preventing layout shifts. 
- Move the overflow panel upward by adjusting the offset to `y: -104` and add `.zIndex(1)` so the menu appears fully above the More button. 
- Normalize icon and label vertical sizing in `FloatingNavItemLabel` by adding explicit `.frame(height:)` values to the `Image` and `Text` so the More button matches sibling button sizing. 
- Minor HStack/layout cleanup in `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift` to centralize padding/glass effect and keep expansion isolated.

### Testing
- No automated tests were run for this change because it is a UI-only SwiftUI component update and requires visual verification on device/simulator. 
- `git diff` and a local commit were produced to capture the change; no CI test run was executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b9081e64832095c4a9eded6f831c)