### PR TITLE
Reject Plaid exchange with missing account id; guard Plaid mutations from guests

### DIFF
--- a/app/api/routes/plaid.py
+++ b/app/api/routes/plaid.py
@@ -17,7 +17,7 @@ from flask import request
 
 from app.api import api
 from app.api.auth_utils import api_login_required, get_api_user
-from app.api.errors import api_error
+from app.api.errors import api_error, forbidden
 from app.api.responses import api_ok, api_no_content
 from app.plaid_service import (
     PlaidServiceError,
@@ -31,6 +31,13 @@ from app.plaid_service import (
 
 def _service_error(exc: PlaidServiceError):
     return api_error(exc.user_message, exc.code, exc.status)
+
+
+def _forbid_guest_writes():
+    user = get_api_user()
+    if not user.admin:
+        return forbidden("Guest users are read-only")
+    return None
 
 
 @api.route("/plaid/status", methods=["GET"])
@@ -54,6 +61,8 @@ def api_plaid_link_token():
 @api.route("/plaid/exchange-token", methods=["POST"])
 @api_login_required
 def api_plaid_exchange_token():
+    if (resp := _forbid_guest_writes()) is not None:
+        return resp
     user = get_api_user()
     body = request.get_json(silent=True) or {}
     public_token = body.get("public_token")
@@ -68,6 +77,8 @@ def api_plaid_exchange_token():
 @api.route("/plaid/remove", methods=["POST", "DELETE"])
 @api_login_required
 def api_plaid_remove():
+    if (resp := _forbid_guest_writes()) is not None:
+        return resp
     user = get_api_user()
     remove_plaid_connection_for_user(user)
     return api_no_content()
@@ -76,6 +87,8 @@ def api_plaid_remove():
 @api.route("/plaid/update-balance", methods=["POST"])
 @api_login_required
 def api_plaid_update_balance():
+    if (resp := _forbid_guest_writes()) is not None:
+        return resp
     user = get_api_user()
     try:
         result = update_plaid_balance_for_user(user)

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -308,6 +308,15 @@ def exchange_public_token_for_user(user, public_token: str, metadata: dict) -> P
 
     _validate_account_type(selected)
 
+    account_id_raw = selected.get("id")
+    account_id = account_id_raw.strip() if isinstance(account_id_raw, str) else ""
+    if not account_id:
+        raise PlaidServiceError(
+            "Plaid did not return an account id for the selected account.",
+            code="plaid_missing_account_id",
+            status=422,
+        )
+
     from plaid.exceptions import ApiException
     from plaid.model.item_public_token_exchange_request import (
         ItemPublicTokenExchangeRequest,
@@ -349,7 +358,7 @@ def exchange_public_token_for_user(user, public_token: str, metadata: dict) -> P
         user_id=user.id,
         encrypted_access_token=encrypted,
         plaid_item_id=str(item_id),
-        plaid_account_id=str(selected.get("id") or ""),
+        plaid_account_id=account_id,
         institution_id=str(institution_id) if institution_id else None,
         institution_name=str(institution_name) if institution_name else None,
         account_name=(selected.get("name") or None),

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -269,6 +269,40 @@ class TestExchangePublicToken:
             assert ei.value.code == "plaid_select_one_account"
             _deconfigure_plaid(flask_app)
 
+    def test_rejects_when_account_id_missing(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            user = User.query.get(plaid_user)
+            metadata = {
+                "institution": {"institution_id": "i", "name": "n"},
+                "accounts": [
+                    {"type": "depository", "subtype": "checking", "name": "Checking"}
+                ],
+            }
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                with pytest.raises(plaid_service.PlaidServiceError) as ei:
+                    plaid_service.exchange_public_token_for_user(user, "ptok", metadata)
+                assert ei.value.code == "plaid_missing_account_id"
+                assert not mock_client.return_value.item_public_token_exchange.called
+            assert PlaidConnection.query.filter_by(user_id=user.id).count() == 0
+            _deconfigure_plaid(flask_app)
+
+    def test_rejects_when_account_id_blank(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            user = User.query.get(plaid_user)
+            metadata = {
+                "institution": {"institution_id": "i", "name": "n"},
+                "accounts": [
+                    {"id": "   ", "type": "depository", "subtype": "checking"}
+                ],
+            }
+            with pytest.raises(plaid_service.PlaidServiceError) as ei:
+                plaid_service.exchange_public_token_for_user(user, "ptok", metadata)
+            assert ei.value.code == "plaid_missing_account_id"
+            assert PlaidConnection.query.filter_by(user_id=user.id).count() == 0
+            _deconfigure_plaid(flask_app)
+
 
 # ── Remove connection ───────────────────────────────────────────────────────
 
@@ -487,6 +521,115 @@ class TestDashboardIntegration:
             except RuntimeError:
                 pytest.fail("Dashboard should not propagate Plaid errors")
             assert resp.status_code == 200
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+
+
+# ── Guest write restrictions ────────────────────────────────────────────────
+
+
+class TestGuestWriteRestrictions:
+    """Guest (admin=False) users must not be able to mutate Plaid state."""
+
+    @pytest.fixture()
+    def guest_client(self, flask_app):
+        with flask_app.app_context():
+            owner = User(
+                email=f"plaid-owner-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="Owner",
+                admin=True,
+                is_account_owner=True,
+                is_active=True,
+            )
+            db.session.add(owner)
+            db.session.commit()
+            guest = User(
+                email=f"plaid-guest-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="Guest",
+                admin=False,
+                is_active=True,
+                is_account_owner=False,
+                owner_user_id=owner.id,
+                account_owner_id=owner.id,
+            )
+            db.session.add(guest)
+            db.session.commit()
+            guest_id = guest.id
+            owner_id = owner.id
+
+        c = flask_app.test_client()
+        with c.session_transaction() as sess:
+            sess["_user_id"] = str(guest_id)
+            sess["_fresh"] = True
+
+        yield c
+
+        with flask_app.app_context():
+            PlaidConnection.query.filter(
+                PlaidConnection.user_id.in_([guest_id, owner_id])
+            ).delete(synchronize_session=False)
+            User.query.filter(User.id.in_([guest_id, owner_id])).delete(
+                synchronize_session=False
+            )
+            db.session.commit()
+
+    def test_exchange_token_forbidden_for_guest(self, flask_app, guest_client):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        with patch.object(plaid_service, "_plaid_client") as mock_client:
+            resp = guest_client.post(
+                "/api/v1/plaid/exchange-token",
+                json={
+                    "public_token": "ptok",
+                    "metadata": {
+                        "institution": {"institution_id": "i", "name": "n"},
+                        "accounts": [
+                            {"id": "a", "type": "depository", "subtype": "checking"}
+                        ],
+                    },
+                },
+            )
+            assert resp.status_code == 403
+            assert resp.get_json()["code"] == "forbidden"
+            assert not mock_client.return_value.item_public_token_exchange.called
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+
+    def test_remove_forbidden_for_guest(self, flask_app, guest_client):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        resp = guest_client.post("/api/v1/plaid/remove")
+        assert resp.status_code == 403
+        assert resp.get_json()["code"] == "forbidden"
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+
+    def test_remove_delete_forbidden_for_guest(self, flask_app, guest_client):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        resp = guest_client.delete("/api/v1/plaid/remove")
+        assert resp.status_code == 403
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+
+    def test_update_balance_forbidden_for_guest(self, flask_app, guest_client):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        with patch.object(plaid_service, "update_plaid_balance_for_user") as mock_upd:
+            resp = guest_client.post("/api/v1/plaid/update-balance")
+            assert resp.status_code == 403
+            assert not mock_upd.called
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+
+    def test_status_allowed_for_guest(self, flask_app, guest_client):
+        """Read-only status endpoint must remain accessible."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        resp = guest_client.get("/api/v1/plaid/status")
+        assert resp.status_code == 200
         with flask_app.app_context():
             _deconfigure_plaid(flask_app)
 


### PR DESCRIPTION
Codex flagged two P2 issues on the Plaid Balance integration:

1. exchange_public_token_for_user coerced the selected account id to ""
   when metadata.accounts[0].id was missing/blank, persisting a broken
   PlaidConnection that would later fail every balance sync and block
   reconnects via plaid_already_connected. Validate the id up front and
   raise plaid_missing_account_id (422) before calling Plaid.

2. /api/v1/plaid/exchange-token, /remove, and /update-balance only
   required authentication, so guest (admin=False) users could create
   or remove Plaid connections and trigger balance writes. Add the same
   guest write guard used in app/api/routes/data.py to those three
   mutation routes; /status remains read-accessible to guests.