### PR TITLE
Fix redirect destination leakage between login flows

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -110,18 +110,23 @@ def _safe_next_path(raw_next: str | None) -> str | None:
 
 @auth.route('/login')
 def login():
-    next_url = _safe_next_path(request.args.get('next'))
+    raw_next = request.args.get('next')
+    next_url = _safe_next_path(raw_next)
     # Stash the safe next path in the session so it survives login methods
     # that don't carry hidden form fields — e.g. the Passkey button, which
     # navigates directly to /passkey_login. When this GET has no ``next``
-    # query param (the typical failed-attempt retry path, since
+    # query param at all (the typical failed-attempt retry path, since
     # ``login_post`` redirects back to ``/login`` without it), fall back to
     # any value already stashed so the original destination is preserved
-    # across retries.
+    # across retries. But if a ``next`` was explicitly supplied and is
+    # invalid/unsafe, drop the stale stash so a prior flow's destination
+    # can't bleed into this one.
     if next_url:
         session['post_login_next'] = next_url
-    else:
+    elif raw_next is None:
         next_url = _safe_next_path(session.get('post_login_next'))
+    else:
+        session.pop('post_login_next', None)
     return render_template(
         'login.html',
         passkey_enabled=_passkey_enabled(),
@@ -437,13 +442,18 @@ def login_passkey():
     if not _passkey_enabled():
         flash('Passkey authentication is not enabled.')
         return redirect(url_for('auth.login'))
-    next_url = _safe_next_path(request.args.get('next'))
+    raw_next = request.args.get('next')
+    next_url = _safe_next_path(raw_next)
     if next_url:
         session['post_login_next'] = next_url
-    # If no ``next`` is provided (e.g. the user clicked the "Sign In with
-    # Passkey" link from ``/login?next=/settings``, which doesn't forward
-    # the query param), leave any previously stashed value alone so the
-    # original post-login destination survives.
+    elif raw_next is not None:
+        # ``next`` was supplied but unsafe — clear any stale stash so a
+        # prior flow's destination can't carry over.
+        session.pop('post_login_next', None)
+    # If no ``next`` is provided at all (e.g. the user clicked the "Sign In
+    # with Passkey" link from ``/login?next=/settings``, which doesn't
+    # forward the query param), leave any previously stashed value alone
+    # so the original post-login destination survives.
     return render_template('passkey_login.html')
 
 

--- a/tests/test_passkey_auth.py
+++ b/tests/test_passkey_auth.py
@@ -83,6 +83,36 @@ def test_login_get_preserves_stashed_next_without_query(client, monkeypatch):
         assert sess.get("post_login_next") == "/settings"
 
 
+def test_login_get_invalid_next_clears_stashed_value(client, monkeypatch):
+    # An explicit but unsafe ``next`` must not silently inherit a prior
+    # flow's stashed destination — that would redirect users to an
+    # unrelated page after auth.
+    monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)
+
+    resp = client.get("/login?next=/settings")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") == "/settings"
+
+    resp = client.get("/login?next=https://evil.example.com/")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") is None
+
+
+def test_passkey_login_get_invalid_next_clears_stashed_value(client, monkeypatch):
+    monkeypatch.setattr(auth_module, "_WEBAUTHN_AVAILABLE", True)
+    monkeypatch.setattr(auth_module, "_passkey_enabled", lambda: True)
+
+    resp = client.get("/login?next=/settings")
+    assert resp.status_code == 200
+
+    resp = client.get("/passkey_login?next=https://evil.example.com/")
+    assert resp.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess.get("post_login_next") is None
+
+
 def test_passkey_login_get_preserves_stashed_next_without_query(client, monkeypatch):
     # The "Sign In with Passkey" link on /login doesn't forward the ``next``
     # query parameter, so the stashed destination must persist.


### PR DESCRIPTION
## Summary
This PR fixes a security issue where invalid/unsafe `next` parameters in login flows could allow a prior flow's stashed redirect destination to persist, potentially redirecting users to unrelated pages after authentication.

## Key Changes
- **Login endpoint (`/login`)**: Modified to explicitly clear the stashed `post_login_next` session value when an invalid `next` parameter is provided, preventing unsafe destinations from being silently inherited from previous flows
- **Passkey login endpoint (`/passkey_login`)**: Applied the same fix to clear stashed values when an unsafe `next` parameter is supplied
- **Test coverage**: Added two new test cases to verify that invalid `next` parameters properly clear stashed redirect destinations in both login flows

## Implementation Details
The fix distinguishes between three cases:
1. **Valid `next` parameter**: Store it in the session for use after login
2. **No `next` parameter** (`raw_next is None`): Preserve any previously stashed destination (allows the "Sign In with Passkey" flow to work correctly)
3. **Invalid `next` parameter** (`raw_next is not None` but `_safe_next_path()` returns `None`): Explicitly clear the stashed value to prevent destination leakage

This ensures that when a user provides an unsafe redirect destination, it doesn't inadvertently inherit a safe destination from a prior authentication attempt.

https://claude.ai/code/session_015T8xGHRGA3Jpk5EjjjW7gp