### PR TITLE
Fix boolean default value in Plaid balance migration

### DIFF
--- a/migrations/versions/4553e3440cb6_add_plaid_balance_connection.py
+++ b/migrations/versions/4553e3440cb6_add_plaid_balance_connection.py
@@ -31,7 +31,7 @@ def upgrade():
     sa.Column('account_type', sa.String(length=50), nullable=True),
     sa.Column('account_subtype', sa.String(length=50), nullable=True),
     sa.Column('iso_currency_code', sa.String(length=10), nullable=True),
-    sa.Column('is_active', sa.Boolean(), server_default=sa.text('1'), nullable=False),
+    sa.Column('is_active', sa.Boolean(), server_default=sa.true(), nullable=False),
     sa.Column('last_balance_sync_at', sa.DateTime(), nullable=True),
     sa.Column('last_sync_status', sa.String(length=64), nullable=True),
     sa.Column('last_sync_error', sa.String(length=255), nullable=True),


### PR DESCRIPTION
## Summary
Updated the database migration for the Plaid balance connection table to use SQLAlchemy's proper boolean default value syntax instead of a raw SQL text value.

## Key Changes
- Changed `is_active` column default from `sa.text('1')` to `sa.true()` in the migration file
- This ensures the boolean default is properly handled by SQLAlchemy across different database backends

## Implementation Details
The previous approach of using `sa.text('1')` as a server default for a Boolean column could cause compatibility issues across different database systems. SQLAlchemy's `sa.true()` function provides the correct abstraction that translates to the appropriate boolean literal for the target database (e.g., `TRUE` for PostgreSQL, `1` for SQLite, etc.).

https://claude.ai/code/session_0111dUy5yE6N54gimqs5ZusR