### PR TITLE
Commit cash projection updates in _project_data

### DIFF
--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -141,7 +141,7 @@ def _project_data(user_id: int):
     skips = Skip.query.filter_by(user_id=user_id).all()
     scenarios = Scenario.query.filter_by(user_id=user_id).all()
 
-    trans, run, run_scenario = update_cash(balance_amount, schedules, holds, skips, scenarios, commit=False)
+    trans, run, run_scenario = update_cash(balance_amount, schedules, holds, skips, scenarios, commit=True)
     result = (balance, balance_amount, trans, run, run_scenario)
     cache[user_id] = result
     return result


### PR DESCRIPTION
### Motivation
- Ensure that calling the cash projection in `_project_data` persists any changes produced by `update_cash` instead of running in read-only mode.

### Description
- Change the `update_cash` call in `_project_data` to pass `commit=True` instead of `commit=False`, so generated transactions and runs are saved to the database during projection.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9226ac14483208cb0e9e323882fad)