### PR TITLE
Fix Plaid OAuth redirect flow to preserve state through login

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,18 +483,27 @@ PLAID_REDIRECT_URI=          # required for OAuth institutions (Chase, etc.)
 
 Some institutions (e.g. Chase) require Plaid's OAuth redirect flow. For these:
 
-- `PLAID_REDIRECT_URI` must be set to a fully-qualified URL pointing back to
-  the PyCashFlow web settings page, for example:
-  `https://app.example.com/settings?plaid_oauth_return=1`
-- The **exact same URI** must also be added to the allowed redirect URIs in
-  your [Plaid Dashboard](https://dashboard.plaid.com). A mismatch (or a
-  missing entry) will cause OAuth institutions to fail to complete the Link
-  flow.
+- `PLAID_REDIRECT_URI` must be set to a fully-qualified HTTPS URL pointing
+  back to the PyCashFlow web settings page. Any of these forms work:
+  - `https://app.example.com/settings`
+  - `https://app.example.com/settings?plaid_oauth_return=1`
+
+  Any query string and fragment are stripped before the URL is sent to
+  Plaid's `/link/token/create` (Plaid's redirect_uri field does not accept
+  query parameters), so the value that actually reaches Plaid is always the
+  bare path, e.g. `https://app.example.com/settings`.
+- In the [Plaid Dashboard](https://dashboard.plaid.com), allowlist that
+  **bare** URL (without any query string). It must be an exact match,
+  otherwise Plaid will refuse to redirect OAuth users back.
+- On the way back, Plaid appends `oauth_state_id=...` to the URL. The
+  settings page must preserve that query parameter long enough for Plaid
+  Link to resume — see the next bullet.
 - After the bank redirect, the settings page detects the `oauth_state_id`
   query parameter, reopens the Plaid modal automatically, and resumes Plaid
-  Link using the original `link_token` (kept in `sessionStorage`) and the
-  return URL as `receivedRedirectUri`. The user does not need to click
-  Connect again.
+  Link using the original `link_token` (kept in `sessionStorage`/
+  `localStorage`) and `window.location.href` as `receivedRedirectUri`. The
+  user does not need to click Connect again. The URL is cleaned only after
+  the public-token exchange completes (or Plaid Link is exited).
 - iOS Plaid setup is intentionally **not** supported in this phase. Users
   must connect Plaid from the web settings page.
 
@@ -538,18 +547,26 @@ After deploying changes, verify the Plaid flow end-to-end:
 
 - [ ] Set `PLAID_CLIENT_ID`, `PLAID_SECRET`, `PLAID_ENV`, `PLAID_PRODUCTS`,
   `PLAID_COUNTRY_CODES`, and (for OAuth) `PLAID_REDIRECT_URI`.
-- [ ] Add the exact `PLAID_REDIRECT_URI` value to the Plaid Dashboard
-  allowed redirect URIs.
+- [ ] Add the **bare** `PLAID_REDIRECT_URI` value (path only, no query
+  string) to the Plaid Dashboard allowed redirect URIs.
 - [ ] Open the web Settings page → **Plaid Balance Sync** card → **Connect
   Plaid Account**.
 - [ ] Test a non-OAuth sandbox institution (e.g. "First Platypus Bank")
   and confirm the connection completes inline.
 - [ ] Test an OAuth sandbox institution (e.g. Plaid's "OAuth Bank") and
   confirm the browser is redirected to Plaid, then back to PyCashFlow.
-- [ ] Confirm the user lands on the Settings page and the Plaid modal
-  re-opens automatically with "Completing Plaid connection…".
-- [ ] Confirm `public_token` is exchanged and the connected account row
-  appears in the Plaid card.
+- [ ] Confirm the browser lands on `/settings?...&oauth_state_id=...`
+  (the `oauth_state_id` query parameter must still be present in the URL
+  bar when the page renders).
+- [ ] Confirm the Plaid modal re-opens automatically with
+  "Completing Plaid connection…".
+- [ ] Confirm Link resumes automatically (no second click on Connect).
+- [ ] Confirm `onSuccess` fires and the `public_token` is exchanged.
+- [ ] Confirm the connected account row appears in the Plaid card.
+- [ ] Confirm the URL is cleaned only **after** the connection completes
+  (no `oauth_state_id` left over once the card shows the new account).
+- [ ] Confirm no access tokens or public tokens appear in the browser
+  console or server logs.
 - [ ] Confirm no iOS changes are required — iOS Plaid Link is not
   supported in this phase.
 

--- a/app/.env_example
+++ b/app/.env_example
@@ -113,11 +113,15 @@ GETEMAIL_LOG_FILE=
 # PLAID_REDIRECT_URI is REQUIRED for OAuth institutions (e.g. Chase). It must
 # point back to the PyCashFlow web settings page so Plaid Link can resume
 # automatically after the bank redirect, for example:
+#   https://app.example.com/settings
 #   https://app.example.com/settings?plaid_oauth_return=1
-# The exact same URI must also be added to your Plaid Dashboard's allowed
-# redirect URIs. If unset or mismatched, OAuth institutions will fail to
-# complete the Link flow. iOS Plaid setup is intentionally not supported in
-# this phase — users must connect Plaid from the web settings page.
+# Any query string is stripped before the value is sent to Plaid's
+# /link/token/create (Plaid does not accept query parameters there), so the
+# bare path is what is actually registered. Add that bare URL — without any
+# query string — to your Plaid Dashboard's allowed redirect URIs. If unset
+# or mismatched, OAuth institutions will fail to complete the Link flow.
+# iOS Plaid setup is intentionally not supported in this phase — users must
+# connect Plaid from the web settings page.
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 PLAID_ENV=sandbox

--- a/app/auth.py
+++ b/app/auth.py
@@ -88,12 +88,34 @@ def _external_signup_url() -> str | None:
     return candidate
 
 
+def _safe_next_path(raw_next: str | None) -> str | None:
+    """Return ``raw_next`` if it is a safe relative path on this host.
+
+    Rejects absolute URLs, scheme/netloc redirects, and anything outside
+    a leading "/" path. The full path + query string is preserved so flows
+    like Plaid's OAuth return (``/settings?oauth_state_id=...``) survive a
+    detour through ``/login``.
+    """
+    if not raw_next:
+        return None
+    if not isinstance(raw_next, str):
+        return None
+    if not raw_next.startswith('/') or raw_next.startswith('//'):
+        return None
+    parsed = urlparse(raw_next)
+    if parsed.scheme or parsed.netloc:
+        return None
+    return raw_next
+
+
 @auth.route('/login')
 def login():
+    next_url = _safe_next_path(request.args.get('next'))
     return render_template(
         'login.html',
         passkey_enabled=_passkey_enabled(),
         external_signup_url=_external_signup_url(),
+        next_url=next_url,
     )
 
 
@@ -160,6 +182,14 @@ def login_post():
         flash('Your account is pending approval. Please contact an administrator.')
         return redirect(url_for('auth.login'))
 
+    # Preserve a safe ``next`` URL across the (optional) 2FA step so flows
+    # like the Plaid OAuth redirect can land back on ``/settings?...``.
+    next_url = _safe_next_path(request.form.get('next') or request.args.get('next'))
+    if next_url:
+        session['post_login_next'] = next_url
+    else:
+        session.pop('post_login_next', None)
+
     # If 2FA is enabled, redirect to TOTP verification step
     if user.twofa_enabled:
         session['twofa_pending_user_id'] = user.id
@@ -171,6 +201,9 @@ def login_post():
     session['name'] = user.name
     session['email'] = user.email
 
+    next_target = _safe_next_path(session.pop('post_login_next', None))
+    if next_target:
+        return redirect(next_target)
     return redirect(url_for('main.index'))
 
 
@@ -224,6 +257,9 @@ def login_2fa_post():
     session['name'] = user.name
     session['email'] = user.email
 
+    next_target = _safe_next_path(session.pop('post_login_next', None))
+    if next_target:
+        return redirect(next_target)
     return redirect(url_for('main.index'))
 
 

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -41,6 +41,9 @@
         <!-- Login Form -->
         <form method="POST" action="/login">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            {% if next_url %}
+            <input type="hidden" name="next" value="{{ next_url }}">
+            {% endif %}
             <div class="form-group-modern">
                 <label class="form-label-modern">
                     <i class="fa-solid fa-envelope"></i> Email Address

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1005,6 +1005,10 @@
                 setError((r.body && r.body.error) || 'Could not save Plaid connection.');
             }
             setOAuthResume('');
+            // Strip oauth_state_id / plaid_oauth_return only after Plaid Link has
+            // fully consumed the redirect and the exchange has completed.
+            cleanupOAuthUrl();
+            clearOAuthResumeInProgress();
             loadStatus();
         });
     }
