### PR TITLE
Add client-side Plaid Link exit diagnostics logging

### DIFF
--- a/app/api/routes/plaid.py
+++ b/app/api/routes/plaid.py
@@ -25,6 +25,7 @@ from app.plaid_service import (
     create_link_token_for_user,
     exchange_public_token_for_user,
     get_plaid_connection_status,
+    log_plaid_link_exit_for_user,
     remove_plaid_connection_for_user,
     update_plaid_balance_for_user,
 )
@@ -75,6 +76,22 @@ def api_plaid_exchange_token():
     except PlaidServiceError as exc:
         return _service_error(exc)
     return api_ok(get_plaid_connection_status(user))
+
+
+@api.route("/plaid/link-exit", methods=["POST"])
+@api_login_required
+@limiter.limit("60 per hour")
+def api_plaid_link_exit():
+    """Record a client-side Plaid Link exit for server-side diagnostics.
+
+    Plaid Link surfaces OAuth handoff failures (common for real banks in
+    production) only in the browser. This endpoint accepts a small,
+    whitelisted subset of those fields and writes them to the server log.
+    """
+    user = get_api_user()
+    body = request.get_json(silent=True) or {}
+    log_plaid_link_exit_for_user(user, body)
+    return api_no_content()
 
 
 @api.route("/plaid/remove", methods=["POST", "DELETE"])

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -278,6 +278,78 @@ def create_link_token_for_user(user) -> str:
     return response.link_token
 
 
+# ── Link client-side event logging ───────────────────────────────────────────
+
+
+# Whitelisted fields we accept from the client. Plaid documents these as the
+# onExit error envelope and metadata; none of them carry credentials, access
+# tokens, or balances, so it is safe to write them to server logs.
+_LINK_EVENT_ERROR_FIELDS = (
+    "error_type",
+    "error_code",
+    "error_message",
+    "display_message",
+)
+_LINK_EVENT_METADATA_FIELDS = (
+    "status",
+    "link_session_id",
+    "request_id",
+    "institution_name",
+)
+
+
+def _sanitize_link_event_payload(payload: dict) -> dict:
+    """Pick only whitelisted, short string fields from a client-supplied payload."""
+    safe: dict = {}
+    if not isinstance(payload, dict):
+        return safe
+    err = payload.get("error")
+    if isinstance(err, dict):
+        for key in _LINK_EVENT_ERROR_FIELDS:
+            val = err.get(key)
+            if isinstance(val, str) and val:
+                safe[key] = val[:255]
+    meta = payload.get("metadata")
+    if isinstance(meta, dict):
+        for key in _LINK_EVENT_METADATA_FIELDS:
+            val = meta.get(key)
+            if isinstance(val, str) and val:
+                safe["metadata_" + key] = val[:255]
+    return safe
+
+
+def log_plaid_link_exit_for_user(user, payload: dict) -> None:
+    """Log client-reported Plaid Link exit diagnostics for a user.
+
+    Plaid Link reports failures (especially OAuth handoff problems for real
+    banks in production) entirely client-side; the server otherwise sees no
+    error. This bridges that gap by accepting a whitelisted subset of the
+    onExit ``err`` + ``metadata`` fields and emitting them to the server log.
+    """
+    safe = _sanitize_link_event_payload(payload or {})
+    if not safe:
+        logger.warning(
+            "Plaid Link exited with no recoverable diagnostics for user %s "
+            "(env=%s, products=%s, country_codes=%s, redirect_uri_set=%s)",
+            getattr(user, "id", None),
+            _config("PLAID_ENV"),
+            ",".join(get_configured_products()),
+            ",".join(get_configured_country_codes()),
+            bool(_config("PLAID_REDIRECT_URI")),
+        )
+        return
+    logger.warning(
+        "Plaid Link exit reported by user %s: %s "
+        "(env=%s, products=%s, country_codes=%s, redirect_uri_set=%s)",
+        getattr(user, "id", None),
+        ", ".join("%s=%s" % (k, v) for k, v in safe.items()),
+        _config("PLAID_ENV"),
+        ",".join(get_configured_products()),
+        ",".join(get_configured_country_codes()),
+        bool(_config("PLAID_REDIRECT_URI")),
+    )
+
+
 # ── Public token exchange ────────────────────────────────────────────────────
 
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1080,6 +1080,53 @@
         } catch (e) {}
     }
 
