### PR TITLE
Rename cloud subscription button on login screen

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -169,15 +169,10 @@ struct LoginView: View {
                     }
                     .surfaceCard()
                 } else {
-                    VStack(alignment: .leading, spacing: 8) {
-                        Text("Using PyCashFlow Cloud hosted service.")
-                            .foregroundStyle(AppTheme.textSecondary)
-                        NavigationLink("Activate or Restore Cloud Subscription") {
-                            SubscriptionPaywallView()
-                        }
-                        .buttonStyle(PrimaryButtonStyle())
+                    NavigationLink("Sign up for PyCashFlow Cloud") {
+                        SubscriptionPaywallView()
                     }
-                    .surfaceCard()
+                    .buttonStyle(PrimaryButtonStyle())
                 }
 
             }


### PR DESCRIPTION
Renames "Activate or Restore Cloud Subscription" to "Sign up for
PyCashFlow Cloud" and removes the surrounding card and the "Using
PyCashFlow Cloud hosted service." caption from the login screen.