### PR TITLE
Fix post-login redirects for passkey auth and log injection

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -111,6 +111,11 @@ def _safe_next_path(raw_next: str | None) -> str | None:
 @auth.route('/login')
 def login():
     next_url = _safe_next_path(request.args.get('next'))
+    # Stash the safe next path in the session so it survives login methods
+    # that don't carry hidden form fields — e.g. the Passkey button, which
+    # navigates directly to /passkey_login.
+    if next_url:
+        session['post_login_next'] = next_url
     return render_template(
         'login.html',
         passkey_enabled=_passkey_enabled(),
@@ -426,6 +431,9 @@ def login_passkey():
     if not _passkey_enabled():
         flash('Passkey authentication is not enabled.')
         return redirect(url_for('auth.login'))
+    next_url = _safe_next_path(request.args.get('next'))
+    if next_url:
+        session['post_login_next'] = next_url
     return render_template('passkey_login.html')
 
 
@@ -516,6 +524,9 @@ def login_passkey_post():
     session['name'] = user.name
     session['email'] = user.email
 
+    next_target = _safe_next_path(session.pop('post_login_next', None))
+    if next_target:
+        return redirect(next_target)
     return redirect(url_for('main.index'))
 
 

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -11,6 +11,7 @@ payloads to callers, and it never logs them either.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import date, datetime, timezone
 from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
@@ -298,6 +299,15 @@ _LINK_EVENT_METADATA_FIELDS = (
 )
 
 
+# Strip ASCII control characters (incl. CR/LF) so a client-supplied value
+# cannot inject forged log lines when interpolated into a single-line warning.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _scrub_log_value(val: str) -> str:
+    return _CONTROL_CHARS_RE.sub(" ", val)[:255]
+
+
 def _sanitize_link_event_payload(payload: dict) -> dict:
     """Pick only whitelisted, short string fields from a client-supplied payload."""
     safe: dict = {}
@@ -308,13 +318,13 @@ def _sanitize_link_event_payload(payload: dict) -> dict:
         for key in _LINK_EVENT_ERROR_FIELDS:
             val = err.get(key)
             if isinstance(val, str) and val:
-                safe[key] = val[:255]
+                safe[key] = _scrub_log_value(val)
     meta = payload.get("metadata")
     if isinstance(meta, dict):
         for key in _LINK_EVENT_METADATA_FIELDS:
             val = meta.get(key)
             if isinstance(val, str) and val:
-                safe["metadata_" + key] = val[:255]
+                safe["metadata_" + key] = _scrub_log_value(val)
     return safe
 
 

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -36,6 +36,35 @@ def test_passkey_login_verify_without_challenge_redirects(client, monkeypatch):
     assert resp.headers["Location"].endswith("/passkey_login")
 
 
+def test_login_get_stashes_safe_next_in_session(client, monkeypatch):
+    # The Passkey button on /login navigates without a hidden form field, so the
+    # safe next path must survive in session for the post-passkey redirect.
+    monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)
+
+    resp = client.get("/login?next=/settings%3Foauth_state_id%3Dabc")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") == "/settings?oauth_state_id=abc"
+
+
+def test_login_get_ignores_external_next(client, monkeypatch):
+    monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)
+    resp = client.get("/login?next=https://evil.example.com/")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") is None
+
+
+def test_passkey_login_get_stashes_safe_next_in_session(client, monkeypatch):
+    monkeypatch.setattr(auth_module, "_WEBAUTHN_AVAILABLE", True)
+    monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)
+
+    resp = client.get("/passkey_login?next=/settings%3Foauth_state_id%3Dabc")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") == "/settings?oauth_state_id=abc"
+
+
 def test_passkey_register_verify_creates_credential(client, app_ctx, monkeypatch):
     monkeypatch.setattr(auth_module, "_WEBAUTHN_AVAILABLE", True)
     monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -474,6 +474,35 @@ class TestLinkExitDiagnostics:
         assert "encrypted_access_token" not in text
         assert "access_token" not in text
 
+    def test_endpoint_scrubs_control_chars_to_prevent_log_injection(
+        self, auth_client, flask_app, caplog
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        import logging as _logging
+        caplog.set_level(_logging.WARNING, logger="app.plaid_service")
+        resp = auth_client.post(
+            "/api/v1/plaid/link-exit",
+            json={
+                "error": {
+                    "error_message": "real msg\nFORGED line",
+                    "error_code": "CODE\r\nINJECT",
+                },
+                "metadata": {
+                    "institution_name": "Bank\x00null\x1b[31m",
+                },
+            },
+        )
+        assert resp.status_code == 204
+        # Every emitted log record must be a single line — the attacker's
+        # CR/LF/NUL must not appear in the message body.
+        for record in caplog.records:
+            msg = record.getMessage()
+            assert "\n" not in msg
+            assert "\r" not in msg
+            assert "\x00" not in msg
+            assert "\x1b" not in msg
+
     def test_endpoint_ignores_non_whitelisted_fields(
         self, auth_client, flask_app, caplog
     ):


### PR DESCRIPTION
## Summary
This PR addresses two security and functionality issues:
1. Preserves safe redirect URLs across passkey authentication flows by stashing them in the session
2. Prevents log injection attacks by scrubbing control characters from client-supplied log values

## Key Changes

**Passkey Authentication Redirect Flow:**
- Modified `/login` GET handler to stash safe `next` parameter in session as `post_login_next`
- Modified `/passkey_login` GET handler to stash safe `next` parameter in session
- Modified `/login_passkey_post` to redirect to the stashed `post_login_next` URL if present
- This ensures the redirect target survives the navigation from `/login` to `/passkey_login` without relying on hidden form fields

**Log Injection Prevention:**
- Added `_scrub_log_value()` function that strips ASCII control characters (0x00-0x1f, 0x7f) from strings
- Applied scrubbing to all client-supplied values logged in `_sanitize_link_event_payload()` 
- Prevents attackers from injecting forged log lines via CR/LF/NUL characters in error messages and metadata

## Implementation Details

- The session-based redirect approach allows the Passkey button to navigate directly to `/passkey_login` without carrying the `next` parameter as a hidden form field
- Control character scrubbing replaces problematic characters with spaces and truncates to 255 characters, maintaining log readability while preventing injection
- All three new test cases verify the security fixes work correctly for both normal and malicious inputs

https://claude.ai/code/session_01VTUdSamT7yxHKqZQBmPHSP