### PR TITLE
Prefer DigitalOcean agent when model is unset to avoid subscription-tier model errors

### DIFF
--- a/app/ai_insights.py
+++ b/app/ai_insights.py
@@ -302,15 +302,15 @@ def select_provider(ai_config):
         has DO_AI_BASE_URL and DO_AI_API_KEY environment variables set.
       - None when no provider is available.
     """
-    if ai_config and ai_config.api_key:
-        return {
-            'kind': 'openai',
-            'api_key': ai_config.api_key,
-            'model': ai_config.model_version or DEFAULT_MODEL,
-        }
     do_base_url = os.environ.get('DO_AI_BASE_URL')
     do_api_key = os.environ.get('DO_AI_API_KEY')
-    if do_base_url and do_api_key:
+    # If a DigitalOcean agent is configured server-side and the user has not
+    # explicitly chosen a model, prefer the DO provider. This avoids accidental
+    # default-model injection (e.g. gpt-4o-mini) when the agent decides the
+    # model on the server side.
+    if do_base_url and do_api_key and (
+        not ai_config or ai_config.model_version in (None, '', DO_DEFAULT_MODEL)
+    ):
         # DigitalOcean GenAI agent endpoints require model="n/a" — the real
         # model is configured on the agent itself.  Always send the placeholder
         # so a stray DO_AI_MODEL env var can't reintroduce the
@@ -320,6 +320,12 @@ def select_provider(ai_config):
             'api_key': do_api_key,
             'base_url': normalize_do_base_url(do_base_url),
             'model': DO_DEFAULT_MODEL,
+        }
+    if ai_config and ai_config.api_key:
+        return {
+            'kind': 'openai',
+            'api_key': ai_config.api_key,
+            'model': ai_config.model_version or DEFAULT_MODEL,
         }
     return None
 

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -80,14 +80,21 @@ def _ai_config(api_key="enc-key", model="gpt-4o"):
 
 
 class TestSelectProvider:
-    def test_user_openai_settings_take_precedence(self, monkeypatch):
-        # Even with DO env vars present, user OpenAI settings win.
+    def test_user_openai_settings_take_precedence_when_model_is_explicit(self, monkeypatch):
+        # With an explicit user-selected model, OpenAI settings still win.
         monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
         monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
         provider = select_provider(_ai_config(api_key="encrypted", model="gpt-4o"))
         assert provider["kind"] == "openai"
         assert provider["api_key"] == "encrypted"
         assert provider["model"] == "gpt-4o"
+
+    def test_do_agent_preferred_when_user_model_is_not_set(self, monkeypatch):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
+        monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
+        provider = select_provider(_ai_config(api_key="encrypted", model=None))
+        assert provider["kind"] == "digitalocean"
+        assert provider["model"] == DO_DEFAULT_MODEL
 
     def test_user_openai_default_model_when_none(self, monkeypatch):
         provider = select_provider(_ai_config(api_key="encrypted", model=None))


### PR DESCRIPTION
### Motivation
- Users configuring a DigitalOcean GenAI agent server-side expect the agent to control the model, and sending a concrete default model (e.g. `gpt-4o-mini`) can trigger upstream "not available for your subscription tier" errors.
- The change ensures the server-configured DO agent is chosen when the user has not explicitly selected an OpenAI model, avoiding accidental model injection into the DO proxy path.

### Description
- Adjusted `select_provider` to prefer the DigitalOcean provider when `DO_AI_BASE_URL`/`DO_AI_API_KEY` are present and the user's `AISettings.model_version` is unset, empty, or already the DO placeholder (`DO_DEFAULT_MODEL`).
- Kept existing behavior so an explicit user-selected model still routes to the user's OpenAI settings via `select_provider`.
- Updated tests in `tests/test_ai_insights.py` to cover the new precedence and renamed/added assertions to validate DO preference when the user model is not set.
- Modified files: `app/ai_insights.py` and `tests/test_ai_insights.py`.

### Testing
- Ran the AI insights unit tests with `python -m pytest -q tests/test_ai_insights.py` and all tests passed (`39 passed`, with 2 non-blocking warnings).
- The updated test suite verifies `select_provider` behavior for OpenAI explicit-model, DO-agent fallback when no user key, and DO preference when the user model is unset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe405e1aa08320a4c2d3dc8b9774ef)