### PR TITLE
Update password setup test to match new flash message

### DIFF
--- a/tests/test_password_setup_flow.py
+++ b/tests/test_password_setup_flow.py
@@ -191,7 +191,7 @@ def test_web_set_password_route_completes_setup(
         follow_redirects=True,
     )
     assert resp.status_code == 200
-    assert b"Password setup complete. Please sign in." in resp.data
+    assert b"Password successfully set! You can sign in here or on the iOS app." in resp.data
 
     with flask_app.app_context():
         db_user = user_model.query.filter_by(email="web-setup@test.local").first()


### PR DESCRIPTION
Commit c6602c0 changed the set-password success flash from
"Password setup complete. Please sign in." to
"Password successfully set! You can sign in here or on the iOS app."
but the corresponding assertion in test_web_set_password_route_completes_setup
was not updated, causing the test to fail.

https://claude.ai/code/session_01B2148wuYeTzN2UGjW7638U