### PR TITLE
iOS: replace floating bottom nav with UITabBar-backed TabView

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -17,23 +17,12 @@ struct RootView: View {
                         ProgressView("Checking account status...")
                             .foregroundStyle(AppTheme.textPrimary)
                     case .allowed:
-                        selectedView
-                            .safeAreaPadding(.bottom, bottomContentInset)
+                        tabScaffold
                     case .blocked:
                         if session.appMode == .cloud {
                             SubscriptionPaywallView()
                         } else {
-                            selectedView
-                                .safeAreaPadding(.bottom, bottomContentInset)
-                        }
-                    }
-                }
-                .safeAreaInset(edge: .bottom, spacing: 0) {
-                    if shouldShowBottomBar {
-                        if session.user?.is_guest == true {
-                            GuestSettingsButton(selectedSection: $selectedSection, isDisabled: session.isNavigationInteractionLocked)
-                        } else {
-                            FloatingNavBar(primaryItems: navItems, overflowItems: moreNavItems, selectedSection: $selectedSection, isDisabled: session.isNavigationInteractionLocked)
+                            tabScaffold
                         }
                     }
                 }
@@ -64,25 +53,58 @@ private extension RootView {
         }
     }
 
-    var bottomContentInset: CGFloat {
-        shouldShowBottomBar ? 78 : 0
+    @ViewBuilder
+    var tabScaffold: some View {
+        if shouldShowBottomBar {
+            tabView
+        } else {
+            selectedView
+        }
     }
 
-    var navItems: [FloatingNavItem] {
-        [
-            FloatingNavItem(title: "Dashboard", systemImage: "house", section: .dashboard),
-            FloatingNavItem(title: "Balance", systemImage: "dollarsign.circle", section: .balance),
-            FloatingNavItem(title: "Schedules", systemImage: "calendar", section: .schedules),
-            FloatingNavItem(title: "Scenarios", systemImage: "slider.horizontal.3", section: .scenarios)
-        ]
-    }
+    @ViewBuilder
+    var tabView: some View {
+        if session.user?.is_guest == true {
+            TabView(selection: $selectedSection) {
+                DashboardView()
+                    .tabItem { Label("Dashboard", systemImage: "house") }
+                    .tag(AppSection.dashboard)
 
-    var moreNavItems: [FloatingNavItem] {
-        [
-            FloatingNavItem(title: "Holds", systemImage: "pause.circle", section: .holds),
-            FloatingNavItem(title: "AI Insights", systemImage: "sparkles", section: .aiInsights),
-            FloatingNavItem(title: "Settings", systemImage: "gearshape", section: .settings)
-        ]
+                SettingsView()
+                    .tabItem { Label("Settings", systemImage: "gearshape") }
+                    .tag(AppSection.settings)
+            }
+        } else {
+            TabView(selection: $selectedSection) {
+                DashboardView()
+                    .tabItem { Label("Dashboard", systemImage: "house") }
+                    .tag(AppSection.dashboard)
+
+                BalanceView()
+                    .tabItem { Label("Balance", systemImage: "dollarsign.circle") }
+                    .tag(AppSection.balance)
+
+                SchedulesView()
+                    .tabItem { Label("Schedules", systemImage: "calendar") }
+                    .tag(AppSection.schedules)
+
+                ScenariosView()
+                    .tabItem { Label("Scenarios", systemImage: "slider.horizontal.3") }
+                    .tag(AppSection.scenarios)
+
+                HoldsView()
+                    .tabItem { Label("Holds", systemImage: "pause.circle") }
+                    .tag(AppSection.holds)
+
+                AIInsightsView()
+                    .tabItem { Label("AI Insights", systemImage: "sparkles") }
+                    .tag(AppSection.aiInsights)
+
+                SettingsView()
+                    .tabItem { Label("Settings", systemImage: "gearshape") }
+                    .tag(AppSection.settings)
+            }
+        }
     }
 
     @ViewBuilder


### PR DESCRIPTION
### Motivation
- Replace the custom floating bottom navigation UI with a native `UITabBar`-backed solution while preserving all existing navigation targets and access-state behavior.

### Description
- Replaced the `safeAreaInset` + `FloatingNavBar` presentation in `RootView` with a `TabView` scaffold that maps to `UITabBar` on iOS by adding `tabScaffold` and `tabView` computed views and binding selection to `selectedSection`.
- Kept guest behavior to show only Dashboard and Settings tabs, and kept all existing authenticated non-guest sections (Dashboard, Balance, Schedules, Scenarios, Holds, AI Insights, Settings) as tab items.
- Preserved the access-state branching so the bottom navigation appears only in the same states as before (`allowed`, and local `blocked`), and the cloud `blocked` state still shows the paywall.
- Removed the previous `safeAreaInset` and `bottomContentInset` helper usage in favor of the `TabView` presentation without changing business logic or API code.

### Testing
- Attempted to run an iOS build via `xcodebuild` to validate the change, which failed due to `xcodebuild` not being available in this environment.  
- No other automated app tests were executed in this environment because iOS build tooling is not present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c4c6ebe88320872601ee46d9f042)