### PR TITLE
Fix iOS More button tap target in floating nav bar

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -122,6 +122,7 @@ private struct FloatingNavItemLabel: View {
         .frame(minWidth: 54, minHeight: 42)
         .padding(.horizontal, 9)
         .padding(.vertical, 4)
+        .contentShape(Rectangle())
     }
 }
 


### PR DESCRIPTION
### Motivation
- Taps near the ellipsis icon for the floating nav overflow (`More`) were not consistently registering because hit-testing was limited to opaque glyph/text pixels instead of the full padded label area.

### Description
- Add `.contentShape(Rectangle())` to `FloatingNavItemLabel` in `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift` so the entire padded label frame becomes tappable, keeping the change minimal and scoped to the shared nav label.

### Testing
- No automated tests were executed for this UI-only change in this environment; please validate via the iOS simulator or CI UI tests that the `More` button responds across its full padded area.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7bbc5f2e48320bae65d0f994e92c7)