### PR TITLE
Fix iOS floating nav "More" menu overlap by rendering expansion above bar

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -20,27 +20,7 @@ struct FloatingNavBar: View {
     }
 
     private var navContent: some View {
-        HStack(spacing: 4) {
-            ForEach(primaryItems) { item in
-                navButton(for: item)
-            }
-
-            if !overflowItems.isEmpty {
-                Button {
-                    isMoreExpanded.toggle()
-                } label: {
-                    FloatingNavItemLabel(
-                        item: FloatingNavItem(title: "More", systemImage: "ellipsis", section: selectedSection)
-                    )
-                }
-                .buttonStyle(FloatingNavButtonStyle(isSelected: isMoreExpanded))
-                .disabled(isDisabled)
-            }
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
-        .glassEffect(.regular.interactive().tint(.white.opacity(0.08)), in: Capsule(style: .continuous))
-        .overlay(alignment: .topTrailing) {
+        VStack(alignment: .trailing, spacing: 8) {
             if isMoreExpanded {
                 VStack(spacing: 8) {
                     ForEach(overflowItems) { item in
@@ -50,10 +30,29 @@ struct FloatingNavBar: View {
                 .padding(.horizontal, 10)
                 .padding(.vertical, 10)
                 .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
-                .offset(x: -6, y: -104)
                 .transition(.move(edge: .bottom).combined(with: .opacity))
-                .zIndex(1)
             }
+
+            HStack(spacing: 4) {
+                ForEach(primaryItems) { item in
+                    navButton(for: item)
+                }
+
+                if !overflowItems.isEmpty {
+                    Button {
+                        isMoreExpanded.toggle()
+                    } label: {
+                        FloatingNavItemLabel(
+                            item: FloatingNavItem(title: "More", systemImage: "ellipsis", section: selectedSection)
+                        )
+                    }
+                    .buttonStyle(FloatingNavButtonStyle(isSelected: isMoreExpanded))
+                    .disabled(isDisabled)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .glassEffect(.regular.interactive().tint(.white.opacity(0.08)), in: Capsule(style: .continuous))
         }
     }
 


### PR DESCRIPTION
### Motivation
- The expanded "More" pull-up was overlapping the navigation capsule because it was positioned via an overlay with a hard-coded negative offset. 
- The intent is for the overflow menu to visually extend upward from the floating nav bar instead of covering it. 
- This improves visual layering and keeps the menu aligned with the bottom navigation affordance.

### Description
- Reworked `FloatingNavBar` so the overflow items are rendered in a `VStack` above the primary `HStack` instead of using `.overlay(alignment:.topTrailing)` with `.offset(...)` in `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift`.
- Removed the negative `.offset(x:y:)` and `zIndex` previously used to force placement and preserved the existing `.transition(.move(edge: .bottom).combined(with: .opacity))` animation so the menu still animates upward.
- Kept the original padding, `glassEffect` styling and button behaviors so appearance and interactions remain consistent.

### Testing
- Attempted to list the Xcode project with `xcodebuild -list -project pycashflow.xcodeproj`, but `xcodebuild` is not available in this environment so the check could not be completed. 
- No iOS/Swift unit tests were executed in this environment due to the lack of Xcode tools.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ba13b4d48320b267167bbbc254a1)