### PR TITLE
Fix AI insights banner to treat DigitalOcean agent as a configured provider

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -108,21 +108,21 @@ def index():
     ai_config = AISettings.query.filter_by(user_id=user_id).first()
     ai_insights_data = None
     ai_last_updated = None
-    has_ai_key = False
+    ai_provider_configured = False
     if ai_config:
-        has_ai_key = bool(ai_config.api_key)
         ai_last_updated = ai_config.last_updated
         if ai_config.last_insights:
             try:
                 ai_insights_data = json.loads(ai_config.last_insights)
             except (json.JSONDecodeError, ValueError) as exc:
                 logger.warning("Could not parse cached AI insights for user %s: %s", user_id, exc)
+    ai_provider_configured = select_provider(ai_config) is not None
 
     if current_user.admin:
         return render_template('index.html', title='Index', todaydate=todaydate, balance=balance.amount,
                            minbalance=minbalance, min_scenario=min_scenario, graphJSON=graphJSON,
                            ai_insights_data=ai_insights_data, ai_last_updated=ai_last_updated,
-                           has_ai_key=has_ai_key, cash_risk=cash_risk)
+                           ai_provider_configured=ai_provider_configured, cash_risk=cash_risk)
     else:
         return render_template('index_guest.html', title='Index', todaydate=todaydate, balance=balance.amount,
                            minbalance=minbalance, min_scenario=min_scenario, graphJSON=graphJSON,

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -158,7 +158,7 @@
 
         <!-- AI-generated insights (replaced on refresh) -->
         <div id="ai-insights-list">
-        {% if not has_ai_key %}
+        {% if not ai_provider_configured %}
         <div style="text-align: center; padding: 2rem; color: var(--text-muted);">
             <i class="fa-solid fa-robot" style="font-size: 2rem; margin-bottom: 0.75rem; display: block; color: #6366f1;"></i>
             <p style="margin: 0 0 0.5rem;">AI insights are not configured yet.</p>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -95,6 +95,22 @@ class TestAuthenticatedGetRoutes:
         assert resp.status_code in (301, 302)
         assert "/" in resp.headers.get("Location", "")
 
+    def test_index_shows_ai_not_configured_only_when_no_provider(self, auth_client, monkeypatch):
+        monkeypatch.delenv("DO_AI_BASE_URL", raising=False)
+        monkeypatch.delenv("DO_AI_API_KEY", raising=False)
+
+        resp = auth_client.get("/", follow_redirects=True)
+        assert resp.status_code == 200
+        assert b"AI insights are not configured yet." in resp.data
+
+    def test_index_hides_ai_not_configured_when_do_provider_set(self, auth_client, monkeypatch):
+        monkeypatch.setenv("DO_AI_BASE_URL", "https://example.digitalocean.com")
+        monkeypatch.setenv("DO_AI_API_KEY", "test-key")
+
+        resp = auth_client.get("/", follow_redirects=True)
+        assert resp.status_code == 200
+        assert b"AI insights are not configured yet." not in resp.data
+
 
 class TestSignupLinkBehavior:
     def test_login_create_account_defaults_to_builtin_signup(self, client):


### PR DESCRIPTION
### Motivation
- The dashboard showed “AI insights are not configured yet.” whenever the user had not saved an OpenAI key, even if a server-side DigitalOcean GenAI agent (DO env vars) was available; the intent is to only show that message when no provider at all is configured.

### Description
- Use `select_provider(ai_config)` in `index()` to compute `ai_provider_configured` instead of relying on a user-saved OpenAI key. (change in `app/main.py`)
- Pass `ai_provider_configured` into the admin `index.html` template and update the template condition to check `ai_provider_configured` before showing the "AI insights are not configured yet." banner. (change in `app/templates/index.html`)
- Add two route tests verifying both cases: no provider shows the banner, and DO env vars present hide the banner. (change in `tests/test_routes.py`)

### Testing
- Ran the new route tests with `python -m pytest -q tests/test_routes.py::TestAuthenticatedGetRoutes::test_index_shows_ai_not_configured_only_when_no_provider tests/test_routes.py::TestAuthenticatedGetRoutes::test_index_hides_ai_not_configured_when_do_provider_set`, and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe41b7ea048320875e011313c39bb1)