### PR TITLE
Preserve stashed next URL across failed login retries

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -113,13 +113,15 @@ def login():
     next_url = _safe_next_path(request.args.get('next'))
     # Stash the safe next path in the session so it survives login methods
     # that don't carry hidden form fields — e.g. the Passkey button, which
-    # navigates directly to /passkey_login. Clear any stale value when the
-    # current request has no valid ``next`` so an earlier attempt doesn't
-    # bleed into this one.
+    # navigates directly to /passkey_login. When this GET has no ``next``
+    # query param (the typical failed-attempt retry path, since
+    # ``login_post`` redirects back to ``/login`` without it), fall back to
+    # any value already stashed so the original destination is preserved
+    # across retries.
     if next_url:
         session['post_login_next'] = next_url
     else:
-        session.pop('post_login_next', None)
+        next_url = _safe_next_path(session.get('post_login_next'))
     return render_template(
         'login.html',
         passkey_enabled=_passkey_enabled(),
@@ -438,8 +440,10 @@ def login_passkey():
     next_url = _safe_next_path(request.args.get('next'))
     if next_url:
         session['post_login_next'] = next_url
-    else:
-        session.pop('post_login_next', None)
+    # If no ``next`` is provided (e.g. the user clicked the "Sign In with
+    # Passkey" link from ``/login?next=/settings``, which doesn't forward
+    # the query param), leave any previously stashed value alone so the
+    # original post-login destination survives.
     return render_template('passkey_login.html')
 
 

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -65,6 +65,39 @@ def test_passkey_login_get_stashes_safe_next_in_session(client, monkeypatch):
         assert sess.get("post_login_next") == "/settings?oauth_state_id=abc"
 
 
+def test_login_get_preserves_stashed_next_without_query(client, monkeypatch):
+    # Failed login attempts redirect back to /login without the ``next``
+    # query parameter; the previously stashed destination must survive so a
+    # successful retry still lands on the original page.
+    monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)
+
+    resp = client.get("/login?next=/settings")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") == "/settings"
+
+    resp = client.get("/login")
+    assert resp.status_code == 200
+    assert b'name="next" value="/settings"' in resp.data
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") == "/settings"
+
+
+def test_passkey_login_get_preserves_stashed_next_without_query(client, monkeypatch):
+    # The "Sign In with Passkey" link on /login doesn't forward the ``next``
+    # query parameter, so the stashed destination must persist.
+    monkeypatch.setattr(auth_module, "_WEBAUTHN_AVAILABLE", True)
+    monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)
+
+    resp = client.get("/login?next=/settings")
+    assert resp.status_code == 200
+
+    resp = client.get("/passkey_login")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") == "/settings"
+
+
 def test_passkey_register_verify_creates_credential(client, app_ctx, monkeypatch):
     monkeypatch.setattr(auth_module, "_WEBAUTHN_AVAILABLE", True)
     monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)


### PR DESCRIPTION
## Summary
This change fixes a bug where the post-login redirect destination (`next` URL) was lost when users retried login after a failed attempt. The fix ensures that the stashed destination persists across multiple login attempts and authentication method changes.

## Key Changes
- **Modified `/login` GET handler**: Changed from clearing the stashed `post_login_next` session value when no `next` query parameter is present to instead falling back to any previously stashed value. This allows the original destination to survive failed login attempts that redirect back to `/login` without the query parameter.

- **Modified `/passkey_login` GET handler**: Removed the code that cleared the stashed `post_login_next` value when no `next` query parameter was provided. This allows users who click "Sign In with Passkey" from a login page with a destination to maintain that destination.

- **Added test coverage**: Two new tests verify the fix:
  - `test_login_get_preserves_stashed_next_without_query`: Ensures that after a failed login attempt redirects back to `/login`, the stashed destination is preserved and available in the form.
  - `test_passkey_login_get_preserves_stashed_next_without_query`: Ensures that navigating to `/passkey_login` from `/login?next=/settings` preserves the destination in the session.

## Implementation Details
The fix changes the session handling logic from a "clear on missing query param" approach to a "preserve on missing query param" approach. This is safe because:
1. When a fresh login flow starts with an explicit `next` parameter, it overwrites any stale value
2. When retrying after a failed attempt (no `next` parameter), the previous value is preserved
3. The `_safe_next_path()` validation is still applied to any retrieved stashed value to maintain security

https://claude.ai/code/session_01EPjBzGACkvCnG9C566LyKi