### PR TITLE
Strip query and fragment from PLAID_REDIRECT_URI before /link/token/create

### DIFF
--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 from datetime import date, datetime, timezone
 from typing import Optional
+from urllib.parse import urlsplit, urlunsplit
 
 from flask import current_app, g
 from sqlalchemy import desc
@@ -233,7 +234,14 @@ def create_link_token_for_user(user) -> str:
     )
     redirect_uri = _config("PLAID_REDIRECT_URI")
     if redirect_uri:
-        request_kwargs["redirect_uri"] = redirect_uri
+        # Plaid rejects redirect_uri values that include a query string or
+        # fragment ("redirect_uri cannot include query"). The dashboard-
+        # registered URI is the bare path; OAuth-return params are appended
+        # by Plaid on the way back, not configured here.
+        parts = urlsplit(redirect_uri)
+        request_kwargs["redirect_uri"] = urlunsplit(
+            (parts.scheme, parts.netloc, parts.path, "", "")
+        )
 
     try:
         client = _plaid_client()

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -197,9 +197,9 @@ class TestLinkTokenRequest:
                 token = plaid_service.create_link_token_for_user(user)
             assert token == "link-sandbox-xyz"
             req = self._captured_request(mock_client)
-            assert req.get("redirect_uri") == (
-                "https://app.example.com/settings?plaid_oauth_return=1"
-            )
+            # Plaid rejects redirect_uri values containing a query string, so
+            # the service must strip it before calling /link/token/create.
+            assert req.get("redirect_uri") == "https://app.example.com/settings"
             _deconfigure_plaid(flask_app)
 
     def test_omits_redirect_uri_when_not_configured(self, flask_app, plaid_user):


### PR DESCRIPTION
Plaid rejects redirect_uri values containing a query string with
"redirect_uri cannot include query". Deployments that put OAuth-return
hints (e.g. ?plaid_oauth_return=1) in PLAID_REDIRECT_URI hit this on
every link-token request. Strip the query and fragment in the service
layer so the value sent to Plaid always matches the bare URI registered
in the dashboard; OAuth-return params are appended by Plaid on the way
back and parsed by the settings page already.