### PR TITLE
Add server-managed DigitalOcean AI fallback with 24h refresh limit

### DIFF
--- a/app/ai_insights.py
+++ b/app/ai_insights.py
@@ -5,7 +5,8 @@ gpt-4o-mini for risk, pattern, and observation insights.
 """
 import json
 import logging
-from datetime import datetime, timedelta
+import os
+from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import relativedelta
 from openai import OpenAI
 
@@ -216,6 +217,8 @@ def build_payload(current_balance, schedules, holds, skips):
 
 
 DEFAULT_MODEL = 'gpt-4o-mini'
+DO_DEFAULT_MODEL = 'n/a'
+REFRESH_INTERVAL = timedelta(hours=24)
 
 
 def validate_model(api_key, model_name):
@@ -237,20 +240,66 @@ def validate_model(api_key, model_name):
         return False, f"Could not validate model: {exc}"
 
 
-def fetch_insights(encrypted_api_key, current_balance, schedules, holds, skips, model=None):
-    """
-    Decrypt the API key, build the payload, call OpenAI, and return the raw
-    JSON string of insights.
+def normalize_do_base_url(url):
+    """Ensure a DigitalOcean AI base URL ends with ``/api/v1/`` and has no
+    duplicated slashes between segments."""
+    if not url:
+        return url
+    base = url.strip().rstrip('/')
+    if not base.endswith('/api/v1'):
+        base = base + '/api/v1'
+    return base + '/'
 
