### PR TITLE
Surface 'model not available for your subscription tier' errors

### DIFF
--- a/app/ai_insights.py
+++ b/app/ai_insights.py
@@ -221,19 +221,59 @@ DO_DEFAULT_MODEL = 'n/a'
 REFRESH_INTERVAL = timedelta(hours=24)
 
 
+class AIProviderError(Exception):
+    """Raised when an AI provider request fails with a user-fixable cause.
+
+    ``user_message`` is sanitised and safe to surface in API responses /
+    flash messages.  ``original`` is the underlying provider exception, kept
+    for logging only.
+    """
+
+    def __init__(self, user_message, *, original=None):
+        super().__init__(user_message)
+        self.user_message = user_message
+        self.original = original
+
+
+def _is_subscription_tier_error(exc):
+    """Detect the wrapped 'model not available for your subscription tier' case.
+
+    The DigitalOcean GenAI gateway forwards upstream OpenAI 403s by stuffing
+    them inside a 401 envelope, so the OpenAI SDK raises AuthenticationError
+    even though the API key is fine — the model is the real problem.  Walk
+    the exception body and message to spot that pattern so we can reclassify.
+    """
+    candidates = [str(exc)]
+    body = getattr(exc, 'body', None)
+    if isinstance(body, dict):
+        err = body.get('error')
+        if isinstance(err, str):
+            candidates.append(err)
+        elif isinstance(err, dict):
+            msg = err.get('message')
+            if isinstance(msg, str):
+                candidates.append(msg)
+    haystack = ' '.join(candidates).lower()
+    return 'subscription tier' in haystack or 'forbidden_error' in haystack
+
+
 def validate_model(api_key, model_name):
     """
     Check whether model_name is a valid model accessible with the given API key.
     Returns (True, None) if valid, (False, error_message) otherwise.
     """
-    from openai import NotFoundError, AuthenticationError
+    from openai import NotFoundError, AuthenticationError, PermissionDeniedError
     client = OpenAI(api_key=api_key)
     try:
         client.models.retrieve(model_name)
         return True, None
     except NotFoundError:
         return False, f"Model '{model_name}' does not exist or is not accessible with this API key."
-    except AuthenticationError:
+    except PermissionDeniedError:
+        return False, f"Model '{model_name}' is not available for your subscription tier."
+    except AuthenticationError as exc:
+        if _is_subscription_tier_error(exc):
+            return False, f"Model '{model_name}' is not available for your subscription tier."
         return False, "Invalid API key — could not validate the model."
     except Exception as exc:
         logger.warning("Unexpected error validating model %r: %s", model_name, exc)
