### PR TITLE
Switch Plaid balance sync from /accounts/balance/get to /accounts/get

### DIFF
--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -595,10 +595,8 @@ def update_plaid_balance_for_user(user) -> dict:
         return result
 
     from plaid.exceptions import ApiException
-    from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
-    from plaid.model.accounts_balance_get_request_options import (
-        AccountsBalanceGetRequestOptions,
-    )
+    from plaid.model.accounts_get_request import AccountsGetRequest
+    from plaid.model.accounts_get_request_options import AccountsGetRequestOptions
 
     try:
         access_token = decrypt_password(conn.encrypted_access_token)
@@ -611,17 +609,21 @@ def update_plaid_balance_for_user(user) -> dict:
             cache[user.id] = result
         return result
 
+    # Use /accounts/get rather than /accounts/balance/get: the latter requires
+    # the "balance" product authorization, while /accounts/get is included
+    # with "transactions" and returns the same available/current balance
+    # fields (refreshed as part of regular transaction sync).
     try:
         client = _plaid_client()
-        request = AccountsBalanceGetRequest(
+        request = AccountsGetRequest(
             access_token=access_token,
-            options=AccountsBalanceGetRequestOptions(account_ids=[conn.plaid_account_id]),
+            options=AccountsGetRequestOptions(account_ids=[conn.plaid_account_id]),
         )
-        response = client.accounts_balance_get(request)
+        response = client.accounts_get(request)
     except ApiException as exc:
         info = _plaid_error_info(exc)
         logger.warning(
-            "Plaid accounts_balance_get failed for user %s "
+            "Plaid accounts_get failed for user %s "
             "(request_id=%s, error_type=%s, error_code=%s, error_message=%s)",
             user.id,
             info.get("request_id"),
@@ -636,7 +638,7 @@ def update_plaid_balance_for_user(user) -> dict:
             cache[user.id] = result
         return result
     except Exception:
-        logger.exception("Unexpected error calling Plaid balance API for user %s", user.id)
+        logger.exception("Unexpected error calling Plaid accounts API for user %s", user.id)
         _record_sync_status(conn, "unexpected_error", "Unexpected Plaid error.")
         try:
             db.session.commit()

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -741,7 +741,7 @@ class TestUpdateBalance:
             _add_connection(plaid_user)
             user = User.query.get(plaid_user)
             with patch.object(plaid_service, "_plaid_client") as mock_client:
-                mock_client.return_value.accounts_balance_get.return_value = (
+                mock_client.return_value.accounts_get.return_value = (
                     _make_balances_response("acct-1", available=500.25, current=600.00)
                 )
                 result = plaid_service.update_plaid_balance_for_user(user)
@@ -760,7 +760,7 @@ class TestUpdateBalance:
             _add_connection(plaid_user)
             user = User.query.get(plaid_user)
             with patch.object(plaid_service, "_plaid_client") as mock_client:
-                mock_client.return_value.accounts_balance_get.return_value = (
+                mock_client.return_value.accounts_get.return_value = (
                     _make_balances_response("acct-1", available=None, current=800.10)
                 )
                 result = plaid_service.update_plaid_balance_for_user(user)
@@ -781,7 +781,7 @@ class TestUpdateBalance:
 
             user = User.query.get(plaid_user)
             with patch.object(plaid_service, "_plaid_client") as mock_client:
-                mock_client.return_value.accounts_balance_get.return_value = (
+                mock_client.return_value.accounts_get.return_value = (
                     _make_balances_response("acct-1", available=None, current=None)
                 )
                 result = plaid_service.update_plaid_balance_for_user(user)
@@ -809,7 +809,7 @@ class TestUpdateBalance:
 
             user = User.query.get(plaid_user)
             with patch.object(plaid_service, "_plaid_client") as mock_client:
-                mock_client.return_value.accounts_balance_get.return_value = (
+                mock_client.return_value.accounts_get.return_value = (
                     _make_balances_response("acct-1", available=250.0, current=300.0)
                 )
                 plaid_service.update_plaid_balance_for_user(user)
@@ -825,7 +825,7 @@ class TestUpdateBalance:
             _add_connection(plaid_user)
             user = User.query.get(plaid_user)
             with patch.object(plaid_service, "_plaid_client") as mock_client:
-                mock_client.return_value.accounts_balance_get.return_value = (
+                mock_client.return_value.accounts_get.return_value = (
                     _make_balances_response("acct-1", available=42.0, current=None)
                 )
                 plaid_service.update_plaid_balance_for_user(user)
@@ -843,7 +843,7 @@ class TestUpdateBalance:
             _add_connection(plaid_user)
             user = User.query.get(plaid_user)
             with patch.object(plaid_service, "_plaid_client") as mock_client:
-                mock_client.return_value.accounts_balance_get.side_effect = RuntimeError(
+                mock_client.return_value.accounts_get.side_effect = RuntimeError(
                     "boom"
                 )
                 # Must not raise.


### PR DESCRIPTION
## Summary
This change replaces the Plaid `/accounts/balance/get` endpoint with the `/accounts/get` endpoint for fetching account balance information. This switch eliminates the need for the separate "balance" product authorization, as `/accounts/get` is already included with the "transactions" product and returns the same balance fields.

## Key Changes
- **API Endpoint Migration**: Replaced `AccountsBalanceGetRequest` with `AccountsGetRequest` and corresponding request options classes
- **Client Method Update**: Changed from `client.accounts_balance_get()` to `client.accounts_get()`
- **Documentation**: Added explanatory comment clarifying why `/accounts/get` is preferred over `/accounts/balance/get`
- **Error Logging**: Updated log messages to reference "accounts API" instead of "balance API"
- **Test Updates**: Updated all test mocks to use the new `accounts_get` method instead of `accounts_balance_get`

## Implementation Details
The balance data returned by `/accounts/get` is refreshed as part of the regular transaction synchronization process, making it a more efficient choice than requiring a separate product authorization. The available and current balance fields are identical between both endpoints, so this change is functionally equivalent while reducing API product dependencies.

https://claude.ai/code/session_014iqfytNnyqJvi5CxDFPezr