### PR TITLE
Add Remove Email Settings button to balance update modal

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -764,6 +764,23 @@ def email():
     return redirect(url_for('main.settings'))
 
 
+@main.route('/email/delete', methods=['POST'])
+@login_required
+@admin_required
+def email_delete():
+    # remove the user's email balance update settings
+    user_id = get_effective_user_id()
+    deleted = Email.query.filter_by(user_id=user_id).delete()
+    db.session.commit()
+
+    if deleted:
+        flash('Email balance update settings removed')
+    else:
+        flash('No email balance update settings to remove')
+
+    return redirect(url_for('main.settings'))
+
+
 @main.route('/update_user', methods=['GET', 'POST'])
 @login_required
 @admin_required

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -516,6 +516,17 @@
                         </button>
                     </div>
                 </form>
+                {% if email_config %}
+                <form action="{{url_for('main.email_delete')}}" method="POST"
+                      onsubmit="return confirm('Remove your saved email balance update settings? This cannot be undone.');"
+                      style="margin-top: 0.75rem;">
+                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                    <button class="btn-danger-modern btn-modern" type="submit" style="width: 100%;">
+                        <i class="fa-solid fa-trash"></i>
+                        Remove Email Settings
+                    </button>
+                </form>
+                {% endif %}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Lets admins clear their saved email balance update configuration directly
from the settings page. The button only appears when settings exist and
prompts for confirmation before deleting.