### PR TITLE
Simplify Plaid Link error messaging to users

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -1114,19 +1114,6 @@
         } catch (e) { /* never let diagnostics break the UI */ }
     }
 
-    function formatLinkExitMessage(err) {
-        var display = pickString(err, 'display_message');
-        if (display) return display;
-        var msg = pickString(err, 'error_message');
-        var code = pickString(err, 'error_code');
-        var type = pickString(err, 'error_type');
-        if (code && msg) return 'Plaid Link error (' + code + '): ' + msg;
-        if (msg) return 'Plaid Link error: ' + msg;
-        if (code) return 'Plaid Link error: ' + code;
-        if (type) return 'Plaid Link error: ' + type;
-        return 'Plaid Link did not complete. Please try again.';
-    }
-
     function buildHandlerConfig(linkToken, receivedRedirectUri) {
         var cfg = {
             token: linkToken,
@@ -1145,7 +1132,7 @@
                 clearOAuthResumeInProgress();
                 if (err) {
                     reportLinkExit(err, metadata);
-                    setError(formatLinkExitMessage(err));
+                    setError('Plaid Link did not complete. Please try again.');
                 }
             },
             onEvent: function() { /* no-op; never log Plaid event payloads */ }

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -429,10 +429,11 @@ class TestSettingsPageOAuthMarkup:
         # log captures them.
         assert "/api/v1/plaid/link-exit" in html
         assert "reportLinkExit" in html
-        # Must surface Plaid's own display_message when available, not the
-        # generic fallback.
         assert "display_message" in html
-        assert "formatLinkExitMessage" in html
+        # User-facing message stays generic; detailed error fields go only
+        # to the server log.
+        assert "Plaid Link did not complete. Please try again." in html
+        assert "formatLinkExitMessage" not in html
 
 
 # ── Link exit diagnostics endpoint ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
This change simplifies the user-facing error message when Plaid Link exits with an error, while maintaining detailed error reporting to the server for diagnostics.

## Key Changes
- Removed the `formatLinkExitMessage()` function that attempted to construct user-friendly messages from various Plaid error fields
- Replaced dynamic error message formatting with a single generic message: "Plaid Link did not complete. Please try again."
- Detailed error information (display_message, error_message, error_code, error_type) continues to be sent to the server via `reportLinkExit()` for logging and diagnostics
- Updated test expectations to reflect the new behavior

## Implementation Details
The previous implementation tried to surface Plaid's own `display_message` when available, falling back through various error fields to construct a message. This approach has been simplified to always show a consistent, generic message to users while preserving all error details in server-side logs for debugging purposes. This provides a better user experience (consistent messaging) while maintaining full diagnostic capabilities for support and development teams.

https://claude.ai/code/session_01NhTBf62q4sRA7RfJqdDvvG