@@ -338,10 +378,39 @@ def fetch_insights_for_provider(provider, current_balance, schedules, holds, ski
 
     Reuses the OpenAI Python SDK for both bring-your-own-key and the DO
     OpenAI-compatible endpoint.  Returns the raw JSON string.
+
+    Raises ``AIProviderError`` with a user-friendly message for the common
+    fixable cases (bad key, model not available for the subscription tier,
+    model not found).  Other exceptions propagate unchanged.
     """
+    from openai import AuthenticationError, NotFoundError, PermissionDeniedError
+
     client = _client_for_provider(provider)
     payload = build_payload(current_balance, schedules, holds, skips)
-    return _run_completion(client, provider['model'], payload, provider['kind'])
+    try:
+        return _run_completion(client, provider['model'], payload, provider['kind'])
+    except (AuthenticationError, PermissionDeniedError) as exc:
+        if _is_subscription_tier_error(exc):
+            raise AIProviderError(
+                "The selected AI model is not available for your subscription "
+                "tier. Choose a different model in AI Settings.",
+                original=exc,
+            ) from exc
+        if isinstance(exc, AuthenticationError):
+            raise AIProviderError(
+                "The AI provider rejected the API key. Verify it in AI Settings.",
+                original=exc,
+            ) from exc
+        raise AIProviderError(
+            "The AI provider denied this request. The selected model may not "
+            "be available for your subscription tier.",
+            original=exc,
+        ) from exc
+    except NotFoundError as exc:
+        raise AIProviderError(
+            f"The configured AI model ({provider.get('model')!r}) was not found.",
+            original=exc,
+        ) from exc
 
 
 def fetch_insights(encrypted_api_key, current_balance, schedules, holds, skips, model=None):

--- a/app/ai_insights.py
+++ b/app/ai_insights.py
@@ -311,11 +311,15 @@ def select_provider(ai_config):
     do_base_url = os.environ.get('DO_AI_BASE_URL')
     do_api_key = os.environ.get('DO_AI_API_KEY')
     if do_base_url and do_api_key:
+        # DigitalOcean GenAI agent endpoints require model="n/a" — the real
+        # model is configured on the agent itself.  Always send the placeholder
+        # so a stray DO_AI_MODEL env var can't reintroduce the
+        # 'this model is not available for your subscription tier' rejection.
         return {
             'kind': 'digitalocean',
             'api_key': do_api_key,
             'base_url': normalize_do_base_url(do_base_url),
-            'model': os.environ.get('DO_AI_MODEL') or DO_DEFAULT_MODEL,
+            'model': DO_DEFAULT_MODEL,
         }
     return None
 

--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -11,6 +11,7 @@ from app import db
 from app.models import Schedule, Scenario, Balance, Hold, Skip, AISettings
 from app.cashflow import update_cash, calculate_cash_risk_score
 from app.ai_insights import (
+    AIProviderError,
     fetch_insights_for_provider,
     is_refresh_due,
     select_provider,
@@ -783,6 +784,8 @@ def api_insights_refresh():
     try:
         insights_json = fetch_insights_for_provider(provider, current_balance, schedules, holds, skips)
         parsed = json.loads(insights_json)
+    except AIProviderError as e:
+        return validation_error({"insights": e.user_message}, message="AI insights generation failed")
     except Exception:
         return validation_error({"insights": "Unable to generate AI insights"}, message="AI insights generation failed")
 

--- a/app/main.py
+++ b/app/main.py
@@ -24,6 +24,7 @@ from .getemail import send_account_activation_notification
 from .getemail import send_password_setup_email
 from .crypto_utils import encrypt_password, decrypt_password
 from .ai_insights import (
+    AIProviderError,
     fetch_insights,
     fetch_insights_for_provider,
     is_refresh_due,
@@ -1376,7 +1377,10 @@ def ai_insights():
 
     try:
         insights_json = fetch_insights_for_provider(provider, current_balance, schedules, holds, skips)
-    except Exception as e:
+    except AIProviderError as e:
+        logger.warning("AI insights generation rejected for user %s: %s", user_id, e.original or e)
+        return Response(json.dumps({'error': e.user_message}), status=502, mimetype='application/json')
+    except Exception:
         logger.exception("AI insights generation failed for user %s", user_id)
         return Response(json.dumps({'error': 'An error occurred generating insights. Please try again later.'}), status=500, mimetype='application/json')
 

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -108,11 +108,12 @@ class TestSelectProvider:
     def test_falls_back_when_user_record_has_no_api_key(self, monkeypatch):
         monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run/")
         monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        # DO_AI_MODEL must be ignored — agent endpoints require model="n/a".
         monkeypatch.setenv("DO_AI_MODEL", "llama-3")
         # AISettings exists but api_key is None
         provider = select_provider(_ai_config(api_key=None, model=None))
         assert provider["kind"] == "digitalocean"
-        assert provider["model"] == "llama-3"
+        assert provider["model"] == DO_DEFAULT_MODEL
         assert provider["base_url"] == "https://example.do.run/api/v1/"
 
     def test_returns_none_when_no_user_key_and_no_do_env(self, monkeypatch):
@@ -334,6 +335,7 @@ class TestRefreshEndpointProviderAndLimit:
     def test_uses_digitalocean_when_user_key_missing_and_env_set(self, client, flask_app, clean_ai_settings, monkeypatch):
         monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run/")
         monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        # DO_AI_MODEL must be ignored — agent endpoints require model="n/a".
         monkeypatch.setenv("DO_AI_MODEL", "do-model")
 
         captured = {}
@@ -352,7 +354,7 @@ class TestRefreshEndpointProviderAndLimit:
         assert resp.status_code == 200, resp.get_json()
         assert captured["provider"]["kind"] == "digitalocean"
         assert captured["provider"]["base_url"] == "https://example.do.run/api/v1/"
-        assert captured["provider"]["model"] == "do-model"
+        assert captured["provider"]["model"] == DO_DEFAULT_MODEL
 
         # And it should have created an AISettings row with last_updated set
         # so the cache check works on subsequent calls.

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -24,10 +24,13 @@ from app.api.routes import data as _api_data_module
 from app.ai_insights import (
     DEFAULT_MODEL,
     DO_DEFAULT_MODEL,
+    AIProviderError,
+    _is_subscription_tier_error,
     fetch_insights_for_provider,
     is_refresh_due,
     normalize_do_base_url,
     select_provider,
+    validate_model,
 )
 from app.crypto_utils import encrypt_password
 from app.models import AISettings
@@ -520,3 +523,190 @@ class TestRemoveApiKeyRoute:
         # No AISettings row at all — endpoint should redirect without 500.
         resp = auth_client.post("/ai_settings/remove", follow_redirects=False)
         assert resp.status_code in (302, 303)
+
+
+# ── Provider error classification ────────────────────────────────────────────
+
+
+class _FakeAuthError(Exception):
+    """Stand-in for openai.AuthenticationError that bypasses the SDK's
+    httpx.Response-bound constructor.  Subclasses the real class so the
+    isinstance() checks in fetch_insights_for_provider still match."""
+
+    def __new__(cls, message, body=None):
+        from openai import AuthenticationError
+        # Build a real subclass instance without invoking the real __init__
+        # (which would require a live httpx.Response).
+        kls = type("_TestAuthError", (AuthenticationError,), {})
+        inst = Exception.__new__(kls)
+        Exception.__init__(inst, message)
+        inst.body = body
+        return inst
+
+
+def _make_permission_error(message, body=None):
+    from openai import PermissionDeniedError
+    kls = type("_TestPermErr", (PermissionDeniedError,), {})
+    inst = Exception.__new__(kls)
+    Exception.__init__(inst, message)
+    inst.body = body
+    return inst
+
+
+def _make_not_found_error(message, body=None):
+    from openai import NotFoundError
+    kls = type("_TestNotFound", (NotFoundError,), {})
+    inst = Exception.__new__(kls)
+    Exception.__init__(inst, message)
+    inst.body = body
+    return inst
+
+
+# The exact wrapped body the user reported: a 401 envelope from the DO GenAI
+# gateway whose "error" string contains a 403 "subscription tier" rejection.
+_WRAPPED_TIER_BODY = {
+    "error": (
+        "Error code: 403 - {'error': {'message': 'this model is not "
+        "available for your subscription tier', 'type': 'forbidden_error'}, "
+        "'message': 'this model is not available for your subscription "
+        "tier', 'status_code': 403}"
+    ),
+    "code": 401,
+}
+
+
+class TestIsSubscriptionTierError:
+    def test_detects_wrapped_401_with_inner_403_tier_message(self):
+        exc = _FakeAuthError("Error code: 401", body=_WRAPPED_TIER_BODY)
+        assert _is_subscription_tier_error(exc) is True
+
+    def test_detects_dict_error_with_message_key(self):
+        body = {"error": {"message": "this model is not available for your subscription tier"}}
+        exc = _FakeAuthError("oops", body=body)
+        assert _is_subscription_tier_error(exc) is True
+
+    def test_does_not_match_plain_invalid_key(self):
+        body = {"error": {"message": "Incorrect API key provided"}}
+        exc = _FakeAuthError("Error code: 401", body=body)
+        assert _is_subscription_tier_error(exc) is False
+
+    def test_handles_missing_body(self):
+        exc = _FakeAuthError("boom", body=None)
+        assert _is_subscription_tier_error(exc) is False
+
+
+class TestFetchInsightsErrorClassification:
+    def _patch_client_to_raise(self, monkeypatch, exc):
+        class FakeClient:
+            def __init__(self, *, api_key, base_url=None):
+                def _raise(**_kwargs):
+                    raise exc
+                self.chat = SimpleNamespace(
+                    completions=SimpleNamespace(create=_raise)
+                )
+
+        monkeypatch.setattr(_ai_insights_module, "OpenAI", FakeClient)
+        monkeypatch.setattr(
+            _ai_insights_module, "build_payload",
+            lambda *a, **kw: {"today": "2026-05-08"},
+        )
+        monkeypatch.setattr(
+            _ai_insights_module, "decrypt_password", lambda enc: "plain",
+        )
+
+    def test_wrapped_tier_401_becomes_subscription_tier_error(self, monkeypatch):
+        wrapped = _FakeAuthError("Error code: 401", body=_WRAPPED_TIER_BODY)
+        self._patch_client_to_raise(monkeypatch, wrapped)
+        provider = {"kind": "openai", "api_key": "ENC", "model": "gpt-4o"}
+        with pytest.raises(AIProviderError) as ei:
+            fetch_insights_for_provider(provider, 0.0, [], [], [])
+        assert "subscription tier" in ei.value.user_message.lower()
+        assert ei.value.original is wrapped
+
+    def test_plain_authentication_error_signals_bad_key(self, monkeypatch):
+        exc = _FakeAuthError(
+            "Error code: 401",
+            body={"error": {"message": "Incorrect API key provided"}},
+        )
+        self._patch_client_to_raise(monkeypatch, exc)
+        provider = {"kind": "openai", "api_key": "ENC", "model": "gpt-4o"}
+        with pytest.raises(AIProviderError) as ei:
+            fetch_insights_for_provider(provider, 0.0, [], [], [])
+        msg = ei.value.user_message.lower()
+        assert "api key" in msg
+        assert "subscription tier" not in msg
+
+    def test_permission_denied_becomes_provider_error(self, monkeypatch):
+        exc = _make_permission_error(
+            "Error code: 403",
+            body={"error": {"message": "model not available for your subscription tier"}},
+        )
+        self._patch_client_to_raise(monkeypatch, exc)
+        provider = {"kind": "openai", "api_key": "ENC", "model": "gpt-4o"}
+        with pytest.raises(AIProviderError) as ei:
+            fetch_insights_for_provider(provider, 0.0, [], [], [])
+        assert "subscription tier" in ei.value.user_message.lower()
+
+    def test_not_found_includes_model_name(self, monkeypatch):
+        exc = _make_not_found_error("Error code: 404", body={})
+        self._patch_client_to_raise(monkeypatch, exc)
+        provider = {"kind": "openai", "api_key": "ENC", "model": "made-up"}
+        with pytest.raises(AIProviderError) as ei:
+            fetch_insights_for_provider(provider, 0.0, [], [], [])
+        assert "made-up" in ei.value.user_message
+
+
+class TestValidateModelTierError:
+    def test_validate_model_handles_permission_denied(self, monkeypatch):
+        exc = _make_permission_error(
+            "Error code: 403",
+            body={"error": {"message": "model not available for your subscription tier"}},
+        )
+
+        class FakeClient:
+            def __init__(self, *, api_key, base_url=None):
+                self.models = SimpleNamespace(retrieve=lambda _name: (_ for _ in ()).throw(exc))
+
+        monkeypatch.setattr(_ai_insights_module, "OpenAI", FakeClient)
+        ok, msg = validate_model("sk-test", "gpt-4o")
+        assert ok is False
+        assert "subscription tier" in msg.lower()
+
+    def test_validate_model_handles_wrapped_tier_in_auth_error(self, monkeypatch):
+        # The DO gateway pattern: AuthenticationError carrying a wrapped 403
+        # tier rejection in its body.  Should classify as a tier issue, not
+        # an invalid key.
+        exc = _FakeAuthError("Error code: 401", body=_WRAPPED_TIER_BODY)
+
+        class FakeClient:
+            def __init__(self, *, api_key, base_url=None):
+                self.models = SimpleNamespace(retrieve=lambda _name: (_ for _ in ()).throw(exc))
+
+        monkeypatch.setattr(_ai_insights_module, "OpenAI", FakeClient)
+        ok, msg = validate_model("sk-test", "gpt-4o")
+        assert ok is False
+        assert "subscription tier" in msg.lower()
+        assert "invalid api key" not in msg.lower()
+
+
+class TestRefreshEndpointSurfacesProviderError:
+    def test_subscription_tier_error_returned_as_validation_error(
+        self, client, flask_app, clean_ai_settings, monkeypatch
+    ):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+
+        def _raise(provider, *args, **kwargs):
+            raise AIProviderError(
+                "The selected AI model is not available for your subscription "
+                "tier. Choose a different model in AI Settings."
+            )
+
+        monkeypatch.setattr(_api_data_module, "fetch_insights_for_provider", _raise)
+
+        token = _login(client)
+        resp = client.post("/api/v1/insights/refresh", headers=_bearer(token))
+        assert resp.status_code == 422
+        body = resp.get_json()
+        assert body["code"] == "validation_error"
+        assert "subscription tier" in body["fields"]["insights"].lower()


### PR DESCRIPTION
The DigitalOcean GenAI gateway forwards upstream OpenAI 403s by wrapping
them inside a 401 envelope, so the OpenAI SDK raises AuthenticationError
even though the API key is fine — the model is the real problem.  Both
AI insights routes were catching everything as a generic 500 ("An error
occurred generating insights. Please try again later."), giving users
no way to discover that the fix is to choose a different model.

Detect the wrapped tier rejection (and a plain PermissionDeniedError /
NotFoundError), wrap them in a new AIProviderError carrying a
user-friendly message, and surface that message through both the web
route and /api/v1/insights/refresh.  validate_model() now also handles
PermissionDeniedError and the wrapped-401 tier case at config time.