### PR TITLE
Adjust 'More' menu appearance and tweak FloatingNavBar glass effect

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/PyCashFlowApp.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/PyCashFlowApp.swift
@@ -1,9 +1,16 @@
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 @main
 struct PyCashFlowApp: App {
     @StateObject private var session = SessionManager()
     @Environment(\.scenePhase) private var scenePhase
+
+    init() {
+        configureMoreMenuAppearance()
+    }
 
     var body: some Scene {
         WindowGroup {
@@ -16,5 +23,18 @@ struct PyCashFlowApp: App {
                 await session.refreshSubscriptionState(forceProfileRefresh: false)
             }
         }
+    }
+
+    private func configureMoreMenuAppearance() {
+#if canImport(UIKit)
+        guard
+            let moreListController = NSClassFromString("UIMoreListController") as? UIAppearanceContainer.Type
+        else {
+            return
+        }
+
+        let moreListTableView = UITableView.appearance(whenContainedInInstancesOf: [moreListController])
+        moreListTableView.backgroundColor = UIColor(AppTheme.primaryDark)
+#endif
     }
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/FloatingNavBar.swift
@@ -29,7 +29,7 @@ struct FloatingNavBar: View {
                 }
                 .padding(.horizontal, 10)
                 .padding(.vertical, 10)
-                .glassEffect(.regular.interactive().tint(AppTheme.surface.opacity(0.45)), in: Capsule(style: .continuous))
+                .glassEffect(.regular.interactive(), in: Capsule(style: .continuous))
                 .transition(.move(edge: .bottom).combined(with: .opacity))
             }
 


### PR DESCRIPTION
### Motivation

- Ensure the system "More" list uses the app's dark surface color for consistency with the app theme on UIKit hosts.
- Simplify the glass appearance on the expanded overflow area of the floating nav bar for a more consistent visual treatment.

### Description

- Added a conditional `UIKit` import and a new `configureMoreMenuAppearance()` initializer call in `PyCashFlowApp` that uses `UIAppearance` to set the `UITableView` background color when contained in `UIMoreListController` to `AppTheme.primaryDark` on platforms that can import `UIKit`.
- Added a private `configureMoreMenuAppearance()` helper on `PyCashFlowApp` to centralize the `More` menu appearance customization and guard it behind `#if canImport(UIKit)`.
- Removed the explicit tint color passed to the glass effect on the overflow items in `FloatingNavBar` by changing `.glassEffect(.regular.interactive().tint(AppTheme.surface.opacity(0.45)), ...)` to `.glassEffect(.regular.interactive(), ...)` to simplify the visual effect.

### Testing

- Verified the iOS target builds successfully in Xcode after the changes with the default scheme. 
- Ran the project's automated unit test suite and confirmed all tests completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c78ff10c8320917a01236351c1c7)