### PR TITLE
Detach Plaid Items when users lose access or are deleted

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -34,7 +34,10 @@ from .ai_insights import (
     validate_model,
 )
 from .password_setup import create_password_setup_link
-from .plaid_service import safe_update_plaid_balance_for_user
+from .plaid_service import (
+    safe_update_plaid_balance_for_user,
+    remove_plaid_connections_for_user_ids,
+)
 from .totp_utils import (
     generate_totp_secret, encrypt_totp_secret, decrypt_totp_secret,
     generate_qr_code_b64, verify_totp,
@@ -902,6 +905,12 @@ def _cascade_delete_user(user):
     guest_ids = [
         guest_id for (guest_id,) in db.session.query(User.id).filter_by(account_owner_id=user_id).all()
     ]
+
+    # Best-effort: tell Plaid the Items are gone so we stop being billed for
+    # the Transactions subscription. Must run before the bulk delete clears
+    # PlaidConnection rows (we need the access tokens).
+    remove_plaid_connections_for_user_ids([user_id] + guest_ids)
+
     _delete_user_owned_rows(guest_ids)
     if guest_ids:
         db.session.query(User).filter(User.id.in_(guest_ids)).delete(synchronize_session=False)

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -498,42 +498,79 @@ def exchange_public_token_for_user(user, public_token: str, metadata: dict) -> P
 # ── Remove connection ────────────────────────────────────────────────────────
 
 
+def _detach_plaid_item(conn: PlaidConnection) -> None:
+    """Best-effort call to Plaid's /item/remove for ``conn``. Never raises.
+
+    Calling /item/remove ends the Plaid Transactions subscription for the
+    underlying Item; skipping this step means Plaid keeps billing us for the
+    Item even after the local record is gone.
+    """
+    if not plaid_is_configured():
+        return
+
+    from plaid.exceptions import ApiException
+    from plaid.model.item_remove_request import ItemRemoveRequest
+
+    try:
+        access_token = decrypt_password(conn.encrypted_access_token)
+        client = _plaid_client()
+        client.item_remove(ItemRemoveRequest(access_token=access_token))
+    except ApiException as exc:
+        info = _plaid_error_info(exc)
+        logger.warning(
+            "Plaid item_remove failed for user %s connection %s "
+            "(request_id=%s, error_type=%s, error_code=%s, error_message=%s); "
+            "deleting local record anyway",
+            conn.user_id,
+            conn.id,
+            info.get("request_id"),
+            info.get("error_type"),
+            info.get("error_code"),
+            info.get("error_message"),
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error calling Plaid item_remove for user %s connection %s; "
+            "deleting local record anyway",
+            conn.user_id,
+            conn.id,
+        )
+
+
 def remove_plaid_connection_for_user(user) -> bool:
     """Remove the active Plaid connection for ``user``. Returns True if removed."""
     conn = get_active_connection(user)
     if conn is None:
         return False
 
-    # Best-effort call to /item/remove; never propagate raw errors to caller.
-    if plaid_is_configured():
-        from plaid.exceptions import ApiException
-        from plaid.model.item_remove_request import ItemRemoveRequest
-
-        try:
-            access_token = decrypt_password(conn.encrypted_access_token)
-            client = _plaid_client()
-            client.item_remove(ItemRemoveRequest(access_token=access_token))
-        except ApiException as exc:
-            info = _plaid_error_info(exc)
-            logger.warning(
-                "Plaid item_remove failed for user %s "
-                "(request_id=%s, error_type=%s, error_code=%s, error_message=%s); "
-                "deleting local record anyway",
-                user.id,
-                info.get("request_id"),
-                info.get("error_type"),
-                info.get("error_code"),
-                info.get("error_message"),
-            )
-        except Exception:
-            logger.exception(
-                "Unexpected error calling Plaid item_remove for user %s; deleting local record anyway",
-                user.id,
-            )
-
+    _detach_plaid_item(conn)
     db.session.delete(conn)
     db.session.commit()
     return True
+
+
+def remove_plaid_connections_for_user_ids(user_ids, *, commit: bool = False) -> int:
+    """Remove every PlaidConnection owned by the given user IDs.
+
+    For each row, best-effort calls Plaid's /item/remove (so we stop being
+    billed for the Item's Transactions subscription) and then deletes the
+    local record. Returns the number of rows removed. Caller is responsible
+    for committing the session unless ``commit=True``.
+    """
+    if not user_ids:
+        return 0
+
+    connections = (
+        PlaidConnection.query.filter(PlaidConnection.user_id.in_(list(user_ids))).all()
+    )
+    for conn in connections:
+        _detach_plaid_item(conn)
+        db.session.delete(conn)
+
+    if commit and connections:
+        db.session.commit()
+
+    return len(connections)
 
 
 # ── Balance update ───────────────────────────────────────────────────────────

--- a/app/subscription.py
+++ b/app/subscription.py
@@ -13,6 +13,7 @@ from flask import current_app
 
 from app import db
 from app.models import Subscription, User
+from app.plaid_service import remove_plaid_connections_for_user_ids
 
 
 logger = logging.getLogger(__name__)
@@ -196,6 +197,12 @@ def apply_subscription_status(
         user.is_active = False
 
     db.session.add(user)
+
+    # If the user just lost active status, detach their Plaid Items so we
+    # stop being billed for the Plaid Transactions subscription.
+    if old_active and not user.is_active:
+        remove_plaid_connections_for_user_ids([user.id])
+
     if commit:
         db.session.commit()
     logger.info(
@@ -266,7 +273,9 @@ def enforce_user_access(user: User | None) -> bool:
             db.session.commit()
         return True
 
-    changed = _expire_user(owner)
+    deactivated_ids: list[int] = []
+    if _expire_user(owner):
+        deactivated_ids.append(owner.id)
 
     # Guests inherit owner status; mark inactive for consistency in admin UIs.
     guests = User.query.filter(
@@ -275,7 +284,14 @@ def enforce_user_access(user: User | None) -> bool:
     for guest in guests:
         if guest.is_active:
             guest.is_active = False
-            changed = True
+            deactivated_ids.append(guest.id)
+
+    changed = bool(deactivated_ids)
+
+    # Detach Plaid Items for any user that just lost access so Plaid stops
+    # billing us for the Transactions subscription on their Item.
+    if deactivated_ids:
+        remove_plaid_connections_for_user_ids(deactivated_ids)
 
     if changed:
         db.session.commit()

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -714,6 +714,66 @@ class TestRemoveConnection:
             _deconfigure_plaid(flask_app)
 
 
+class TestRemoveConnectionsBulk:
+    def test_calls_item_remove_for_every_user(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            other = User(
+                email=f"plaid-bulk-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="Other",
+                admin=True,
+                is_active=True,
+            )
+            db.session.add(other)
+            db.session.commit()
+            other_id = other.id
+            _add_connection(plaid_user)
+            _add_connection(
+                other_id,
+                encrypted_access_token=encrypt_password("access-sandbox-other"),
+                plaid_item_id="item-other",
+            )
+
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                removed = plaid_service.remove_plaid_connections_for_user_ids(
+                    [plaid_user, other_id], commit=True
+                )
+                assert removed == 2
+                assert mock_client.return_value.item_remove.call_count == 2
+
+            assert PlaidConnection.query.filter_by(user_id=plaid_user).count() == 0
+            assert PlaidConnection.query.filter_by(user_id=other_id).count() == 0
+
+            User.query.filter_by(id=other_id).delete()
+            db.session.commit()
+            _deconfigure_plaid(flask_app)
+
+    def test_noop_when_no_user_ids(self, flask_app):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                removed = plaid_service.remove_plaid_connections_for_user_ids([])
+                assert removed == 0
+                assert not mock_client.return_value.item_remove.called
+            _deconfigure_plaid(flask_app)
+
+    def test_swallows_item_remove_failures(self, flask_app, plaid_user):
+        from plaid.exceptions import ApiException
+
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.item_remove.side_effect = ApiException()
+                removed = plaid_service.remove_plaid_connections_for_user_ids(
+                    [plaid_user], commit=True
+                )
+            assert removed == 1
+            assert PlaidConnection.query.filter_by(user_id=plaid_user).count() == 0
+            _deconfigure_plaid(flask_app)
+
+
 # ── Balance update ──────────────────────────────────────────────────────────
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -18,7 +18,10 @@ import pytest
 import importlib
 import json
 from datetime import datetime, timezone
+from unittest.mock import patch
 from werkzeug.security import generate_password_hash
+
+from app.crypto_utils import encrypt_password
 
 
 
@@ -520,6 +523,191 @@ def test_delete_my_account_blocks_global_admin(
     assert "/settings" in resp.headers.get("Location", "")
     # The admin account must still exist after the blocked self-delete attempt.
     assert user_model.query.filter_by(id=admin_id).first() is not None
+
+
+def _enable_plaid(flask_app):
+    flask_app.config.update(
+        PLAID_CLIENT_ID="client-id",
+        PLAID_SECRET="secret",
+        PLAID_ENV="sandbox",
+        PLAID_PRODUCTS="auth",
+        PLAID_COUNTRY_CODES="US",
+        PLAID_REDIRECT_URI="",
+    )
+
+
+def _disable_plaid(flask_app):
+    for k in (
+        "PLAID_CLIENT_ID",
+        "PLAID_SECRET",
+        "PLAID_ENV",
+        "PLAID_PRODUCTS",
+        "PLAID_REDIRECT_URI",
+    ):
+        flask_app.config[k] = ""
+
+
+def test_delete_user_calls_plaid_item_remove(
+    auth_client, flask_app, app_ctx, user_model, plaid_connection_model, plaid_service_module
+):
+    """Removing a user must tell Plaid so we stop paying for the Item."""
+    db = app_ctx
+    acting_admin = user_model.query.filter_by(email="admin@test.local").first()
+    acting_admin.is_global_admin = True
+    db.session.flush()
+
+    owner = user_model(
+        email="owner-plaid-delete@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Owner With Plaid",
+        admin=True,
+        is_active=True,
+        account_owner_id=None,
+        is_global_admin=False,
+    )
+    db.session.add(owner)
+    db.session.flush()
+
+    guest = user_model(
+        email="guest-plaid-delete@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Guest With Plaid",
+        admin=False,
+        is_active=True,
+        account_owner_id=owner.id,
+        is_global_admin=False,
+    )
+    db.session.add(guest)
+    db.session.flush()
+
+    db.session.add(plaid_connection_model(
+        user_id=owner.id,
+        encrypted_access_token=encrypt_password("access-owner"),
+        plaid_item_id="item-owner",
+        plaid_account_id="acct-owner",
+        is_active=True,
+    ))
+    db.session.add(plaid_connection_model(
+        user_id=guest.id,
+        encrypted_access_token=encrypt_password("access-guest"),
+        plaid_item_id="item-guest",
+        plaid_account_id="acct-guest",
+        is_active=True,
+    ))
+    db.session.commit()
+
+    owner_id = owner.id
+    guest_id = guest.id
+
+    _enable_plaid(flask_app)
+    try:
+        with patch.object(plaid_service_module, "_plaid_client") as mock_client:
+            resp = auth_client.post(f"/delete_user/{owner_id}", follow_redirects=False)
+            assert resp.status_code in (301, 302)
+            assert mock_client.return_value.item_remove.call_count == 2
+    finally:
+        _disable_plaid(flask_app)
+
+    assert user_model.query.filter_by(id=owner_id).first() is None
+    assert user_model.query.filter_by(id=guest_id).first() is None
+    assert plaid_connection_model.query.filter_by(user_id=owner_id).count() == 0
+    assert plaid_connection_model.query.filter_by(user_id=guest_id).count() == 0
+
+
+def test_subscription_expired_removes_plaid_connection(
+    flask_app, app_ctx, user_model, plaid_connection_model, plaid_service_module
+):
+    """When apply_subscription_status flips a user to inactive due to an
+    expired subscription, their Plaid Item must be detached so Plaid stops
+    charging us."""
+    from app.subscription import apply_subscription_status, SUB_EXPIRED
+
+    db = app_ctx
+    owner = user_model(
+        email="owner-sub-lapse@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Lapsed Owner",
+        admin=True,
+        is_active=True,
+        account_owner_id=None,
+        is_global_admin=False,
+    )
+    db.session.add(owner)
+    db.session.flush()
+    db.session.add(plaid_connection_model(
+        user_id=owner.id,
+        encrypted_access_token=encrypt_password("access-lapse"),
+        plaid_item_id="item-lapse",
+        plaid_account_id="acct-lapse",
+        is_active=True,
+    ))
+    db.session.commit()
+    owner_id = owner.id
+
+    _enable_plaid(flask_app)
+    try:
+        with patch.object(plaid_service_module, "_plaid_client") as mock_client:
+            apply_subscription_status(
+                owner,
+                status=SUB_EXPIRED,
+                source="apple",
+                subscription_id="txn-1",
+                activate=False,
+            )
+            assert mock_client.return_value.item_remove.call_count == 1
+    finally:
+        _disable_plaid(flask_app)
+
+    refreshed = user_model.query.filter_by(id=owner_id).first()
+    assert refreshed is not None
+    assert refreshed.is_active is False
+    assert plaid_connection_model.query.filter_by(user_id=owner_id).count() == 0
+
+
+def test_enforce_user_access_removes_plaid_on_expiry(
+    flask_app, app_ctx, user_model, plaid_connection_model, plaid_service_module
+):
+    """enforce_user_access flips owners + guests to inactive when the owner's
+    subscription is no longer current; Plaid Items must be detached for any
+    user that just lost access."""
+    from app.subscription import enforce_user_access
+
+    db = app_ctx
+    flask_app.config["PAYMENTS_ENABLED"] = True
+    try:
+        owner = user_model(
+            email="owner-enforce-lapse@test.local",
+            password=generate_password_hash("testpass123", method="scrypt"),
+            name="Enforce Lapse Owner",
+            admin=True,
+            is_active=True,
+            account_owner_id=None,
+            is_global_admin=False,
+        )
+        db.session.add(owner)
+        db.session.flush()
+        db.session.add(plaid_connection_model(
+            user_id=owner.id,
+            encrypted_access_token=encrypt_password("access-enforce"),
+            plaid_item_id="item-enforce",
+            plaid_account_id="acct-enforce",
+            is_active=True,
+        ))
+        db.session.commit()
+        owner_id = owner.id
+
+        _enable_plaid(flask_app)
+        try:
+            with patch.object(plaid_service_module, "_plaid_client") as mock_client:
+                assert enforce_user_access(owner) is False
+                assert mock_client.return_value.item_remove.call_count == 1
+        finally:
+            _disable_plaid(flask_app)
+
+        assert user_model.query.filter_by(id=owner_id).first().is_active is False
+        assert plaid_connection_model.query.filter_by(user_id=owner_id).count() == 0
+    finally:
+        flask_app.config["PAYMENTS_ENABLED"] = False
 
 
 class TestGuestOnboarding:


### PR DESCRIPTION
## Summary
This PR ensures that Plaid Items are properly detached (via the `/item/remove` API) whenever users lose access to the application or are deleted. This prevents Plaid from continuing to bill us for Transactions subscriptions on Items that are no longer in use.

## Key Changes

- **New `_detach_plaid_item()` function in `plaid_service.py`**: Extracted common logic for best-effort Plaid item removal into a reusable helper that handles API exceptions gracefully without propagating errors to callers.

- **New `remove_plaid_connections_for_user_ids()` function in `plaid_service.py`**: Bulk removal function that detaches Plaid Items for multiple users at once, with optional transaction commit control.

- **User deletion flow (`main.py`)**: Updated `_cascade_delete_user()` to call `remove_plaid_connections_for_user_ids()` before deleting user records, ensuring Plaid is notified before local data is removed.

- **Subscription expiration (`subscription.py`)**: Updated `apply_subscription_status()` to detach Plaid Items when a user's subscription expires and they become inactive.

- **Access enforcement (`subscription.py`)**: Updated `enforce_user_access()` to detach Plaid Items for both account owners and their guests when access is revoked due to expired subscriptions.

- **Comprehensive test coverage**: Added three new test suites covering user deletion with Plaid connections, subscription expiration scenarios, and access enforcement with Plaid cleanup.

## Implementation Details

- All Plaid API calls are best-effort and never raise exceptions to callers; failures are logged as warnings but don't prevent local record deletion.
- The `_detach_plaid_item()` function checks if Plaid is configured before attempting API calls, avoiding unnecessary errors in non-Plaid environments.
- Bulk operations support optional transaction commits to allow callers to batch multiple operations before committing.
- Tests use mocking to verify that `item_remove` is called the correct number of times in each scenario.

https://claude.ai/code/session_01GBZYo4ohNZpLHzragfxzh2