+    function pickString(obj, key) {
+        if (!obj) return '';
+        var val = obj[key];
+        return typeof val === 'string' ? val : '';
+    }
+
+    function reportLinkExit(err, metadata) {
+        // Plaid Link surfaces failures (especially OAuth handoff issues for
+        // real banks in production) only in the browser. Forward a small,
+        // whitelisted set of fields so they land in the server log.
+        try {
+            var inst = (metadata && metadata.institution) || {};
+            var payload = {
+                error: {
+                    error_type: pickString(err, 'error_type'),
+                    error_code: pickString(err, 'error_code'),
+                    error_message: pickString(err, 'error_message'),
+                    display_message: pickString(err, 'display_message')
+                },
+                metadata: {
+                    status: pickString(metadata, 'status'),
+                    link_session_id: pickString(metadata, 'link_session_id'),
+                    request_id: pickString(metadata, 'request_id'),
+                    institution_name: pickString(inst, 'name')
+                }
+            };
+            fetchJSON('/api/v1/plaid/link-exit', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+            });
+        } catch (e) { /* never let diagnostics break the UI */ }
+    }
+
+    function formatLinkExitMessage(err) {
+        var display = pickString(err, 'display_message');
+        if (display) return display;
+        var msg = pickString(err, 'error_message');
+        var code = pickString(err, 'error_code');
+        var type = pickString(err, 'error_type');
+        if (code && msg) return 'Plaid Link error (' + code + '): ' + msg;
+        if (msg) return 'Plaid Link error: ' + msg;
+        if (code) return 'Plaid Link error: ' + code;
+        if (type) return 'Plaid Link error: ' + type;
+        return 'Plaid Link did not complete. Please try again.';
+    }
+
     function buildHandlerConfig(linkToken, receivedRedirectUri) {
         var cfg = {
             token: linkToken,
@@ -1089,7 +1136,7 @@
                 // after the server-side exchange completes.
                 exchangePublicToken(public_token, metadata);
             },
-            onExit: function(err) {
+            onExit: function(err, metadata) {
                 setOAuthResume('');
                 clearOAuthLinkToken();
                 // Final handled exit: now safe to clean the OAuth params and
@@ -1097,7 +1144,8 @@
                 cleanupOAuthUrl();
                 clearOAuthResumeInProgress();
                 if (err) {
-                    setError('Plaid Link did not complete. Please try again.');
+                    reportLinkExit(err, metadata);
+                    setError(formatLinkExitMessage(err));
                 }
             },
             onEvent: function() { /* no-op; never log Plaid event payloads */ }

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -422,6 +422,86 @@ class TestSettingsPageOAuthMarkup:
         html = self._settings_html(auth_client)
         assert "Plaid connection session expired" in html
 
+    def test_on_exit_reports_diagnostics_to_server(self, auth_client):
+        html = self._settings_html(auth_client)
+        # Plaid Link surfaces OAuth handoff failures only client-side. The
+        # template must forward whitelisted onExit diagnostics so the server
+        # log captures them.
+        assert "/api/v1/plaid/link-exit" in html
+        assert "reportLinkExit" in html
+        # Must surface Plaid's own display_message when available, not the
+        # generic fallback.
+        assert "display_message" in html
+        assert "formatLinkExitMessage" in html
+
+
+# ── Link exit diagnostics endpoint ─────────────────────────────────────────
+
+
+class TestLinkExitDiagnostics:
+    def test_endpoint_requires_login(self, client):
+        resp = client.post("/api/v1/plaid/link-exit", json={})
+        assert resp.status_code in (401, 403)
+
+    def test_endpoint_logs_whitelisted_fields(self, auth_client, flask_app, caplog):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        import logging as _logging
+        caplog.set_level(_logging.WARNING, logger="app.plaid_service")
+        resp = auth_client.post(
+            "/api/v1/plaid/link-exit",
+            json={
+                "error": {
+                    "error_type": "INVALID_FIELD",
+                    "error_code": "INVALID_FIELD",
+                    "error_message": "redirect_uri must be registered",
+                    "display_message": "Please contact support",
+                },
+                "metadata": {
+                    "status": "requires_credentials",
+                    "link_session_id": "ls-1",
+                    "request_id": "rq-1",
+                    "institution_name": "Bank of America",
+                },
+            },
+        )
+        assert resp.status_code == 204
+        text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "INVALID_FIELD" in text
+        assert "redirect_uri must be registered" in text
+        assert "Bank of America" in text
+        # Must not log unexpected attacker-supplied keys.
+        assert "encrypted_access_token" not in text
+        assert "access_token" not in text
+
+    def test_endpoint_ignores_non_whitelisted_fields(
+        self, auth_client, flask_app, caplog
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        import logging as _logging
+        caplog.set_level(_logging.WARNING, logger="app.plaid_service")
+        resp = auth_client.post(
+            "/api/v1/plaid/link-exit",
+            json={
+                "error": {
+                    "error_type": "ITEM_ERROR",
+                    "secret_exfil": "should-not-appear",
+                    "access_token": "should-not-appear-either",
+                },
+                "metadata": {
+                    "status": "choose_device",
+                    "credit_card_number": "4111111111111111",
+                },
+            },
+        )
+        assert resp.status_code == 204
+        text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "ITEM_ERROR" in text
+        assert "choose_device" in text
+        assert "should-not-appear" not in text
+        assert "4111111111111111" not in text
+
 
 # ── Exchange token ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
This PR adds infrastructure to capture and log client-side Plaid Link exit events on the server. Plaid Link surfaces OAuth handoff failures and other errors only in the browser, so this change bridges that gap by forwarding whitelisted diagnostic fields to the server log.

## Key Changes
- **New API endpoint** (`POST /api/v1/plaid/link-exit`): Accepts client-reported Plaid Link exit diagnostics with strict field whitelisting to prevent credential leakage
- **Sanitization function** (`_sanitize_link_event_payload`): Filters client payloads to only include safe, documented Plaid fields (error type/code/message, display_message, status, session IDs, institution name)
- **Server-side logging** (`log_plaid_link_exit_for_user`): Emits whitelisted diagnostics to the application log with user context and Plaid configuration details
- **Client-side event handling**: Updated Plaid Link `onExit` handler to report diagnostics and display Plaid's own error messages when available
- **Helper functions**: Added `reportLinkExit` and `formatLinkExitMessage` JavaScript functions to safely extract and forward error information

## Notable Implementation Details
- All client-supplied data is validated and truncated to 255 characters to prevent log injection
- Non-whitelisted fields (including access tokens, encrypted tokens, credit card numbers) are explicitly rejected
- The endpoint requires authentication and is rate-limited to 60 requests per hour
- Error reporting is wrapped in try-catch to ensure diagnostics never break the UI
- Comprehensive test coverage validates both the whitelisting behavior and the rejection of sensitive fields

https://claude.ai/code/session_013sQuVzZWxshNAbMjhXjkuR