### PR TITLE
Switch gunicorn to gthread workers so slow AI calls don't freeze the app

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -111,15 +111,17 @@ else
 fi
 
 GUNICORN_WORKERS="${RESOLVED_GUNICORN_WORKERS}"
-GUNICORN_TIMEOUT="${GUNICORN_TIMEOUT:-120}"
+GUNICORN_TIMEOUT="${GUNICORN_TIMEOUT:-240}"
+GUNICORN_THREADS="${GUNICORN_THREADS:-8}"
 
-echo "Starting Gunicorn: workers=${GUNICORN_WORKERS}, timeout=${GUNICORN_TIMEOUT}, bind=0.0.0.0:5000"
+echo "Starting Gunicorn: workers=${GUNICORN_WORKERS}, threads=${GUNICORN_THREADS}, timeout=${GUNICORN_TIMEOUT}, bind=0.0.0.0:5000"
 
 # Run gunicorn as appuser (exec replaces the root shell — no root process remains)
 exec su-exec appuser gunicorn \
     --bind 0.0.0.0:5000 \
     --workers "${GUNICORN_WORKERS}" \
-    --worker-class sync \
+    --worker-class gthread \
+    --threads "${GUNICORN_THREADS}" \
     --timeout "${GUNICORN_TIMEOUT}" \
     --access-logfile - \
     --error-logfile - \


### PR DESCRIPTION
Sync workers handle one request at a time, so a single user's AI
insights refresh (5-30s OpenAI call) blocks every other request to
the container — page loads, API calls, healthcheck. Switching to
gthread lets one worker serve N concurrent requests on threads, so
an in-flight AI call only ties up one thread while the rest keep
serving traffic.

Default threads=8 (override via GUNICORN_THREADS) and timeout bumped
from 120s to 240s to give large model responses more headroom.