### PR TITLE
Prevent AI refresh timestamp updates during 2-hour cooldown

### DIFF
--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -761,18 +761,17 @@ def api_insights_refresh():
 
     last_updated = ai_config.last_updated if ai_config else None
     cached_insights = ai_config.last_insights if ai_config else None
-    if cached_insights and not is_refresh_due(last_updated):
+    if not is_refresh_due(last_updated):
         try:
-            parsed = json.loads(cached_insights)
+            parsed = json.loads(cached_insights) if cached_insights else None
         except (json.JSONDecodeError, ValueError, TypeError):
             parsed = None
-        if parsed is not None:
-            return api_ok({
-                "configured": bool(ai_config and ai_config.api_key),
-                "insights": parsed,
-                "last_updated": _datetime(ai_config.last_updated) if ai_config else None,
-                "model": ai_config.model_version if ai_config else None,
-            })
+        return api_ok({
+            "configured": bool(ai_config and ai_config.api_key),
+            "insights": parsed,
+            "last_updated": _datetime(ai_config.last_updated) if ai_config else None,
+            "model": ai_config.model_version if ai_config else None,
+        })
 
     balance_record = _latest_balance(user_id)
     current_balance = float(balance_record.amount) if balance_record else 0.0

--- a/app/main.py
+++ b/app/main.py
@@ -1365,8 +1365,8 @@ def ai_insights():
 
     last_updated = ai_config.last_updated if ai_config else None
     cached_insights = ai_config.last_insights if ai_config else None
-    if cached_insights and not is_refresh_due(last_updated):
-        return Response(cached_insights, status=200, mimetype='application/json')
+    if not is_refresh_due(last_updated):
+        return Response(cached_insights or json.dumps({'insights': None}), status=200, mimetype='application/json')
 
     balance_record = Balance.query.filter_by(user_id=user_id).order_by(desc(Balance.date), desc(Balance.id)).first()
     current_balance = float(balance_record.amount) if balance_record else 0.0

--- a/tests/test_ai_insights.py
+++ b/tests/test_ai_insights.py
@@ -408,9 +408,9 @@ class TestRefreshEndpointProviderAndLimit:
         body = resp.get_json()["data"]
         assert body["insights"] == json.loads(cached_payload)
 
-    def test_invalid_cached_json_within_window_regenerates(self, client, flask_app, clean_ai_settings, monkeypatch):
-        # A malformed cached payload inside the 24-hour window must not lock
-        # the user out — treat it as a cache miss and regenerate immediately.
+    def test_invalid_cached_json_within_window_returns_without_regenerating(self, client, flask_app, clean_ai_settings, monkeypatch):
+        # A malformed cached payload inside the 2-hour window should not trigger
+        # a provider call, and must preserve the existing last_updated timestamp.
         monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")
         monkeypatch.setenv("DO_AI_API_KEY", "do-secret")
 
@@ -440,13 +440,16 @@ class TestRefreshEndpointProviderAndLimit:
         token = _login(client)
         resp = client.post("/api/v1/insights/refresh", headers=_bearer(token))
         assert resp.status_code == 200, resp.get_json()
-        assert called["count"] == 1
+        assert called["count"] == 0
         body = resp.get_json()["data"]
-        assert body["insights"] == {"insights": [{"title": "fresh"}]}
+        assert body["insights"] is None
 
         with flask_app.app_context():
             row = AISettings.query.filter_by(user_id=user_id).first()
-            assert row.last_insights == '{"insights": [{"title": "fresh"}]}'
+            assert row.last_insights == "not-json{"
+            assert row.last_updated is not None
+            row_dt = row.last_updated if row.last_updated.tzinfo else row.last_updated.replace(tzinfo=timezone.utc)
+            assert abs((row_dt - recent).total_seconds()) < 5
 
     def test_stale_refresh_calls_provider_and_updates_timestamp(self, client, flask_app, clean_ai_settings, monkeypatch):
         monkeypatch.setenv("DO_AI_BASE_URL", "https://example.do.run")


### PR DESCRIPTION
### Motivation
- Prevent accidental bumps to the AI insights `last_updated` timestamp when a user attempts to refresh inside the 2-hour cooldown window so rate-limits and cache semantics remain correct.
- Ensure that malformed cached payloads inside the cooldown do not cause a provider call or overwrite the existing timestamp.

### Description
- Short-circuited both the web handler (`/ai_insights`) and API handler (`/api/v1/insights/refresh`) to return cached insights (or `null` when cached JSON is unusable) when `is_refresh_due(last_updated)` is false, without calling the provider or modifying `last_updated` (changes in `app/main.py` and `app/api/routes/data.py`).
- Adjusted cached JSON parsing so an absent `last_insights` becomes `None` rather than attempting to parse and treating that as a cache miss in the cooldown path (changes in `app/api/routes/data.py`).
- Updated unit tests to assert that malformed cached payloads within the cooldown Window do not trigger a provider call and that `last_updated` remains unchanged (changes in `tests/test_ai_insights.py`).

### Testing
- Ran the AI insights test suite with `python -m pytest -q tests/test_ai_insights.py` and all tests passed: `39 passed, 2 warnings`.
- Verified the modified API and web refresh paths return cached data when refresh is not due and do not call `fetch_insights_for_provider` during the cooldown via the updated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe48fff9648320b65ac955e3df3879)