### PR TITLE
Increase TOTP input maxlength and remove numeric inputmode

### DIFF
--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -702,7 +702,7 @@
                         </label>
                         <input class="form-control-modern" type="text" name="totp_code"
                                placeholder="6-digit code or backup code"
-                               maxlength="10" inputmode="numeric" autocomplete="one-time-code"
+                               maxlength="32" autocomplete="one-time-code"
                                style="letter-spacing: 0.25em; text-align: center;">
                         <small style="color: var(--text-secondary); font-size: 0.75rem; margin-top: 0.25rem; display: block;">
                             Enter the current code from your authenticator app, or a backup code.

--- a/app/templates/settings_guest.html
+++ b/app/templates/settings_guest.html
@@ -453,7 +453,7 @@
                         </label>
                         <input class="form-control-modern" type="text" name="totp_code"
                                placeholder="6-digit code or backup code"
-                               maxlength="10" inputmode="numeric" autocomplete="one-time-code"
+                               maxlength="32" autocomplete="one-time-code"
                                style="letter-spacing: 0.25em; text-align: center;">
                         <small style="color: var(--text-secondary); font-size: 0.75rem; margin-top: 0.25rem; display: block;">
                             Enter the current code from your authenticator app, or a backup code.


### PR DESCRIPTION
## Summary
Updated TOTP code input fields to support longer backup codes by increasing the maximum length constraint and removing the numeric-only input mode restriction.

## Key Changes
- Increased `maxlength` from 10 to 32 characters in TOTP input fields to accommodate backup codes which can be longer than 6-digit authenticator codes
- Removed `inputmode="numeric"` attribute to allow users to enter backup codes that may contain letters or special characters
- Applied changes to both `settings.html` and `settings_guest.html` templates for consistency

## Implementation Details
The changes allow the TOTP input field to accept both:
- Standard 6-digit time-based one-time passwords from authenticator apps
- Longer backup codes that may exceed the previous 10-character limit and contain non-numeric characters

The `autocomplete="one-time-code"` attribute is retained to maintain browser support for autofill functionality.

https://claude.ai/code/session_01Vkp2FdxMVt5Mtk9ipqPEbu