### PR TITLE
Raise iOS APIClient timeouts to 240s to match Gunicorn

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Networking/APIClient.swift
@@ -8,6 +8,8 @@ final class APIClient {
         let config = URLSessionConfiguration.ephemeral
         config.requestCachePolicy = .reloadIgnoringLocalCacheData
         config.urlCache = nil
+        config.timeoutIntervalForRequest = 240
+        config.timeoutIntervalForResource = 240
         return URLSession(configuration: config)
     }()
 


### PR DESCRIPTION
The default URLSession request timeout (~60s) was firing during AI
insights refresh while the backend continued processing and eventually
returned results. Bumping both timeouts to 240s aligns the client with
the Gunicorn worker timeout so the spinner stays up until the refresh
actually completes.