### PR TITLE
Add forgot-password link and use in-app browser for external links

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Browser/SafariView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Browser/SafariView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+import SafariServices
+
+/// Wraps `SFSafariViewController` so SwiftUI sheets can present links inside
+/// the app instead of bouncing the user out to Safari.
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let controller = SFSafariViewController(url: url)
+        controller.preferredBarTintColor = UIColor(AppTheme.primaryDark)
+        controller.preferredControlTintColor = UIColor(AppTheme.accent)
+        controller.dismissButtonStyle = .done
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: SFSafariViewController, context: Context) {}
+}
+
+extension View {
+    /// Presents a `SafariView` sheet whenever the bound URL becomes non-nil.
+    func inAppBrowser(url: Binding<URL?>) -> some View {
+        sheet(isPresented: Binding(
+            get: { url.wrappedValue != nil },
+            set: { isPresented in
+                if !isPresented { url.wrappedValue = nil }
+            }
+        )) {
+            if let target = url.wrappedValue {
+                SafariView(url: target)
+                    .ignoresSafeArea()
+            }
+        }
+    }
+}

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -21,7 +21,10 @@ struct LoginView: View {
     @State private var isPasskeyLoading = false
     @State private var showPasswordLoginFields = false
     @State private var showPasskeyEmailField = false
+    @State private var inAppBrowserURL: URL?
     @FocusState private var focusedField: Field?
+
+    private static let forgotPasswordURL = URL(string: "https://cash.hahn3.com/forgot-password")!
 
     var body: some View {
         ScrollView {
@@ -78,6 +81,13 @@ struct LoginView: View {
                             .padding(12)
                             .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
                             .foregroundStyle(AppTheme.textPrimary)
+
+                        Button("Forgot password?") {
+                            inAppBrowserURL = Self.forgotPasswordURL
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(AppTheme.accent)
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     } else if challenge != nil {
                         TextField("6-digit code or backup code", text: $twoFACode)
                             .textInputAutocapitalization(.never)
@@ -188,6 +198,7 @@ struct LoginView: View {
         // user is typing. `.immediately` keeps scroll-to-dismiss UX without
         // the conflicting drag recognizer.
         .scrollDismissesKeyboard(.immediately)
+        .inAppBrowser(url: $inAppBrowserURL)
         .onAppear {
             selfHostedURL = session.selfHostedBaseURLText
         }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -7,6 +7,9 @@ struct SettingsView: View {
     @State private var newPassword = ""
     @State private var errorText: String?
     @State private var showPasswordFields = false
+    @State private var inAppBrowserURL: URL?
+
+    private static let userGuideURL = URL(string: "https://pycashflow.com/user_guide")!
 
     var body: some View {
         ScrollView {
@@ -45,8 +48,10 @@ struct SettingsView: View {
                 .surfaceCard()
 
                 if let moreSettingsURL {
-                    Link("More Settings", destination: moreSettingsURL)
-                        .buttonStyle(PrimaryButtonStyle())
+                    Button("More Settings") {
+                        inAppBrowserURL = moreSettingsURL
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
                 }
 
                 Button("Refresh Subscription Status") { Task { await session.refreshSubscriptionState(forceProfileRefresh: true) } }
@@ -73,10 +78,13 @@ struct SettingsView: View {
         .task { await load() }
         .refreshable { await load() }
         .appBackground()
+        .inAppBrowser(url: $inAppBrowserURL)
         .navigationTitle("Settings")
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
-                Link(destination: URL(string: "https://pycashflow.com/user_guide")!) {
+                Button {
+                    inAppBrowserURL = Self.userGuideURL
+                } label: {
                     Image(systemName: "questionmark.circle")
                         .accessibilityLabel("User Guide")
                 }


### PR DESCRIPTION
Adds a "Forgot password?" text link under the iOS app's password field
that expands and collapses with the email/password fields, opening
https://cash.hahn3.com/forgot-password inside the app. Routes the new
link plus the existing "More Settings" and user guide actions through a
shared SFSafariViewController wrapper so they no longer kick the user
out to Safari.