### PR TITLE
Scope Plaid OAuth resume token by authenticated user

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1009,7 +1009,10 @@
         });
     }
 
-    var PLAID_OAUTH_LINK_TOKEN_KEY = 'plaid.oauth.link_token';
+    var PLAID_OAUTH_LINK_TOKEN_KEY_PREFIX = 'plaid.oauth.link_token';
+    var PLAID_OAUTH_LINK_TOKEN_LEGACY_KEY = PLAID_OAUTH_LINK_TOKEN_KEY_PREFIX;
+    var PLAID_OAUTH_LINK_TOKEN_KEY =
+        PLAID_OAUTH_LINK_TOKEN_KEY_PREFIX + '.u{{ current_user.id }}';
 
     function storeOAuthLinkToken(linkToken) {
         try {
@@ -1022,6 +1025,8 @@
         try {
             if (window.localStorage && linkToken) {
                 window.localStorage.setItem(PLAID_OAUTH_LINK_TOKEN_KEY, linkToken);
+                // Remove unscoped legacy token to prevent cross-account reuse.
+                window.localStorage.removeItem(PLAID_OAUTH_LINK_TOKEN_LEGACY_KEY);
             }
         } catch (e) {}
     }
@@ -1050,6 +1055,7 @@
         try {
             if (window.localStorage) {
                 window.localStorage.removeItem(PLAID_OAUTH_LINK_TOKEN_KEY);
+                window.localStorage.removeItem(PLAID_OAUTH_LINK_TOKEN_LEGACY_KEY);
             }
         } catch (e) {}
     }


### PR DESCRIPTION
### Motivation
- Prevent cross-account resume of Plaid OAuth by ensuring the stored `link_token` cannot be reused across different authenticated users on the same browser profile.

### Description
- Change the client-side Plaid resume token key to be user-scoped (`plaid.oauth.link_token.u{{ current_user.id }}`), preserve the `sessionStorage`/`localStorage` fallback, and remove the legacy unscoped key during store/clear in `app/templates/settings.html`.

### Testing
- Ran `python -m pytest -q tests/test_plaid_integration.py`, which completed successfully with `43 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a882da6788320b694500b1af17f15)