### PR TITLE
Reduce AI insights refresh cooldown to 2 hours

### DIFF
--- a/app/ai_insights.py
+++ b/app/ai_insights.py
@@ -218,7 +218,7 @@ def build_payload(current_balance, schedules, holds, skips):
 
 DEFAULT_MODEL = 'gpt-4o-mini'
 DO_DEFAULT_MODEL = 'n/a'
-REFRESH_INTERVAL = timedelta(hours=24)
+REFRESH_INTERVAL = timedelta(hours=2)
 
 
 class AIProviderError(Exception):
@@ -333,7 +333,7 @@ def select_provider(ai_config):
 def is_refresh_due(last_updated, now=None):
     """Return True when AI insights are eligible for a refresh.
 
-    Insights may refresh at most once per 24 hours per user.  A missing
+    Insights may refresh at most once per 2 hours per user.  A missing
     timestamp (first run, or never refreshed) is always eligible.
     """
     if last_updated is None:

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -2,7 +2,7 @@
 Unit tests for the AI insights helper layer:
   - normalize_do_base_url
   - select_provider (user OpenAI vs DigitalOcean fallback vs none)
-  - is_refresh_due (24-hour limit)
+  - is_refresh_due (2-hour limit)
   - fetch_insights_for_provider client construction
   - /api/v1/insights/refresh end-to-end honors the provider/refresh policy
 
@@ -145,24 +145,24 @@ class TestIsRefreshDue:
     def test_missing_timestamp_is_due(self):
         assert is_refresh_due(None) is True
 
-    def test_within_24_hours_is_not_due(self):
+    def test_within_2_hours_is_not_due(self):
         now = datetime.now(timezone.utc)
         recent = now - timedelta(hours=1)
         assert is_refresh_due(recent, now=now) is False
 
-    def test_just_under_24_hours_is_not_due(self):
+    def test_just_under_2_hours_is_not_due(self):
         now = datetime.now(timezone.utc)
-        recent = now - timedelta(hours=23, minutes=59)
+        recent = now - timedelta(hours=1, minutes=59)
         assert is_refresh_due(recent, now=now) is False
 
-    def test_exactly_24_hours_is_due(self):
+    def test_exactly_2_hours_is_due(self):
         now = datetime.now(timezone.utc)
-        boundary = now - timedelta(hours=24)
+        boundary = now - timedelta(hours=2)
         assert is_refresh_due(boundary, now=now) is True
 
-    def test_older_than_24_hours_is_due(self):
+    def test_older_than_2_hours_is_due(self):
         now = datetime.now(timezone.utc)
-        old = now - timedelta(days=2)
+        old = now - timedelta(hours=3)
         assert is_refresh_due(old, now=now) is True
 
     def test_handles_naive_timestamp_as_utc(self):
@@ -263,7 +263,7 @@ class TestFetchInsightsForProvider:
         assert '"today": "2026-05-08"' in messages[1]["content"]
 
 
-# ── End-to-end: /api/v1/insights/refresh respects provider + 24h limit ───────
+# ── End-to-end: /api/v1/insights/refresh respects provider + 2h limit ───────
 
 
 def _login(client, email="admin@test.local", password="testpass123"):
@@ -373,7 +373,7 @@ class TestRefreshEndpointProviderAndLimit:
 
     def test_recent_refresh_returns_cached_without_calling_provider(self, client, flask_app, clean_ai_settings, monkeypatch):
         # Even though DO env is present and would otherwise be used, a refresh
-        # less than 24 hours ago must skip the AI call entirely.
+        # less than 2 hours ago must skip the AI call entirely.
         monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
         monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
 
@@ -515,7 +515,7 @@ class TestRemoveApiKeyRoute:
             assert row is not None
             assert row.api_key is None
             assert row.model_version is None
-            # Cached insights and the 24h refresh window are shared with the
+            # Cached insights and the 2h refresh window are shared with the
             # DigitalOcean provider and must be preserved.
             assert row.last_insights == cached_payload
             assert row.last_updated is not None


### PR DESCRIPTION
### Motivation
- Make AI insights eligible for refresh more frequently by changing the cooldown from 24 hours to 2 hours so users can get fresher insights.

### Description
- Change the refresh interval constant from `timedelta(hours=24)` to `timedelta(hours=2)` by updating `REFRESH_INTERVAL` in `app/ai_insights.py`.
- Update the `is_refresh_due` docstring to describe the new 2-hour policy in `app/ai_insights.py`.
- Update unit tests in `tests/test_ai_insights.py` to validate the 2-hour window, including test names, boundary `timedelta` values, and related comments.

### Testing
- Ran `python -m pytest -q tests/test_ai_insights.py` and all tests in that file passed (`39 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe47827cd8832090e4db7d966ba589)