### PR TITLE
Flash forgot-password success message with success category

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -128,7 +128,7 @@ def forgot_password():
             flash("Password reset is currently unavailable. Please contact support.")
             return render_template('forgot_password.html')
 
-    flash(success_message)
+    flash(success_message, 'success')
     return redirect(url_for('auth.login'))
 
 


### PR DESCRIPTION
The login template only renders the green success style when the
flashed message has the 'success' category; otherwise it falls through
to the red error style. The forgot-password handler was flashing the
"If an account exists..." message without a category, so it appeared
in the red box instead of the green one.