### PR TITLE
Add localStorage fallback for Plaid OAuth link-token resume

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1017,12 +1017,25 @@
                 window.sessionStorage.setItem(PLAID_OAUTH_LINK_TOKEN_KEY, linkToken);
             }
         } catch (e) {}
+        // OAuth institutions can bounce back in a different tab/webview where
+        // sessionStorage is empty; keep a same-origin fallback for resume.
+        try {
+            if (window.localStorage && linkToken) {
+                window.localStorage.setItem(PLAID_OAUTH_LINK_TOKEN_KEY, linkToken);
+            }
+        } catch (e) {}
     }
 
     function loadOAuthLinkToken() {
         try {
             if (window.sessionStorage) {
-                return window.sessionStorage.getItem(PLAID_OAUTH_LINK_TOKEN_KEY) || '';
+                var sessionToken = window.sessionStorage.getItem(PLAID_OAUTH_LINK_TOKEN_KEY) || '';
+                if (sessionToken) return sessionToken;
+            }
+        } catch (e) {}
+        try {
+            if (window.localStorage) {
+                return window.localStorage.getItem(PLAID_OAUTH_LINK_TOKEN_KEY) || '';
             }
         } catch (e) {}
         return '';
@@ -1032,6 +1045,11 @@
         try {
             if (window.sessionStorage) {
                 window.sessionStorage.removeItem(PLAID_OAUTH_LINK_TOKEN_KEY);
+            }
+        } catch (e) {}
+        try {
+            if (window.localStorage) {
+                window.localStorage.removeItem(PLAID_OAUTH_LINK_TOKEN_KEY);
             }
         } catch (e) {}
     }


### PR DESCRIPTION
### Motivation
- Plaid OAuth may return to a different top-level browsing context (tab/webview) where `sessionStorage` is empty, causing the resume flow to hard-fail with a misleading "session expired" message.
- The settings page previously persisted the link token only to `sessionStorage`, which regressed resume behavior for cross-tab OAuth returns.

### Description
- Update `app/templates/settings.html` to write the Link token to `localStorage` in addition to the existing `sessionStorage` in `storeOAuthLinkToken` so a same-origin fallback is available.
- Update `loadOAuthLinkToken` to prefer `sessionStorage` and fall back to `localStorage` when a session token is not found.
- Update `clearOAuthLinkToken` to remove the token from both `sessionStorage` and `localStorage` after success or exit to avoid stale tokens.

### Testing
- Ran the full test suite with `python -m pytest -q` and all automated tests passed (367 passed).
- No Plaid-specific unit/regression tests were added because the change is a browser-side persistence fallback, and existing integration tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a85d6bf08832081d9b9fc047e452a)