### PR TITLE
docs: reduce README logo display size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![logo](./app/static/app_logo_rounded.png)
+<img src="./app/static/app_logo_rounded.png" alt="PyCashFlow logo" width="220" />
 
 # PyCashFlow
 


### PR DESCRIPTION
### Motivation
- Make the top-of-README logo render smaller for improved layout and visual balance in the repository landing page.

### Description
- Replace the Markdown image with an HTML `<img>` tag in `README.md` and set `width="220"` so `app/static/app_logo_rounded.png` displays at the reduced size.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00147c47c48320bbbf4e504c4743f1)