### PR TITLE
Fold system prompt into user message for DigitalOcean AI provider

### DIFF
--- a/app/ai_insights.py
+++ b/app/ai_insights.py
@@ -296,14 +296,29 @@ def is_refresh_due(last_updated, now=None):
     return (now - last_updated) >= REFRESH_INTERVAL
 
 
-def _run_completion(client, model, payload):
-    """Send the system prompt + JSON payload and return the raw JSON string."""
+def _build_messages(provider_kind, payload):
+    """Compose the chat messages for the given provider.
+
+    DigitalOcean GenAI agents reject system and developer messages — agent
+    instructions are configured at the agent level on the platform. Fold the
+    prompt into the user message so the model still sees the rules.
+    """
+    payload_json = json.dumps(payload)
+    if provider_kind == 'digitalocean':
+        return [
+            {'role': 'user', 'content': f"{SYSTEM_PROMPT}\n\n{payload_json}"},
+        ]
+    return [
+        {'role': 'system', 'content': SYSTEM_PROMPT},
+        {'role': 'user', 'content': payload_json},
+    ]
+
+
+def _run_completion(client, model, payload, provider_kind='openai'):
+    """Send the prompt + JSON payload and return the raw JSON string."""
     response = client.chat.completions.create(
         model=model,
-        messages=[
-            {'role': 'system', 'content': SYSTEM_PROMPT},
-            {'role': 'user', 'content': json.dumps(payload)},
-        ],
+        messages=_build_messages(provider_kind, payload),
         response_format={'type': 'json_object'},
     )
     return response.choices[0].message.content
@@ -326,7 +341,7 @@ def fetch_insights_for_provider(provider, current_balance, schedules, holds, ski
     """
     client = _client_for_provider(provider)
     payload = build_payload(current_balance, schedules, holds, skips)
-    return _run_completion(client, provider['model'], payload)
+    return _run_completion(client, provider['model'], payload, provider['kind'])
 
 
 def fetch_insights(encrypted_api_key, current_balance, schedules, holds, skips, model=None):

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -172,9 +172,12 @@ class TestFetchInsightsForProvider:
                 captured["api_key"] = api_key
                 captured["base_url"] = base_url
                 self.chat = SimpleNamespace(completions=SimpleNamespace(
-                    create=lambda **kwargs: SimpleNamespace(
-                        choices=[SimpleNamespace(message=SimpleNamespace(
-                            content='{"insights": []}'))]
+                    create=lambda **kwargs: (
+                        captured.update(create_kwargs=kwargs)
+                        or SimpleNamespace(
+                            choices=[SimpleNamespace(message=SimpleNamespace(
+                                content='{"insights": []}'))]
+                        )
                     )
                 ))
 
@@ -196,6 +199,13 @@ class TestFetchInsightsForProvider:
         assert captured["api_key"] == "do-plain-key"
         assert captured["base_url"] == "https://example.do.run/api/v1/"
 
+        # DO GenAI agents reject system/developer messages — only a single
+        # user message should be sent, with the prompt folded in.
+        messages = captured["create_kwargs"]["messages"]
+        assert [m["role"] for m in messages] == ["user"]
+        assert _ai_insights_module.SYSTEM_PROMPT in messages[0]["content"]
+        assert '"today": "2026-05-08"' in messages[0]["content"]
+
     def test_openai_decrypts_user_key_and_uses_no_base_url(self, monkeypatch):
         captured = {}
 
@@ -204,9 +214,12 @@ class TestFetchInsightsForProvider:
                 captured["api_key"] = api_key
                 captured["base_url"] = base_url
                 self.chat = SimpleNamespace(completions=SimpleNamespace(
-                    create=lambda **kwargs: SimpleNamespace(
-                        choices=[SimpleNamespace(message=SimpleNamespace(
-                            content='{"insights": []}'))]
+                    create=lambda **kwargs: (
+                        captured.update(create_kwargs=kwargs)
+                        or SimpleNamespace(
+                            choices=[SimpleNamespace(message=SimpleNamespace(
+                                content='{"insights": []}'))]
+                        )
                     )
                 ))
 
@@ -231,6 +244,12 @@ class TestFetchInsightsForProvider:
         assert out == '{"insights": []}'
         assert captured["api_key"] == "decrypted-ENC"
         assert captured["base_url"] is None
+
+        # OpenAI proper still gets the system message.
+        messages = captured["create_kwargs"]["messages"]
+        assert [m["role"] for m in messages] == ["system", "user"]
+        assert messages[0]["content"] == _ai_insights_module.SYSTEM_PROMPT
+        assert '"today": "2026-05-08"' in messages[1]["content"]
 
 
 # ── End-to-end: /api/v1/insights/refresh respects provider + 24h limit ───────


### PR DESCRIPTION
DigitalOcean GenAI agents reject system and developer messages —
agent instructions are configured at the agent level on the
platform — which caused a 400 BadRequestError on every refresh
when falling back to the DO provider. Build messages per provider
so DO sees the prompt as part of the user content while OpenAI
keeps the standard system+user split.