@@ -1013,6 +1017,22 @@
     var PLAID_OAUTH_LINK_TOKEN_LEGACY_KEY = PLAID_OAUTH_LINK_TOKEN_KEY_PREFIX;
     var PLAID_OAUTH_LINK_TOKEN_KEY =
         PLAID_OAUTH_LINK_TOKEN_KEY_PREFIX + '.u{{ current_user.id }}';
+    // Per-page-load guard against duplicate resume attempts (e.g. if the
+    // modal handler fires more than once). Lives in closure so a refresh
+    // gives the user a fresh shot at resuming.
+    var pycashflow_plaid_oauth_resume_in_progress = false;
+
+    function markOAuthResumeInProgress() {
+        pycashflow_plaid_oauth_resume_in_progress = true;
+    }
+
+    function isOAuthResumeInProgress() {
+        return pycashflow_plaid_oauth_resume_in_progress === true;
+    }
+
+    function clearOAuthResumeInProgress() {
+        pycashflow_plaid_oauth_resume_in_progress = false;
+    }
 
     function storeOAuthLinkToken(linkToken) {
         try {
@@ -1065,11 +1085,17 @@
             token: linkToken,
             onSuccess: function(public_token, metadata) {
                 clearOAuthLinkToken();
+                // exchangePublicToken handles URL cleanup + resume flag clear
+                // after the server-side exchange completes.
                 exchangePublicToken(public_token, metadata);
             },
             onExit: function(err) {
                 setOAuthResume('');
                 clearOAuthLinkToken();
+                // Final handled exit: now safe to clean the OAuth params and
+                // release the resume guard so the user can retry from scratch.
+                cleanupOAuthUrl();
+                clearOAuthResumeInProgress();
                 if (err) {
                     setError('Plaid Link did not complete. Please try again.');
                 }
@@ -1099,25 +1125,35 @@
     }
 
     function resumeOAuth() {
+        // Skip if a resume is already underway in this session — prevents
+        // a second Plaid.create() if the modal handler fires twice.
+        if (isOAuthResumeInProgress()) return;
+        markOAuthResumeInProgress();
+
         if (typeof Plaid === 'undefined' || !Plaid.create) {
             setError('Plaid Link script failed to load.');
+            clearOAuthResumeInProgress();
             return;
         }
         setOAuthResume('Completing Plaid connection…');
         var linkToken = loadOAuthLinkToken();
         if (!linkToken) {
             setOAuthResume('');
-            setError('Your Plaid session expired. Please start the connection again.');
+            setError('Plaid connection session expired. Please start the connection again.');
             cleanupOAuthUrl();
+            clearOAuthResumeInProgress();
             return;
         }
+        // Capture window.location.href BEFORE any URL mutation so Plaid.create
+        // receives the original returned URL including oauth_state_id.
+        var receivedRedirectUri = window.location.href;
         var handler = Plaid.create(
-            buildHandlerConfig(linkToken, window.location.href)
+            buildHandlerConfig(linkToken, receivedRedirectUri)
         );
         handler.open();
-        // The bank-supplied params have served their purpose; clean them up
-        // now that Plaid Link has the URL it needed.
-        cleanupOAuthUrl();
+        // URL cleanup is deferred to onSuccess/onExit. Do NOT call
+        // history.replaceState here — Plaid Link may still race against
+        // the URL during the handoff.
     }
 
     function removeConnection() {

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -339,6 +339,89 @@ class TestSettingsPageOAuthMarkup:
         ):
             assert forbidden not in html
 
+    def test_settings_page_renders_with_oauth_return_params(self, auth_client):
+        # The exact landing URL Plaid uses after an OAuth bank redirect.
+        # Must render with 200 and preserve the query string for the JS.
+        resp = auth_client.get("/settings?plaid_oauth_return=1&oauth_state_id=test")
+        assert resp.status_code == 200
+        # Confirm the route did not redirect or strip the params before the
+        # template ran — the JS detection hooks must still be in the HTML.
+        html = resp.get_data(as_text=True)
+        assert "oauth_state_id" in html
+        assert "plaid_oauth_return" in html
+
+    def test_settings_route_does_not_redirect_on_oauth_query(self, auth_client):
+        # A GET to /settings with OAuth params must not 30x — that would
+        # strip oauth_state_id before window.location.href can capture it.
+        resp = auth_client.get(
+            "/settings?plaid_oauth_return=1&oauth_state_id=abc",
+            follow_redirects=False,
+        )
+        assert resp.status_code == 200
+
+    def test_resume_oauth_does_not_create_a_new_link_token(self, auth_client):
+        html = self._settings_html(auth_client)
+        # Pull just the resumeOAuth function body and make sure it does not
+        # call the link-token endpoint. The OAuth resume MUST reuse the
+        # link_token stored before the bank redirect.
+        marker = "function resumeOAuth"
+        idx = html.find(marker)
+        assert idx != -1, "resumeOAuth function not found in settings template"
+        # End at the next top-level function definition.
+        end = html.find("function removeConnection", idx)
+        assert end != -1
+        body = html[idx:end]
+        assert "/api/v1/plaid/link-token" not in body
+        # Confirm receivedRedirectUri is still wired up to window.location.href.
+        assert "receivedRedirectUri" in body
+        assert "window.location.href" in body
+
+    def test_start_link_stores_link_token_in_session_storage(self, auth_client):
+        html = self._settings_html(auth_client)
+        marker = "function startLink"
+        idx = html.find(marker)
+        assert idx != -1
+        end = html.find("function resumeOAuth", idx)
+        assert end != -1
+        body = html[idx:end]
+        # The first launch must persist the link_token before opening Link,
+        # otherwise OAuth resume has nothing to reuse.
+        assert "storeOAuthLinkToken" in body
+
+    def test_url_cleanup_is_deferred_until_exchange_or_exit(self, auth_client):
+        html = self._settings_html(auth_client)
+        # The cleanup function is allowed to exist, but resumeOAuth itself
+        # must NOT call it inline after handler.open(); the only legitimate
+        # callers are exchangePublicToken (success) and the onExit handler.
+        resume_start = html.find("function resumeOAuth")
+        resume_end = html.find("function removeConnection", resume_start)
+        assert resume_start != -1 and resume_end != -1
+        resume_body = html[resume_start:resume_end]
+        # Allow cleanupOAuthUrl in the no-link-token early-return branch,
+        # but make sure it does NOT appear after handler.open() in the
+        # normal-resume path.
+        open_idx = resume_body.find("handler.open()")
+        assert open_idx != -1
+        after_open = resume_body[open_idx:]
+        assert "cleanupOAuthUrl" not in after_open, (
+            "cleanupOAuthUrl must not run synchronously after handler.open(); "
+            "defer it to onSuccess or onExit so Plaid Link is not racing the URL."
+        )
+
+    def test_resume_in_progress_guard_present(self, auth_client):
+        html = self._settings_html(auth_client)
+        # Spec marker — guard exists to prevent duplicate Plaid.create() calls.
+        assert "pycashflow_plaid_oauth_resume_in_progress" in html
+
+    def test_completing_plaid_connection_message_present(self, auth_client):
+        html = self._settings_html(auth_client)
+        # User-facing resume status.
+        assert "Completing Plaid connection" in html
+
+    def test_session_expired_message_present(self, auth_client):
+        html = self._settings_html(auth_client)
+        assert "Plaid connection session expired" in html
+
 
 # ── Exchange token ──────────────────────────────────────────────────────────
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -123,6 +123,29 @@ class TestSignupLinkBehavior:
         assert resp.status_code == 200
         assert b'href="/signup"' in resp.data
 
+    def test_login_preserves_safe_next_in_form(self, client):
+        # Plaid's OAuth return is a long /settings?...&oauth_state_id=... URL;
+        # we must round-trip it through the login form so the post-login
+        # redirect lands back on the OAuth-return URL.
+        resp = client.get("/login?next=/settings%3Foauth_state_id%3Dabc")
+        assert resp.status_code == 200
+        # Jinja autoescapes ? as &#63; or leaves as ? depending on context.
+        assert b"name=\"next\"" in resp.data
+        # Make sure the value contains /settings and the oauth_state_id token.
+        assert b"/settings" in resp.data
+        assert b"oauth_state_id" in resp.data
+
+    def test_login_rejects_external_next_url(self, client):
+        resp = client.get("/login?next=https://evil.example.com/")
+        assert resp.status_code == 200
+        # External URLs must not be reflected into the form value.
+        assert b"https://evil.example.com" not in resp.data
+
+    def test_login_rejects_protocol_relative_next(self, client):
+        resp = client.get("/login?next=//evil.example.com/path")
+        assert resp.status_code == 200
+        assert b"//evil.example.com" not in resp.data
+
     def test_login_create_account_uses_external_signup_url(self, client, app_ctx, text_settings_model):
         db = app_ctx
         text_settings_model.query.filter_by(name="external_signup_url").delete()


### PR DESCRIPTION
## Summary
This PR fixes the Plaid OAuth redirect flow to properly preserve the `oauth_state_id` query parameter through the login page, allowing users to resume their Plaid connection after being redirected back from the bank. It also adds comprehensive test coverage and improves documentation around the OAuth flow.

## Key Changes

### Core OAuth Flow Fixes
- **Login URL preservation**: Added `_safe_next_path()` validation function in `auth.py` to safely preserve the full `/settings?oauth_state_id=...` URL through the login flow without open redirect vulnerabilities
- **Session storage**: Store the safe `next` URL in the session during login POST, then redirect to it after successful authentication (both password and 2FA paths)
- **Login template**: Pass `next_url` to the login form and include it as a hidden input so it survives the POST request

### Plaid Resume Logic Improvements
- **Resume guard**: Added `pycashflow_plaid_oauth_resume_in_progress` flag to prevent duplicate `Plaid.create()` calls if the modal handler fires multiple times
- **URL cleanup deferral**: Moved `cleanupOAuthUrl()` calls to `onSuccess` and `onExit` handlers instead of running synchronously after `handler.open()`, preventing race conditions with Plaid Link's redirect handling
- **Captured redirect URI**: Store `window.location.href` before any mutations so Plaid receives the original URL with `oauth_state_id` intact
- **Error messaging**: Updated session expiration message for consistency

### Test Coverage
- Added 8 new integration tests covering:
  - Settings page renders with OAuth query parameters preserved
  - No redirects strip parameters before template renders
  - Resume function doesn't create new link tokens
  - Link token is stored before opening Plaid modal
  - URL cleanup is deferred until exchange or exit
  - Resume guard and user-facing messages are present
- Added 3 new route tests for login URL safety:
  - Safe relative paths with query strings are preserved
  - External URLs are rejected
  - Protocol-relative URLs are rejected

### Documentation Updates
- Clarified that `PLAID_REDIRECT_URI` can be either bare path or with query string
- Explained that query strings are stripped before sending to Plaid's API
- Updated deployment checklist with specific verification steps for OAuth flow
- Improved `.env_example` comments about redirect URI configuration

## Implementation Details
- The `_safe_next_path()` function validates that URLs start with `/`, don't start with `//`, and have no scheme/netloc, preventing open redirect attacks while preserving query strings and fragments
- OAuth resume is guarded at the page-load level (closure variable) rather than per-request, so a page refresh gives users a fresh attempt
- URL cleanup is now only called after the public token exchange completes or the user exits Plaid Link, ensuring Plaid has fully consumed the redirect parameters

https://claude.ai/code/session_015tztMzPXH4YFMr775uf1YZ