### PR TITLE
Add DigitalOcean GenAI agent env vars to .env_example

### DIFF
--- a/app/.env_example
+++ b/app/.env_example
@@ -84,6 +84,11 @@ PASSKEY_RP_ID=
 PASSKEY_RP_NAME=PyCashFlow
 PASSKEY_ORIGIN=
 
+# Optional: DigitalOcean GenAI Agent endpoint settings.
+# When both are set, AI insights can use the DO provider via OpenAI-compatible API.
+DO_AI_BASE_URL=
+DO_AI_API_KEY=
+
 # Optional (legacy integrations)
 API_SECRET=
 PROJECT_ID=


### PR DESCRIPTION
### Motivation
- Add optional environment configuration to enable using DigitalOcean GenAI as an OpenAI-compatible provider for AI insights via the app's agent settings.

### Description
- Introduce `DO_AI_BASE_URL` and `DO_AI_API_KEY` to `app/.env_example` with explanatory comments describing when to set them and how they enable the DO provider.

### Testing
- No automated tests were added or modified since this is a documentation/example environment change and requires no runtime code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff420b41a08320941f8badbc77e100)