### PR TITLE
Match More menu background tint with app views

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -29,7 +29,7 @@ struct FloatingNavBar: View {
                 }
                 .padding(.horizontal, 10)
                 .padding(.vertical, 10)
-                .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
+                .glassEffect(.regular.interactive().tint(AppTheme.surface.opacity(0.45)), in: Capsule(style: .continuous))
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 


### PR DESCRIPTION
### Motivation
- Make the expanded “More” menu visually consistent with other app views by using the same darker surface tint.

### Description
- Updated `ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift` to apply `.glassEffect(.regular.interactive().tint(AppTheme.surface.opacity(0.45)), in: Capsule(style: .continuous))` to the expanded More menu container.

### Testing
- No automated tests were run for this UI-only Swift change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c666dc1083208e1f59ac0d04fe72)