### PR TITLE
Fix Plaid OAuth resume to reuse original link token

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1009,14 +1009,43 @@
         });
     }
 
+    var PLAID_OAUTH_LINK_TOKEN_KEY = 'plaid.oauth.link_token';
+
+    function storeOAuthLinkToken(linkToken) {
+        try {
+            if (window.sessionStorage && linkToken) {
+                window.sessionStorage.setItem(PLAID_OAUTH_LINK_TOKEN_KEY, linkToken);
+            }
+        } catch (e) {}
+    }
+
+    function loadOAuthLinkToken() {
+        try {
+            if (window.sessionStorage) {
+                return window.sessionStorage.getItem(PLAID_OAUTH_LINK_TOKEN_KEY) || '';
+            }
+        } catch (e) {}
+        return '';
+    }
+
+    function clearOAuthLinkToken() {
+        try {
+            if (window.sessionStorage) {
+                window.sessionStorage.removeItem(PLAID_OAUTH_LINK_TOKEN_KEY);
+            }
+        } catch (e) {}
+    }
+
     function buildHandlerConfig(linkToken, receivedRedirectUri) {
         var cfg = {
             token: linkToken,
             onSuccess: function(public_token, metadata) {
+                clearOAuthLinkToken();
                 exchangePublicToken(public_token, metadata);
             },
             onExit: function(err) {
                 setOAuthResume('');
+                clearOAuthLinkToken();
                 if (err) {
                     setError('Plaid Link did not complete. Please try again.');
                 }
@@ -1039,6 +1068,7 @@
                 return;
             }
             var linkToken = resp.body.data.link_token;
+            storeOAuthLinkToken(linkToken);
             var handler = Plaid.create(buildHandlerConfig(linkToken, null));
             handler.open();
         });
@@ -1050,22 +1080,20 @@
             return;
         }
         setOAuthResume('Completing Plaid connection…');
-        fetchJSON('/api/v1/plaid/link-token', { method: 'POST' }).then(function(resp) {
-            if (!resp.ok || !resp.body || !resp.body.data || !resp.body.data.link_token) {
-                setOAuthResume('');
-                setError((resp.body && resp.body.error) || 'Your Plaid session expired. Please start the connection again.');
-                cleanupOAuthUrl();
-                return;
-            }
-            var linkToken = resp.body.data.link_token;
-            var handler = Plaid.create(
-                buildHandlerConfig(linkToken, window.location.href)
-            );
-            handler.open();
-            // The bank-supplied params have served their purpose; clean them up
-            // now that Plaid Link has the URL it needed.
+        var linkToken = loadOAuthLinkToken();
+        if (!linkToken) {
+            setOAuthResume('');
+            setError('Your Plaid session expired. Please start the connection again.');
             cleanupOAuthUrl();
-        });
+            return;
+        }
+        var handler = Plaid.create(
+            buildHandlerConfig(linkToken, window.location.href)
+        );
+        handler.open();
+        // The bank-supplied params have served their purpose; clean them up
+        // now that Plaid Link has the URL it needed.
+        cleanupOAuthUrl();
     }
 
     function removeConnection() {

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -313,11 +313,12 @@ class TestSettingsPageOAuthMarkup:
         assert resp.status_code == 200
         return resp.get_data(as_text=True)
 
-    def test_does_not_persist_link_token_in_browser_storage(self, auth_client):
+    def test_uses_session_storage_for_oauth_link_token_resume(self, auth_client):
         html = self._settings_html(auth_client)
-        # Link token should not be persisted in browser storage.
-        assert "sessionStorage" not in html
-        assert "localStorage" not in html
+        # OAuth resume must reuse the original link token from the first launch.
+        assert "sessionStorage" in html
+        assert "plaid.oauth.link_token" in html
+        assert "loadOAuthLinkToken" in html
 
     def test_renders_oauth_state_id_detection(self, auth_client):
         html = self._settings_html(auth_client)


### PR DESCRIPTION
### Motivation

- Plaid OAuth resume must reuse the same `link_token` that started the original Link flow so the redirect `oauth_state_id` can be validated; requesting a new token on return can break resume for OAuth institutions. 

### Description

- Store the initial Plaid `link_token` in `sessionStorage` under `plaid.oauth.link_token` when `startLink()` launches Link via `fetchJSON('/api/v1/plaid/link-token')` by adding `storeOAuthLinkToken`/`loadOAuthLinkToken`/`clearOAuthLinkToken` helpers in `app/templates/settings.html`.
- Change the OAuth resume path in `resumeOAuth()` to `loadOAuthLinkToken()` and fail fast with an explanatory message if the stored token is missing instead of requesting a fresh `/api/v1/plaid/link-token`.
- Clear the stored token on Link success and on Link exit by calling `clearOAuthLinkToken()` from the `onSuccess` and `onExit` handlers in `buildHandlerConfig()` to avoid stale-token reuse.
- Update the settings-page markup test in `tests/test_plaid_integration.py` to assert presence of the sessionStorage-based helpers and key (`sessionStorage`, `plaid.oauth.link_token`, `loadOAuthLinkToken`).

### Testing

- Ran the Plaid integration tests with `python -m pytest -q tests/test_plaid_integration.py`, which completed successfully: `43 passed` (with expected deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a83ae25bc8320a3d4ae3b50220dcc)