### PR TITLE
Show PyCashFlow Cloud AI in iOS Settings when DO provider is active

### DIFF
--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -703,6 +703,8 @@ def api_settings():
         py_version = ""
 
     ai_config = AISettings.query.filter_by(user_id=user_id).first()
+    provider = select_provider(ai_config)
+    provider_kind = provider["kind"] if provider else None
     return api_ok({
         "user": {
             "id": user.id,
@@ -717,7 +719,8 @@ def api_settings():
             "python_version": py_version,
         },
         "ai": {
-            "configured": bool(ai_config and ai_config.api_key),
+            "configured": provider is not None,
+            "provider": provider_kind,
             "model": ai_config.model_version if ai_config else None,
             "last_updated": _datetime(ai_config.last_updated) if ai_config else None,
         },

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
@@ -185,6 +185,7 @@ struct SettingsDTO: Decodable {
 
     struct SettingsAIDTO: Decodable {
         let configured: Bool
+        let provider: String?
         let model: String?
         let last_updated: String?
     }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Settings/SettingsView.swift
@@ -117,6 +117,9 @@ struct SettingsView: View {
 
 
     private func aiConfiguredValue(_ ai: SettingsDTO.SettingsAIDTO) -> String {
+        if ai.provider == "digitalocean", session.appMode == .cloud {
+            return "PyCashFlow Cloud AI"
+        }
         guard ai.configured else { return "No" }
         if let model = ai.model, !model.isEmpty {
             return "Yes, \(model)"


### PR DESCRIPTION
The iOS Settings view's 'AI Configured' field only reflected the per-user
OpenAI key, so cloud users relying on the global DigitalOcean provider saw
'No' even though AI insights were available. Expose the effective provider
from /settings via select_provider() and render 'PyCashFlow Cloud AI' when
the user is on PyCashFlow Cloud and the DigitalOcean provider is selected.