-    Raises ValueError for configuration errors, Exception for API errors.
-    """
-    api_key = decrypt_password(encrypted_api_key)
-    payload = build_payload(current_balance, schedules, holds, skips)
-    selected_model = model if model else DEFAULT_MODEL
 
-    client = OpenAI(api_key=api_key)
+def select_provider(ai_config):
+    """Decide which AI provider to use for this user.
+
+    Returns one of:
+      - {"kind": "openai", "api_key": <encrypted>, "model": <name>} when the
+        user has their own OpenAI settings configured.
+      - {"kind": "digitalocean", "api_key": <plain>, "base_url": <url>,
+         "model": <name>} when the user has no OpenAI settings but the server
+        has DO_AI_BASE_URL and DO_AI_API_KEY environment variables set.
+      - None when no provider is available.
+    """
+    if ai_config and ai_config.api_key:
+        return {
+            'kind': 'openai',
+            'api_key': ai_config.api_key,
+            'model': ai_config.model_version or DEFAULT_MODEL,
+        }
+    do_base_url = os.environ.get('DO_AI_BASE_URL')
+    do_api_key = os.environ.get('DO_AI_API_KEY')
+    if do_base_url and do_api_key:
+        return {
+            'kind': 'digitalocean',
+            'api_key': do_api_key,
+            'base_url': normalize_do_base_url(do_base_url),
+            'model': os.environ.get('DO_AI_MODEL') or DO_DEFAULT_MODEL,
+        }
+    return None
+
+
+def is_refresh_due(last_updated, now=None):
+    """Return True when AI insights are eligible for a refresh.
+
+    Insights may refresh at most once per 24 hours per user.  A missing
+    timestamp (first run, or never refreshed) is always eligible.
+    """
+    if last_updated is None:
+        return True
+    if now is None:
+        now = datetime.now(timezone.utc)
+    # last_updated read back from the DB may be naive — treat as UTC.
+    if last_updated.tzinfo is None:
+        last_updated = last_updated.replace(tzinfo=timezone.utc)
+    return (now - last_updated) >= REFRESH_INTERVAL
+
+
+def _run_completion(client, model, payload):
+    """Send the system prompt + JSON payload and return the raw JSON string."""
     response = client.chat.completions.create(
-        model=selected_model,
+        model=model,
         messages=[
             {'role': 'system', 'content': SYSTEM_PROMPT},
             {'role': 'user', 'content': json.dumps(payload)},
@@ -258,3 +307,39 @@ def fetch_insights(encrypted_api_key, current_balance, schedules, holds, skips, 
         response_format={'type': 'json_object'},
     )
     return response.choices[0].message.content
+
+
+def _client_for_provider(provider):
+    if provider['kind'] == 'openai':
+        api_key = decrypt_password(provider['api_key'])
+        return OpenAI(api_key=api_key)
+    if provider['kind'] == 'digitalocean':
+        return OpenAI(api_key=provider['api_key'], base_url=provider['base_url'])
+    raise ValueError(f"Unknown AI provider kind: {provider.get('kind')!r}")
+
+
+def fetch_insights_for_provider(provider, current_balance, schedules, holds, skips):
+    """Build the payload and call the AI service indicated by ``provider``.
+
+    Reuses the OpenAI Python SDK for both bring-your-own-key and the DO
+    OpenAI-compatible endpoint.  Returns the raw JSON string.
+    """
+    client = _client_for_provider(provider)
+    payload = build_payload(current_balance, schedules, holds, skips)
+    return _run_completion(client, provider['model'], payload)
+
+
+def fetch_insights(encrypted_api_key, current_balance, schedules, holds, skips, model=None):
+    """
+    Decrypt the API key, build the payload, call OpenAI, and return the raw
+    JSON string of insights.
+
+    Kept for backward compatibility with callers that already hold an
+    encrypted user-supplied OpenAI key.
+    """
+    provider = {
+        'kind': 'openai',
+        'api_key': encrypted_api_key,
+        'model': model or DEFAULT_MODEL,
+    }
+    return fetch_insights_for_provider(provider, current_balance, schedules, holds, skips)

--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -10,7 +10,11 @@ from flask import request, g
 from app import db
 from app.models import Schedule, Scenario, Balance, Hold, Skip, AISettings
 from app.cashflow import update_cash, calculate_cash_risk_score
-from app.ai_insights import fetch_insights
+from app.ai_insights import (
+    fetch_insights_for_provider,
+    is_refresh_due,
+    select_provider,
+)
 from app.files import version
 
 from app.api import api
@@ -750,8 +754,23 @@ def api_insights_refresh():
 
     user_id = _effective_user_id()
     ai_config = AISettings.query.filter_by(user_id=user_id).first()
-    if not ai_config or not ai_config.api_key:
+    provider = select_provider(ai_config)
+    if not provider:
         return validation_error({"api_key": "No OpenAI API key configured"})
+
+    last_updated = ai_config.last_updated if ai_config else None
+    cached_insights = ai_config.last_insights if ai_config else None
+    if cached_insights and not is_refresh_due(last_updated):
+        try:
+            parsed = json.loads(cached_insights)
+        except (json.JSONDecodeError, ValueError, TypeError):
+            parsed = None
+        return api_ok({
+            "configured": bool(ai_config and ai_config.api_key),
+            "insights": parsed,
+            "last_updated": _datetime(ai_config.last_updated) if ai_config else None,
+            "model": ai_config.model_version if ai_config else None,
+        })
 
     balance_record = _latest_balance(user_id)
     current_balance = float(balance_record.amount) if balance_record else 0.0
@@ -761,13 +780,21 @@ def api_insights_refresh():
     skips = Skip.query.filter_by(user_id=user_id).all()
 
     try:
-        insights_json = fetch_insights(ai_config.api_key, current_balance, schedules, holds, skips, model=ai_config.model_version)
+        insights_json = fetch_insights_for_provider(provider, current_balance, schedules, holds, skips)
         parsed = json.loads(insights_json)
     except Exception:
         return validation_error({"insights": "Unable to generate AI insights"}, message="AI insights generation failed")
 
+    if ai_config is None:
+        ai_config = AISettings(user_id=user_id)
+        db.session.add(ai_config)
     ai_config.last_insights = insights_json
     ai_config.last_updated = datetime.now(timezone.utc)
     db.session.commit()
 
-    return api_ok({"configured": True, "insights": parsed, "last_updated": _datetime(ai_config.last_updated), "model": ai_config.model_version})
+    return api_ok({
+        "configured": bool(ai_config.api_key),
+        "insights": parsed,
+        "last_updated": _datetime(ai_config.last_updated),
+        "model": ai_config.model_version,
+    })

--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,13 @@ from .files import export, upload, version
 from .getemail import send_account_activation_notification
 from .getemail import send_password_setup_email
 from .crypto_utils import encrypt_password, decrypt_password
-from .ai_insights import fetch_insights, validate_model
+from .ai_insights import (
+    fetch_insights,
+    fetch_insights_for_provider,
+    is_refresh_due,
+    select_provider,
+    validate_model,
+)
 from .password_setup import create_password_setup_link
 from .totp_utils import (
     generate_totp_secret, encrypt_totp_secret, decrypt_totp_secret,
@@ -1328,13 +1334,20 @@ def ai_settings():
 @login_required
 @admin_required
 def ai_insights():
-    """Query OpenAI for cash flow insights on demand and cache the result."""
+    """Query the configured AI provider for cash flow insights on demand and
+    cache the result.  Limited to one refresh per user per 24 hours."""
     user_id = current_user.id
 
     ai_config = AISettings.query.filter_by(user_id=user_id).first()
-    if not ai_config or not ai_config.api_key:
+    provider = select_provider(ai_config)
+    if not provider:
         return Response(json.dumps({'error': 'No OpenAI API key configured. Please add one in Settings.'}),
                         status=400, mimetype='application/json')
+
+    last_updated = ai_config.last_updated if ai_config else None
+    cached_insights = ai_config.last_insights if ai_config else None
+    if cached_insights and not is_refresh_due(last_updated):
+        return Response(cached_insights, status=200, mimetype='application/json')
 
     balance_record = Balance.query.filter_by(user_id=user_id).order_by(desc(Balance.date), desc(Balance.id)).first()
     current_balance = float(balance_record.amount) if balance_record else 0.0
@@ -1344,11 +1357,14 @@ def ai_insights():
     skips = Skip.query.filter_by(user_id=user_id).all()
 
     try:
-        insights_json = fetch_insights(ai_config.api_key, current_balance, schedules, holds, skips, model=ai_config.model_version)
+        insights_json = fetch_insights_for_provider(provider, current_balance, schedules, holds, skips)
     except Exception as e:
         logger.exception("AI insights generation failed for user %s", user_id)
         return Response(json.dumps({'error': 'An error occurred generating insights. Please try again later.'}), status=500, mimetype='application/json')
 
+    if ai_config is None:
+        ai_config = AISettings(user_id=user_id)
+        db.session.add(ai_config)
     ai_config.last_insights = insights_json
     ai_config.last_updated = datetime.now(timezone.utc)
     db.session.commit()

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -1,0 +1,419 @@
+"""
+Unit tests for the AI insights helper layer:
+  - normalize_do_base_url
+  - select_provider (user OpenAI vs DigitalOcean fallback vs none)
+  - is_refresh_due (24-hour limit)
+  - fetch_insights_for_provider client construction
+  - /api/v1/insights/refresh end-to-end honors the provider/refresh policy
+
+These tests are backend-only and do not exercise the real OpenAI/DO APIs.
+"""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+# Capture real module references at conftest load time, before any sibling
+# test modules (e.g. test_cash_risk_score.py) install sys.modules stubs.
+from app import db as _db
+from app import ai_insights as _ai_insights_module
+from app.api.routes import data as _api_data_module
+from app.ai_insights import (
+    DEFAULT_MODEL,
+    DO_DEFAULT_MODEL,
+    fetch_insights_for_provider,
+    is_refresh_due,
+    normalize_do_base_url,
+    select_provider,
+)
+from app.crypto_utils import encrypt_password
+from app.models import AISettings
+
+
+# ── normalize_do_base_url ────────────────────────────────────────────────────
+
+
+class TestNormalizeDoBaseUrl:
+    def test_appends_api_v1_when_missing(self):
+        assert (
+            normalize_do_base_url("https://example.do.run")
+            == "https://example.do.run/api/v1/"
+        )
+
+    def test_handles_trailing_slash(self):
+        assert (
+            normalize_do_base_url("https://example.do.run/")
+            == "https://example.do.run/api/v1/"
+        )
+
+    def test_keeps_existing_api_v1_segment(self):
+        assert (
+            normalize_do_base_url("https://example.do.run/api/v1")
+            == "https://example.do.run/api/v1/"
+        )
+
+    def test_keeps_existing_api_v1_with_trailing_slash(self):
+        assert (
+            normalize_do_base_url("https://example.do.run/api/v1/")
+            == "https://example.do.run/api/v1/"
+        )
+
+    def test_avoids_double_slash(self):
+        # Trailing slashes should never produce '//api/v1/'
+        url = normalize_do_base_url("https://example.do.run//")
+        assert "//api/v1" not in url
+        assert url.endswith("/api/v1/")
+
+
+# ── select_provider ──────────────────────────────────────────────────────────
+
+
+def _ai_config(api_key="enc-key", model="gpt-4o"):
+    return SimpleNamespace(api_key=api_key, model_version=model, last_updated=None,
+                           last_insights=None)
+
+
+class TestSelectProvider:
+    def test_user_openai_settings_take_precedence(self, monkeypatch):
+        # Even with DO env vars present, user OpenAI settings win.
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        provider = select_provider(_ai_config(api_key="encrypted", model="gpt-4o"))
+        assert provider["kind"] == "openai"
+        assert provider["api_key"] == "encrypted"
+        assert provider["model"] == "gpt-4o"
+
+    def test_user_openai_default_model_when_none(self, monkeypatch):
+        provider = select_provider(_ai_config(api_key="encrypted", model=None))
+        assert provider["kind"] == "openai"
+        assert provider["model"] == DEFAULT_MODEL
+
+    def test_falls_back_to_digitalocean_when_no_user_key(self, monkeypatch):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        monkeypatch.delenv("DO_AI_MODEL", raising=False)
+        # No AISettings record at all
+        provider = select_provider(None)
+        assert provider["kind"] == "digitalocean"
+        assert provider["api_key"] == "do-secret"
+        assert provider["base_url"] == "https://example.do.run/api/v1/"
+        assert provider["model"] == DO_DEFAULT_MODEL
+
+    def test_falls_back_when_user_record_has_no_api_key(self, monkeypatch):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run/")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        monkeypatch.setenv("DO_AI_MODEL", "llama-3")
+        # AISettings exists but api_key is None
+        provider = select_provider(_ai_config(api_key=None, model=None))
+        assert provider["kind"] == "digitalocean"
+        assert provider["model"] == "llama-3"
+        assert provider["base_url"] == "https://example.do.run/api/v1/"
+
+    def test_returns_none_when_no_user_key_and_no_do_env(self, monkeypatch):
+        monkeypatch.delenv("DO_AI_BASE_URL", raising=False)
+        monkeypatch.delenv("DO_AI_API_KEY", raising=False)
+        assert select_provider(None) is None
+        assert select_provider(_ai_config(api_key=None, model=None)) is None
+
+    def test_requires_both_do_env_vars(self, monkeypatch):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.delenv("DO_AI_API_KEY", raising=False)
+        assert select_provider(None) is None
+        monkeypatch.delenv("DO_AI_BASE_URL", raising=False)
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        assert select_provider(None) is None
+
+
+# ── is_refresh_due ───────────────────────────────────────────────────────────
+
+
+class TestIsRefreshDue:
+    def test_missing_timestamp_is_due(self):
+        assert is_refresh_due(None) is True
+
+    def test_within_24_hours_is_not_due(self):
+        now = datetime.now(timezone.utc)
+        recent = now - timedelta(hours=1)
+        assert is_refresh_due(recent, now=now) is False
+
+    def test_just_under_24_hours_is_not_due(self):
+        now = datetime.now(timezone.utc)
+        recent = now - timedelta(hours=23, minutes=59)
+        assert is_refresh_due(recent, now=now) is False
+
+    def test_exactly_24_hours_is_due(self):
+        now = datetime.now(timezone.utc)
+        boundary = now - timedelta(hours=24)
+        assert is_refresh_due(boundary, now=now) is True
+
+    def test_older_than_24_hours_is_due(self):
+        now = datetime.now(timezone.utc)
+        old = now - timedelta(days=2)
+        assert is_refresh_due(old, now=now) is True
+
+    def test_handles_naive_timestamp_as_utc(self):
+        now = datetime.now(timezone.utc)
+        naive_recent = (now - timedelta(hours=1)).replace(tzinfo=None)
+        assert is_refresh_due(naive_recent, now=now) is False
+
+
+# ── fetch_insights_for_provider client construction ──────────────────────────
+
+
+class TestFetchInsightsForProvider:
+    def test_digitalocean_uses_base_url_and_plain_key(self, monkeypatch):
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, *, api_key, base_url=None):
+                captured["api_key"] = api_key
+                captured["base_url"] = base_url
+                self.chat = SimpleNamespace(completions=SimpleNamespace(
+                    create=lambda **kwargs: SimpleNamespace(
+                        choices=[SimpleNamespace(message=SimpleNamespace(
+                            content='{"insights": []}'))]
+                    )
+                ))
+
+        monkeypatch.setattr(_ai_insights_module, "OpenAI", FakeClient)
+        monkeypatch.setattr(
+            _ai_insights_module,
+            "build_payload",
+            lambda *a, **kw: {"today": "2026-05-08"},
+        )
+
+        provider = {
+            "kind": "digitalocean",
+            "api_key": "do-plain-key",
+            "base_url": "https://example.do.run/api/v1/",
+            "model": "n/a",
+        }
+        out = fetch_insights_for_provider(provider, 0.0, [], [], [])
+        assert out == '{"insights": []}'
+        assert captured["api_key"] == "do-plain-key"
+        assert captured["base_url"] == "https://example.do.run/api/v1/"
+
+    def test_openai_decrypts_user_key_and_uses_no_base_url(self, monkeypatch):
+        captured = {}
+
+        class FakeClient:
+            def __init__(self, *, api_key, base_url=None):
+                captured["api_key"] = api_key
+                captured["base_url"] = base_url
+                self.chat = SimpleNamespace(completions=SimpleNamespace(
+                    create=lambda **kwargs: SimpleNamespace(
+                        choices=[SimpleNamespace(message=SimpleNamespace(
+                            content='{"insights": []}'))]
+                    )
+                ))
+
+        monkeypatch.setattr(_ai_insights_module, "OpenAI", FakeClient)
+        monkeypatch.setattr(
+            _ai_insights_module,
+            "build_payload",
+            lambda *a, **kw: {"today": "2026-05-08"},
+        )
+        monkeypatch.setattr(
+            _ai_insights_module,
+            "decrypt_password",
+            lambda enc: "decrypted-" + enc,
+        )
+
+        provider = {
+            "kind": "openai",
+            "api_key": "ENC",
+            "model": "gpt-4o",
+        }
+        out = fetch_insights_for_provider(provider, 0.0, [], [], [])
+        assert out == '{"insights": []}'
+        assert captured["api_key"] == "decrypted-ENC"
+        assert captured["base_url"] is None
+
+
+# ── End-to-end: /api/v1/insights/refresh respects provider + 24h limit ───────
+
+
+def _login(client, email="admin@test.local", password="testpass123"):
+    resp = client.post(
+        "/api/v1/auth/login",
+        json={"email": email, "password": password},
+        content_type="application/json",
+    )
+    return resp.get_json()["data"]["token"]
+
+
+def _bearer(token):
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def clean_ai_settings(flask_app):
+    """Wipe the admin's AISettings before/after each test so independent runs
+    don't leak state through the session-scoped in-memory database."""
+    from conftest import _ADMIN_USER_ID  # type: ignore
+    with flask_app.app_context():
+        AISettings.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+        _db.session.commit()
+    yield _ADMIN_USER_ID
+    with flask_app.app_context():
+        AISettings.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+        _db.session.commit()
+
+
+@pytest.fixture()
+def clear_do_env(monkeypatch):
+    monkeypatch.delenv("DO_AI_BASE_URL", raising=False)
+    monkeypatch.delenv("DO_AI_API_KEY", raising=False)
+    monkeypatch.delenv("DO_AI_MODEL", raising=False)
+
+
+class TestRefreshEndpointProviderAndLimit:
+    def test_no_provider_returns_validation_error(self, client, clean_ai_settings, clear_do_env):
+        token = _login(client)
+        resp = client.post("/api/v1/insights/refresh", headers=_bearer(token))
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert body["code"] == "validation_error"
+        assert "api_key" in body["fields"]
+
+    def test_uses_user_openai_when_configured(self, client, flask_app, clean_ai_settings, monkeypatch):
+        # Even with DO env present, user OpenAI must win.
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+
+        user_id = clean_ai_settings
+        with flask_app.app_context():
+            _db.session.add(AISettings(
+                user_id=user_id,
+                api_key=encrypt_password("sk-user"),
+                model_version="gpt-4o",
+            ))
+            _db.session.commit()
+
+        captured = {}
+
+        def fake_fetch(provider, *args, **kwargs):
+            captured["provider"] = provider
+            return '{"insights": []}'
+
+        monkeypatch.setattr(
+            _api_data_module, "fetch_insights_for_provider",
+            fake_fetch,
+        )
+
+        token = _login(client)
+        resp = client.post("/api/v1/insights/refresh", headers=_bearer(token))
+        assert resp.status_code == 200, resp.get_json()
+        assert captured["provider"]["kind"] == "openai"
+
+    def test_uses_digitalocean_when_user_key_missing_and_env_set(self, client, flask_app, clean_ai_settings, monkeypatch):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run/")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        monkeypatch.setenv("DO_AI_MODEL", "do-model")
+
+        captured = {}
+
+        def fake_fetch(provider, *args, **kwargs):
+            captured["provider"] = provider
+            return '{"insights": []}'
+
+        monkeypatch.setattr(
+            _api_data_module, "fetch_insights_for_provider",
+            fake_fetch,
+        )
+
+        token = _login(client)
+        resp = client.post("/api/v1/insights/refresh", headers=_bearer(token))
+        assert resp.status_code == 200, resp.get_json()
+        assert captured["provider"]["kind"] == "digitalocean"
+        assert captured["provider"]["base_url"] == "https://example.do.run/api/v1/"
+        assert captured["provider"]["model"] == "do-model"
+
+        # And it should have created an AISettings row with last_updated set
+        # so the cache check works on subsequent calls.
+        with flask_app.app_context():
+            row = AISettings.query.filter_by(user_id=clean_ai_settings).first()
+            assert row is not None
+            assert row.last_updated is not None
+            assert row.last_insights == '{"insights": []}'
+
+    def test_recent_refresh_returns_cached_without_calling_provider(self, client, flask_app, clean_ai_settings, monkeypatch):
+        # Even though DO env is present and would otherwise be used, a refresh
+        # less than 24 hours ago must skip the AI call entirely.
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+
+        user_id = clean_ai_settings
+        cached_payload = '{"insights": [{"type": "observation", "title": "cached"}]}'
+        recent = datetime.now(timezone.utc) - timedelta(hours=1)
+        with flask_app.app_context():
+            _db.session.add(AISettings(
+                user_id=user_id,
+                api_key=None,
+                model_version=None,
+                last_updated=recent,
+                last_insights=cached_payload,
+            ))
+            _db.session.commit()
+
+        called = {"count": 0}
+
+        def fake_fetch(*args, **kwargs):
+            called["count"] += 1
+            return '{"insights": []}'
+
+        monkeypatch.setattr(
+            _api_data_module, "fetch_insights_for_provider",
+            fake_fetch,
+        )
+
+        token = _login(client)
+        resp = client.post("/api/v1/insights/refresh", headers=_bearer(token))
+        assert resp.status_code == 200, resp.get_json()
+        assert called["count"] == 0
+        body = resp.get_json()["data"]
+        assert body["insights"] == json.loads(cached_payload)
+
+    def test_stale_refresh_calls_provider_and_updates_timestamp(self, client, flask_app, clean_ai_settings, monkeypatch):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+
+        user_id = clean_ai_settings
+        old = datetime.now(timezone.utc) - timedelta(hours=25)
+        with flask_app.app_context():
+            _db.session.add(AISettings(
+                user_id=user_id,
+                api_key=None,
+                model_version=None,
+                last_updated=old,
+                last_insights='{"insights": [{"title": "stale"}]}',
+            ))
+            _db.session.commit()
+
+        called = {"count": 0}
+
+        def fake_fetch(provider, *args, **kwargs):
+            called["count"] += 1
+            return '{"insights": [{"title": "fresh"}]}'
+
+        monkeypatch.setattr(
+            _api_data_module, "fetch_insights_for_provider",
+            fake_fetch,
+        )
+
+        token = _login(client)
+        resp = client.post("/api/v1/insights/refresh", headers=_bearer(token))
+        assert resp.status_code == 200, resp.get_json()
+        assert called["count"] == 1
+
+        with flask_app.app_context():
+            row = AISettings.query.filter_by(user_id=user_id).first()
+            assert row.last_insights == '{"insights": [{"title": "fresh"}]}'
+            # last_updated was bumped — should be within the last few seconds
+            row_dt = row.last_updated
+            if row_dt.tzinfo is None:
+                row_dt = row_dt.replace(tzinfo=timezone.utc)
+            assert (datetime.now(timezone.utc) - row_dt) < timedelta(minutes=1)


### PR DESCRIPTION
Adds backend support for a server-level DigitalOcean AI endpoint as a
fallback when the user has not configured their own OpenAI key, while
preserving existing bring-your-own-key behavior. Caps AI insight
refreshes to once per user per 24 hours so the cached result is reused
on rapid re-requests regardless of provider.

https://claude.ai/code/session_01PkJAJD5PvzMdRSQdCRfHyz