### PR TITLE
Add OAuth redirect support for Plaid Link flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,8 +476,27 @@ PLAID_SECRET=your-secret
 PLAID_ENV=sandbox            # sandbox | development | production
 PLAID_PRODUCTS=auth          # comma-separated; "balance" is NOT valid here
 PLAID_COUNTRY_CODES=US
-PLAID_REDIRECT_URI=          # optional; set only if your Plaid app requires OAuth
+PLAID_REDIRECT_URI=          # required for OAuth institutions (Chase, etc.)
 ```
+
+### OAuth institutions (Chase, etc.)
+
+Some institutions (e.g. Chase) require Plaid's OAuth redirect flow. For these:
+
+- `PLAID_REDIRECT_URI` must be set to a fully-qualified URL pointing back to
+  the PyCashFlow web settings page, for example:
+  `https://app.example.com/settings?plaid_oauth_return=1`
+- The **exact same URI** must also be added to the allowed redirect URIs in
+  your [Plaid Dashboard](https://dashboard.plaid.com). A mismatch (or a
+  missing entry) will cause OAuth institutions to fail to complete the Link
+  flow.
+- After the bank redirect, the settings page detects the `oauth_state_id`
+  query parameter, reopens the Plaid modal automatically, and resumes Plaid
+  Link using the original `link_token` (kept in `sessionStorage`) and the
+  return URL as `receivedRedirectUri`. The user does not need to click
+  Connect again.
+- iOS Plaid setup is intentionally **not** supported in this phase. Users
+  must connect Plaid from the web settings page.
 
 Get keys from the [Plaid Dashboard](https://dashboard.plaid.com). The settings
 page shows **Plaid setup: configured** once all four required values are set,
@@ -512,6 +531,27 @@ appropriate for your account (typically `auth`); **do not** include
 - **No iOS changes** are included in this phase.
 - Only **depository** (checking/savings/cash-management) accounts are accepted
   to avoid using a credit-card current balance as if it were available cash.
+
+### Manual verification checklist
+
+After deploying changes, verify the Plaid flow end-to-end:
+
+- [ ] Set `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `PLAID_PRODUCTS`,
+  `PLAID_COUNTRY_CODES`, and (for OAuth) `PLAID_REDIRECT_URI`.
+- [ ] Add the exact `PLAID_REDIRECT_URI` value to the Plaid Dashboard
+  allowed redirect URIs.
+- [ ] Open the web Settings page → **Plaid Balance Sync** card → **Connect
+  Plaid Account**.
+- [ ] Test a non-OAuth sandbox institution (e.g. "First Platypus Bank")
+  and confirm the connection completes inline.
+- [ ] Test an OAuth sandbox institution (e.g. Plaid's "OAuth Bank") and
+  confirm the browser is redirected to Plaid, then back to PyCashFlow.
+- [ ] Confirm the user lands on the Settings page and the Plaid modal
+  re-opens automatically with "Completing Plaid connection…".
+- [ ] Confirm `public_token` is exchanged and the connected account row
+  appears in the Plaid card.
+- [ ] Confirm no iOS changes are required — iOS Plaid Link is not
+  supported in this phase.
 
 ### Running the migration
 

--- a/app/.env_example
+++ b/app/.env_example
@@ -110,8 +110,14 @@ GETEMAIL_LOG_FILE=
 # is included with auth/transactions/identity/etc. Use the least-data/cost
 # product appropriate for your Plaid account (typically "auth").
 # PLAID_COUNTRY_CODES is the comma-separated list of country codes for Link.
-# PLAID_REDIRECT_URI is optional; set it only if your Plaid app requires the
-# OAuth redirect flow.
+# PLAID_REDIRECT_URI is REQUIRED for OAuth institutions (e.g. Chase). It must
+# point back to the PyCashFlow web settings page so Plaid Link can resume
+# automatically after the bank redirect, for example:
+#   https://app.example.com/settings?plaid_oauth_return=1
+# The exact same URI must also be added to your Plaid Dashboard's allowed
+# redirect URIs. If unset or mismatched, OAuth institutions will fail to
+# complete the Link flow. iOS Plaid setup is intentionally not supported in
+# this phase — users must connect Plaid from the web settings page.
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 PLAID_ENV=sandbox

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -809,6 +809,12 @@
                         <i class="fa-solid fa-spinner fa-spin"></i> Loading Plaid status...
                     </p>
                 </div>
+                <div id="plaid-oauth-resume" style="display:none; margin-top: 1rem; padding: 0.75rem;
+                    background-color: rgba(99,102,241,0.08); border-left: 4px solid #6366f1;
+                    border-radius: var(--radius-md); font-size: 0.875rem;">
+                    <i class="fa-solid fa-spinner fa-spin"></i>
+                    <span id="plaid-oauth-resume-text">Completing Plaid connection&hellip;</span>
+                </div>
                 <div id="plaid-error" style="display:none; margin-top: 1rem; padding: 0.75rem;
                     background-color: rgba(239, 68, 68, 0.1); border: 1px solid var(--danger);
                     border-radius: var(--radius-md); color: var(--text-primary); font-size: 0.875rem;"></div>
@@ -829,13 +835,38 @@
     var modalEl = document.getElementById('plaidmodal');
     var statusArea = document.getElementById('plaid-status-area');
     var errorArea = document.getElementById('plaid-error');
+    var oauthResumeArea = document.getElementById('plaid-oauth-resume');
+    var oauthResumeText = document.getElementById('plaid-oauth-resume-text');
     if (!modalEl || !statusArea) return;
+
+    // sessionStorage key for the in-flight Plaid Link token. Scoped to
+    // PyCashFlow + Plaid so it cannot collide with other apps. We use
+    // sessionStorage (not localStorage) so the token is bound to the tab
+    // session and cleared when the tab closes.
+    var LINK_TOKEN_STORAGE_KEY = 'pycashflow_plaid_link_token';
+
+    function storeLinkToken(token) {
+        try { sessionStorage.setItem(LINK_TOKEN_STORAGE_KEY, token); } catch (e) {}
+    }
+    function readLinkToken() {
+        try { return sessionStorage.getItem(LINK_TOKEN_STORAGE_KEY); } catch (e) { return null; }
+    }
+    function clearLinkToken() {
+        try { sessionStorage.removeItem(LINK_TOKEN_STORAGE_KEY); } catch (e) {}
+    }
 
     function setError(msg) {
         if (!errorArea) return;
         if (!msg) { errorArea.style.display = 'none'; errorArea.textContent = ''; return; }
         errorArea.textContent = msg;
         errorArea.style.display = 'block';
+    }
+
+    function setOAuthResume(msg) {
+        if (!oauthResumeArea) return;
+        if (!msg) { oauthResumeArea.style.display = 'none'; return; }
+        if (oauthResumeText) oauthResumeText.textContent = msg;
+        oauthResumeArea.style.display = 'block';
     }
 
     function escapeHtml(text) {
@@ -855,6 +886,40 @@
                 return { ok: resp.ok, status: resp.status, body: body };
             });
         });
+    }
+
+    function hasOAuthReturnParam() {
+        // Plaid's OAuth redirect appends ``oauth_state_id`` to the redirect URI.
+        // It may live in the query string or, less commonly, the hash fragment.
+        try {
+            var params = new URLSearchParams(window.location.search || '');
+            if (params.get('oauth_state_id')) return true;
+            var hash = (window.location.hash || '').replace(/^#/, '');
+            if (hash) {
+                var hashParams = new URLSearchParams(hash);
+                if (hashParams.get('oauth_state_id')) return true;
+            }
+        } catch (e) {}
+        // The settings card uses ``plaid_oauth_return=1`` as a stable hint.
+        try {
+            var p2 = new URLSearchParams(window.location.search || '');
+            if (p2.get('plaid_oauth_return')) return true;
+        } catch (e) {}
+        return false;
+    }
+
+    function cleanupOAuthUrl() {
+        // Remove Plaid OAuth tracking params from the visible URL so a reload
+        // does not re-trigger resume. Uses replaceState so back-button history
+        // stays untouched.
+        if (!window.history || !window.history.replaceState) return;
+        try {
+            var url = new URL(window.location.href);
+            url.searchParams.delete('oauth_state_id');
+            url.searchParams.delete('plaid_oauth_return');
+            var cleaned = url.pathname + (url.search ? url.search : '') + (url.hash || '');
+            window.history.replaceState({}, document.title, cleaned);
+        } catch (e) {}
     }
 
     function renderNotConfigured() {
@@ -920,6 +985,45 @@
         });
     }
 
+    function exchangePublicToken(public_token, metadata) {
+        return fetchJSON('/api/v1/plaid/exchange-token', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ public_token: public_token, metadata: metadata }),
+        }).then(function(r) {
+            // Always drop the stored token after a completed Link flow so
+            // we never accidentally reuse it for a different attempt.
+            clearLinkToken();
+            if (!r.ok) {
+                setError((r.body && r.body.error) || 'Could not save Plaid connection.');
+            }
+            setOAuthResume('');
+            loadStatus();
+        });
+    }
+
+    function buildHandlerConfig(linkToken, receivedRedirectUri) {
+        var cfg = {
+            token: linkToken,
+            onSuccess: function(public_token, metadata) {
+                exchangePublicToken(public_token, metadata);
+            },
+            onExit: function(err) {
+                setOAuthResume('');
+                if (err) {
+                    setError('Plaid Link did not complete. Please try again.');
+                }
+                // If the user exited mid-OAuth, the stored link_token is no
+                // longer usable for resume; clear it so the next attempt
+                // starts fresh.
+                if (receivedRedirectUri) clearLinkToken();
+            },
+            onEvent: function() { /* no-op; never log Plaid event payloads */ }
+        };
+        if (receivedRedirectUri) cfg.receivedRedirectUri = receivedRedirectUri;
+        return cfg;
+    }
+
     function startLink() {
         setError('');
         if (typeof Plaid === 'undefined' || !Plaid.create) {
@@ -931,26 +1035,35 @@
                 setError((resp.body && resp.body.error) || 'Could not start Plaid Link.');
                 return;
             }
-            var handler = Plaid.create({
-                token: resp.body.data.link_token,
-                onSuccess: function(public_token, metadata) {
-                    fetchJSON('/api/v1/plaid/exchange-token', {
-                        method: 'POST',
-                        headers: { 'Content-Type': 'application/json' },
-                        body: JSON.stringify({ public_token: public_token, metadata: metadata }),
-                    }).then(function(r) {
-                        if (!r.ok) {
-                            setError((r.body && r.body.error) || 'Could not save Plaid connection.');
-                        }
-                        loadStatus();
-                    });
-                },
-                onExit: function(err) {
-                    if (err) setError('Plaid Link exited with an error.');
-                }
-            });
+            var linkToken = resp.body.data.link_token;
+            storeLinkToken(linkToken);
+            var handler = Plaid.create(buildHandlerConfig(linkToken, null));
             handler.open();
         });
+    }
+
+    function resumeOAuth() {
+        // Called on page load when Plaid has redirected the user back from
+        // an OAuth institution. We must re-create Plaid Link with the
+        // ORIGINAL link_token and the full return URL as receivedRedirectUri.
+        var linkToken = readLinkToken();
+        if (!linkToken) {
+            setError('Your Plaid session expired. Please start the connection again.');
+            cleanupOAuthUrl();
+            return;
+        }
+        if (typeof Plaid === 'undefined' || !Plaid.create) {
+            setError('Plaid Link script failed to load.');
+            return;
+        }
+        setOAuthResume('Completing Plaid connection…');
+        var handler = Plaid.create(
+            buildHandlerConfig(linkToken, window.location.href)
+        );
+        handler.open();
+        // The bank-supplied params have served their purpose; clean them up
+        // now that Plaid Link has the URL it needed.
+        cleanupOAuthUrl();
     }
 
     function removeConnection() {
@@ -965,6 +1078,33 @@
     }
 
     modalEl.addEventListener('show.bs.modal', loadStatus);
+
+    // If we just returned from an OAuth institution, automatically open
+    // the Plaid settings modal and resume Plaid Link. The user should not
+    // have to click Connect again.
+    if (hasOAuthReturnParam()) {
+        var openAndResume = function() {
+            try {
+                if (window.bootstrap && window.bootstrap.Modal) {
+                    var inst = window.bootstrap.Modal.getOrCreateInstance(modalEl);
+                    modalEl.addEventListener('shown.bs.modal', resumeOAuth, { once: true });
+                    inst.show();
+                    return;
+                }
+            } catch (e) {}
+            // Fallback: at least scroll the user back to the Plaid card.
+            try {
+                var card = document.querySelector('[data-bs-target="#plaidmodal"]');
+                if (card && card.scrollIntoView) card.scrollIntoView({ behavior: 'smooth' });
+            } catch (e) {}
+            resumeOAuth();
+        };
+        if (document.readyState === 'complete' || document.readyState === 'interactive') {
+            openAndResume();
+        } else {
+            document.addEventListener('DOMContentLoaded', openAndResume, { once: true });
+        }
+    }
 })();
 </script>
 {% endif %}

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -164,6 +164,182 @@ class TestSettingsPlaidStatus:
         assert body["code"] == "plaid_not_configured"
 
 
+# ── Link token creation request shape ──────────────────────────────────────
+
+
+class TestLinkTokenRequest:
+    """Verify the LinkTokenCreateRequest passed to the Plaid SDK."""
+
+    def _captured_request(self, mock_client):
+        # ``link_token_create`` is called with a single positional arg —
+        # the LinkTokenCreateRequest model. We need its dict form to assert
+        # against, since redirect_uri is set via **kwargs into the model.
+        assert mock_client.return_value.link_token_create.called
+        args, _ = mock_client.return_value.link_token_create.call_args
+        req = args[0]
+        # Plaid SDK request models behave like dicts.
+        try:
+            return req.to_dict()
+        except Exception:
+            return dict(req)
+
+    def test_includes_redirect_uri_when_configured(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(
+                flask_app,
+                PLAID_REDIRECT_URI="https://app.example.com/settings?plaid_oauth_return=1",
+            )
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.link_token_create.return_value = (
+                    SimpleNamespace(link_token="link-sandbox-xyz")
+                )
+                token = plaid_service.create_link_token_for_user(user)
+            assert token == "link-sandbox-xyz"
+            req = self._captured_request(mock_client)
+            assert req.get("redirect_uri") == (
+                "https://app.example.com/settings?plaid_oauth_return=1"
+            )
+            _deconfigure_plaid(flask_app)
+
+    def test_omits_redirect_uri_when_not_configured(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app, PLAID_REDIRECT_URI="")
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.link_token_create.return_value = (
+                    SimpleNamespace(link_token="link-sandbox-no-oauth")
+                )
+                plaid_service.create_link_token_for_user(user)
+            req = self._captured_request(mock_client)
+            # Either missing entirely, or explicitly empty/None — never a
+            # stray value that would force OAuth on a non-OAuth user.
+            assert not req.get("redirect_uri")
+            _deconfigure_plaid(flask_app)
+
+    def test_balance_product_filtered_from_link_token_request(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app, PLAID_PRODUCTS="auth,balance,transactions")
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.link_token_create.return_value = (
+                    SimpleNamespace(link_token="link-x")
+                )
+                plaid_service.create_link_token_for_user(user)
+            req = self._captured_request(mock_client)
+            products = req.get("products") or []
+            product_values = [
+                getattr(p, "value", None) or str(p) for p in products
+            ]
+            assert "balance" not in product_values
+            assert "auth" in product_values
+
+    def test_link_token_endpoint_returns_only_link_token(
+        self, auth_client, flask_app
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        with patch.object(plaid_service, "_plaid_client") as mock_client:
+            mock_client.return_value.link_token_create.return_value = (
+                SimpleNamespace(link_token="link-resp")
+            )
+            resp = auth_client.post("/api/v1/plaid/link-token")
+        assert resp.status_code == 200
+        data = resp.get_json()["data"]
+        assert data == {"link_token": "link-resp"}
+        # No access_token / secret keys must leak into the JSON payload.
+        for forbidden in ("access_token", "encrypted_access_token", "secret"):
+            assert forbidden not in data
+
+
+# ── Exchange-token auth surface ────────────────────────────────────────────
+
+
+class TestExchangeTokenAuthSurface:
+    def test_exchange_requires_login(self, client):
+        resp = client.post(
+            "/api/v1/plaid/exchange-token",
+            json={"public_token": "x", "metadata": {}},
+        )
+        # Unauthenticated callers must not reach the handler.
+        assert resp.status_code in (401, 403)
+
+    def test_exchange_does_not_accept_user_id_from_client(
+        self, auth_client, flask_app, plaid_user
+    ):
+        # Even if a malicious client passes a user_id, the endpoint must
+        # ignore it and act on the authenticated session user only.
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        with patch.object(plaid_service, "_plaid_client") as mock_client:
+            mock_client.return_value.item_public_token_exchange.return_value = (
+                SimpleNamespace(item_id="item-1", access_token="access-leak-test")
+            )
+            resp = auth_client.post(
+                "/api/v1/plaid/exchange-token",
+                json={
+                    "public_token": "ptok",
+                    "user_id": plaid_user,  # must be ignored
+                    "metadata": {
+                        "institution": {"institution_id": "i", "name": "n"},
+                        "accounts": [
+                            {
+                                "id": "acct-leak",
+                                "type": "depository",
+                                "subtype": "checking",
+                            }
+                        ],
+                    },
+                },
+            )
+        # Response should be a normal status payload — never echo a token.
+        body = resp.get_json() or {}
+        flat = repr(body)
+        assert "access-leak-test" not in flat
+        assert "access_token" not in flat
+        assert "encrypted_access_token" not in flat
+
+
+# ── Settings page renders OAuth-aware Plaid JS ─────────────────────────────
+
+
+class TestSettingsPageOAuthMarkup:
+    """The settings template must include the OAuth resume logic for Plaid."""
+
+    def _settings_html(self, auth_client):
+        resp = auth_client.get("/settings")
+        assert resp.status_code == 200
+        return resp.get_data(as_text=True)
+
+    def test_renders_session_storage_link_token_logic(self, auth_client):
+        html = self._settings_html(auth_client)
+        assert "pycashflow_plaid_link_token" in html
+        assert "sessionStorage" in html
+        # Never use localStorage for the link token.
+        assert "localStorage.setItem('pycashflow_plaid_link_token'" not in html
+
+    def test_renders_oauth_state_id_detection(self, auth_client):
+        html = self._settings_html(auth_client)
+        assert "oauth_state_id" in html
+
+    def test_renders_received_redirect_uri_for_oauth_resume(self, auth_client):
+        html = self._settings_html(auth_client)
+        assert "receivedRedirectUri" in html
+        assert "window.location.href" in html
+
+    def test_plaid_script_does_not_log_tokens(self, auth_client):
+        html = self._settings_html(auth_client)
+        # Defensive: no console.log of public_token / access_token anywhere.
+        for forbidden in (
+            "console.log(public_token",
+            "console.log(access_token",
+            "console.log(metadata",
+        ):
+            assert forbidden not in html
+
+
 # ── Exchange token ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Implements full OAuth redirect support for Plaid institutions (Chase, etc.) that require browser-based authentication. When a user is redirected back from their bank, the settings page automatically reopens the Plaid modal and resumes the Link flow without requiring the user to click Connect again.

## Key Changes

- **OAuth Resume Logic**: Added `resumeOAuth()` function that detects when Plaid has redirected the user back from an OAuth institution (via `oauth_state_id` parameter) and automatically reopens the modal to complete the flow.

- **Link Token Persistence**: Implemented `sessionStorage`-based persistence of the `link_token` across the OAuth redirect. The token is stored when Link is first opened and retrieved on resume, allowing Plaid Link to be re-initialized with the original token and the return URL as `receivedRedirectUri`.

- **URL Cleanup**: Added `cleanupOAuthUrl()` to remove OAuth tracking parameters (`oauth_state_id`, `plaid_oauth_return`) from the visible URL after resume, preventing accidental re-triggers on page reload.

- **Handler Configuration**: Refactored Plaid Link handler creation into `buildHandlerConfig()` to support both initial flow and OAuth resume scenarios, with proper cleanup of stored tokens on success or exit.

- **Token Exchange**: Extracted `exchangePublicToken()` to handle the public token exchange with proper error handling and cleanup.

- **Auto-Modal Opening**: On page load, if OAuth return parameters are detected, the code automatically opens the Plaid settings modal and calls `resumeOAuth()`, providing a seamless user experience.

- **Comprehensive Tests**: Added test coverage for:
  - Link token request shape (redirect_uri inclusion/omission)
  - Balance product filtering from link token requests
  - Exchange token endpoint authentication and authorization
  - Settings page OAuth markup validation (sessionStorage, oauth_state_id detection, receivedRedirectUri)

- **Documentation**: Updated README and `.env_example` with detailed OAuth setup instructions, including the requirement to add the redirect URI to the Plaid Dashboard and a manual verification checklist.

## Implementation Details

- Uses `sessionStorage` (not `localStorage`) to scope the link token to the current tab session, ensuring it's cleared when the tab closes.
- Gracefully handles missing Plaid SDK or sessionStorage unavailability with try-catch blocks.
- Supports both query string and hash fragment OAuth parameters for maximum compatibility.
- Includes defensive checks to prevent token leakage in API responses and console logs.
- iOS Plaid setup is intentionally not supported in this phase; users must connect from the web settings page.

https://claude.ai/code/session_01PQsK4nzhkDyuxNf6xhhtRx