### PR TITLE
Show green success notice after signup with password setup instructions

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -291,11 +291,6 @@ def signup_post():
             # Don't fail registration if email notification fails
             logger.warning("Failed to send new user notification for %s: %s", email, exc)
 
-    flash(
-        'Account created successfully! You will receive an email to set your password. '
-        'Once your password is set, you can log in here or on the iOS app.',
-        'success',
-    )
     return redirect(url_for('auth.login'))
 
 
@@ -340,7 +335,11 @@ def set_password(token: str):
     user.password = generate_password_hash(password, method="scrypt")
     user.is_active = True
     db.session.commit()
-    flash("Password setup complete. Please sign in.")
+    flash(
+        "Account created successfully! You will receive an email to set your password. "
+        "You can sign in here or on the iOS app.",
+        "success",
+    )
     return redirect(url_for("auth.login"))
 
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -336,7 +336,7 @@ def set_password(token: str):
     user.is_active = True
     db.session.commit()
     flash(
-        "Account created successfully! You can sign in here or on the iOS app.",
+        "Password successfully set! You can sign in here or on the iOS app.",
         "success",
     )
     return redirect(url_for("auth.login"))

--- a/app/auth.py
+++ b/app/auth.py
@@ -291,6 +291,11 @@ def signup_post():
             # Don't fail registration if email notification fails
             logger.warning("Failed to send new user notification for %s: %s", email, exc)
 
+    flash(
+        'Account created successfully! You will receive an email to set your password. '
+        'Once your password is set, you can log in here or on the iOS app.',
+        'success',
+    )
     return redirect(url_for('auth.login'))
 
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -336,8 +336,7 @@ def set_password(token: str):
     user.is_active = True
     db.session.commit()
     flash(
-        "Account created successfully! You will receive an email to set your password. "
-        "You can sign in here or on the iOS app.",
+        "Account created successfully! You can sign in here or on the iOS app.",
         "success",
     )
     return redirect(url_for("auth.login"))

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -18,13 +18,23 @@
         </h2>
 
         <!-- Flash messages -->
-        {% with messages = get_flashed_messages() %}
+        {% with messages = get_flashed_messages(with_categories=True) %}
         {% if messages %}
-            <div class="alert alert-dismissible fade show" role="alert" style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid var(--danger); color: var(--text-primary); border-radius: var(--radius-md); margin-bottom: 1.5rem;">
-                <i class="fa-solid fa-circle-exclamation"></i>
-                {{ messages[0] }}
+            {% for category, message in messages %}
+            {% if category == 'success' %}
+            <div class="alert alert-dismissible fade show" role="alert" style="background-color: rgba(16, 185, 129, 0.1); border: 1px solid var(--success); color: var(--text-primary); border-radius: var(--radius-md); margin-bottom: 1.5rem;">
+                <i class="fa-solid fa-circle-check"></i>
+                {{ message }}
                 <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
+            {% else %}
+            <div class="alert alert-dismissible fade show" role="alert" style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid var(--danger); color: var(--text-primary); border-radius: var(--radius-md); margin-bottom: 1.5rem;">
+                <i class="fa-solid fa-circle-exclamation"></i>
+                {{ message }}
+                <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+            </div>
+            {% endif %}
+            {% endfor %}
         {% endif %}
         {% endwith %}
 


### PR DESCRIPTION
The post-signup redirect to the login page now flashes a success-category
message and the login template renders that category with green styling.
The message tells the user they will receive an email to set their
password and that they can sign in on the web or in the iOS app.