### PR TITLE
Derive forgot-password URL from active backend

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -24,7 +24,15 @@ struct LoginView: View {
     @State private var inAppBrowserURL: URL?
     @FocusState private var focusedField: Field?
 
-    private static let forgotPasswordURL = URL(string: "https://cash.hahn3.com/forgot-password")!
+    private var forgotPasswordURL: URL? {
+        guard var components = URLComponents(url: session.currentBaseURL, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        components.path = "/forgot-password"
+        components.query = nil
+        components.fragment = nil
+        return components.url
+    }
 
     var body: some View {
         ScrollView {
@@ -83,7 +91,7 @@ struct LoginView: View {
                             .foregroundStyle(AppTheme.textPrimary)
 
                         Button("Forgot password?") {
-                            inAppBrowserURL = Self.forgotPasswordURL
+                            inAppBrowserURL = forgotPasswordURL
                         }
                         .buttonStyle(.plain)
                         .foregroundStyle(AppTheme.accent)


### PR DESCRIPTION
The previous hard-coded https://cash.hahn3.com/forgot-password sent
self-hosted users to the wrong server and didn't match the configured
cloud host (app.pycashflow.com). Build it from session.currentBaseURL
with the path replaced by /forgot-password, mirroring the moreSettingsURL
pattern in SettingsView.