### PR TITLE
Add /healthz endpoint and point Docker HEALTHCHECK at it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN mkdir -p /app/app/data && \
 ENV PYTHONPATH=/app
 ENV DATABASE_URL=sqlite:////app/app/data/db.sqlite
 
-HEALTHCHECK CMD python -c "import sys, urllib.request; sys.exit(0) if urllib.request.urlopen('http://localhost:5000', timeout=5).getcode() < 400 else sys.exit(1)"
+HEALTHCHECK CMD python -c "import sys, urllib.request; sys.exit(0) if urllib.request.urlopen('http://localhost:5000/healthz', timeout=5).getcode() < 400 else sys.exit(1)"
 
 EXPOSE 5000
 

--- a/app/main.py
+++ b/app/main.py
@@ -569,6 +569,15 @@ def apple_app_site_association():
     )
 
 
+@main.route('/healthz', methods=['GET'])
+@limiter.exempt
+def healthz():
+    # Liveness probe for the Docker HEALTHCHECK. Must stay auth-free,
+    # redirect-free, and side-effect-free so it doesn't pollute access logs
+    # or trigger the dashboard Plaid balance refresh.
+    return Response('ok', status=200, mimetype='text/plain')
+
+
 @main.route('/balance', methods=('GET', 'POST'))
 @login_required
 @admin_required

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -63,6 +63,11 @@ class TestUnauthenticatedAccess:
             }
         }
 
+    def test_healthz_is_public_and_does_not_redirect(self, client):
+        resp = client.get("/healthz", follow_redirects=False)
+        assert resp.status_code == 200
+        assert resp.data == b"ok"
+
 
 # ── Tests: authenticated GET routes ──────────────────────────────────────────
 


### PR DESCRIPTION
The Dockerfile HEALTHCHECK previously hit / every 30s. Because
urllib.request.urlopen follows redirects by default and / requires auth,
each check produced two access-log lines (GET / -> 302, GET /login ->
200), which made the access log look like the new Plaid integration was
generating runaway requests. Plaid never hits these paths; the noise was
the healthcheck.

Add a tiny public /healthz route that returns 200 "ok" with no auth, no
redirect, and no side effects (notably, no Plaid balance refresh), and
update the HEALTHCHECK to hit it. This collapses healthcheck noise to a
single access-log line per probe.