### PR TITLE
Fix iOS More menu item background color

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/PyCashFlowApp.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/PyCashFlowApp.swift
@@ -35,6 +35,9 @@ struct PyCashFlowApp: App {
 
         let moreListTableView = UITableView.appearance(whenContainedInInstancesOf: [moreListController])
         moreListTableView.backgroundColor = UIColor(AppTheme.primaryDark)
+
+        let moreListCell = UITableViewCell.appearance(whenContainedInInstancesOf: [moreListController])
+        moreListCell.backgroundColor = UIColor(AppTheme.primaryDark)
 #endif
     }
 }


### PR DESCRIPTION
### Motivation
- The system More menu displayed the overall background using the app theme but individual rows (Holds, AI Insights, Settings) remained black, creating a visual mismatch that should be unified with the app theme.

### Description
- Add `UITableViewCell.appearance(whenContainedInInstancesOf: [moreListController])` and set its `backgroundColor` to `UIColor(AppTheme.primaryDark)` in `configureMoreMenuAppearance()` inside `ios-app/pycashflow/PyCashFlowApp/App/PyCashFlowApp.swift` (guarded by `#if canImport(UIKit)`).

### Testing
- No automated tests were run for this UI appearance-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c92809d48320be663a6831753dcd)