### PR TITLE
Clear stale post-login redirect on login page visits

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -113,9 +113,13 @@ def login():
     next_url = _safe_next_path(request.args.get('next'))
     # Stash the safe next path in the session so it survives login methods
     # that don't carry hidden form fields — e.g. the Passkey button, which
-    # navigates directly to /passkey_login.
+    # navigates directly to /passkey_login. Clear any stale value when the
+    # current request has no valid ``next`` so an earlier attempt doesn't
+    # bleed into this one.
     if next_url:
         session['post_login_next'] = next_url
+    else:
+        session.pop('post_login_next', None)
     return render_template(
         'login.html',
         passkey_enabled=_passkey_enabled(),
@@ -434,6 +438,8 @@ def login_passkey():
     next_url = _safe_next_path(request.args.get('next'))
     if next_url:
         session['post_login_next'] = next_url
+    else:
+        session.pop('post_login_next', None)
     return render_template('passkey_login.html')
 
 


### PR DESCRIPTION
## Summary
This change fixes a bug where stale post-login redirect URLs could persist across multiple login attempts, causing users to be redirected to unintended destinations.

## Key Changes
- **login()**: Added logic to clear the `post_login_next` session value when the current request has no valid `next` parameter, preventing stale values from earlier attempts from persisting
- **login_passkey()**: Applied the same fix to ensure consistency across both login entry points

## Implementation Details
Previously, the code only set `session['post_login_next']` when a valid `next` URL was present, but never cleared it when absent. This meant if a user visited the login page with a redirect parameter, then later visited without one, the old redirect would still be in the session and trigger an unintended redirect after login.

The fix explicitly clears the session value using `session.pop('post_login_next', None)` when no valid `next` parameter is provided in the current request, ensuring each login attempt starts with a clean state.

https://claude.ai/code/session_01WKrDKfBfbtv9t3MiADAR7c