### PR TITLE
Clean oauth_state_id from URL hash fragment

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -917,6 +917,17 @@
             var url = new URL(window.location.href);
             url.searchParams.delete('oauth_state_id');
             url.searchParams.delete('plaid_oauth_return');
+            var hash = (url.hash || '').replace(/^#/, '');
+            if (hash) {
+                try {
+                    var hashParams = new URLSearchParams(hash);
+                    if (hashParams.has('oauth_state_id')) {
+                        hashParams.delete('oauth_state_id');
+                        var remaining = hashParams.toString();
+                        url.hash = remaining ? '#' + remaining : '';
+                    }
+                } catch (e) {}
+            }
             var cleaned = url.pathname + (url.search ? url.search : '') + (url.hash || '');
             window.history.replaceState({}, document.title, cleaned);
         } catch (e) {}


### PR DESCRIPTION
## Summary
Extended the URL cleanup logic in the settings page to also remove `oauth_state_id` parameters from the URL hash fragment, not just from query parameters.

## Key Changes
- Added parsing and cleanup of the URL hash fragment to remove `oauth_state_id` parameters
- Implemented safe hash parameter parsing with error handling to gracefully handle malformed hash fragments
- Preserves any remaining hash parameters after removing `oauth_state_id`

## Implementation Details
- Extracts the hash fragment and removes the leading `#` character for parsing
- Uses `URLSearchParams` to parse hash parameters, matching the existing query parameter cleanup approach
- Includes try-catch error handling to prevent issues if hash parsing fails
- Reconstructs the hash with remaining parameters, only adding the `#` prefix if parameters remain
- Maintains backward compatibility with the existing query parameter cleanup logic

https://claude.ai/code/session_019Af4gb8BkRjfLXdiPYa2Ct