### PR TITLE
Add manual real-time Plaid balance refresh (24h rate-limited)

### DIFF
--- a/app/api/routes/plaid.py
+++ b/app/api/routes/plaid.py
@@ -136,19 +136,49 @@ def api_plaid_update_balance():
     return api_ok(result)
 
 
+def _cooldown_error_response(result: dict):
+    """Build the 429 envelope for a cooldown-blocked realtime refresh.
+
+    Uses the standard ``{error, code, status}`` envelope so existing clients
+    can decode it, plus extra top-level fields (``retry_after_seconds``,
+    ``next_available_refresh_at``) and a ``Retry-After`` header so the UI
+    can disable the button until the window opens.
+    """
+    retry_after = int(result.get("retry_after_seconds") or 0)
+    body = {
+        "error": "Live balance refresh is available once every 24 hours.",
+        "code": "plaid_realtime_cooldown",
+        "status": 429,
+        "retry_after_seconds": retry_after,
+        "last_realtime_balance_at": result.get("last_realtime_balance_at"),
+        "next_available_refresh_at": result.get("next_available_refresh_at"),
+    }
+    response = jsonify(body)
+    response.status_code = 429
+    if retry_after > 0:
+        response.headers["Retry-After"] = str(retry_after)
+    return response
+
+
 @api.route("/plaid/realtime-balance", methods=["POST"])
 @api_login_required(require_bearer=True)
 @limiter.limit("60 per hour")
 def api_plaid_realtime_balance():
     """Force-refresh today's balance via Plaid's billed /accounts/balance/get.
 
-    Server-enforced: at most one successful refresh per connection every 24
-    hours. Callers that hit the cooldown receive HTTP 429 with a
-    ``retry_after_seconds`` field so the UI can disable the button.
+    Server-enforced: at most one attempted refresh per connection every 24
+    hours. The cooldown timestamp is claimed before the Plaid call so a
+    failed-but-billed call still consumes the window and rapid double-clicks
+    cannot trigger duplicate paid calls.
+
+    Callers that hit the cooldown receive HTTP 429 with ``retry_after_seconds``
+    plus ``next_available_refresh_at`` so the UI can disable the button.
     """
     if (resp := _forbid_guest_writes()) is not None:
         return resp
+
     owner = _balance_owner_user()
+
     try:
         result = realtime_update_plaid_balance_for_user(owner)
     except Exception:
@@ -158,24 +188,57 @@ def api_plaid_realtime_balance():
             502,
         )
 
-    if result.get("status") == "rate_limited":
-        retry_after = int(result.get("retry_after_seconds") or 0)
-        body = {
-            "error": "Balance refresh is available once every 24 hours.",
-            "code": "plaid_realtime_cooldown",
-            "status": 429,
-            "retry_after_seconds": retry_after,
-            "last_realtime_balance_at": result.get("last_realtime_balance_at"),
-        }
-        response = jsonify(body)
-        response.status_code = 429
-        if retry_after > 0:
-            response.headers["Retry-After"] = str(retry_after)
-        return response
-    if result.get("status") == "error":
+    status = result.get("status")
+    reason = result.get("reason")
+
+    if status == "skipped" and reason == "no_connection":
+        return api_error(
+            "Connect a Plaid account before using live balance refresh.",
+            "plaid_no_connection",
+            400,
+        )
+
+    if status == "skipped" and reason == "not_configured":
+        return api_error(
+            "Live balance refresh is unavailable right now.",
+            "plaid_not_configured",
+            400,
+        )
+
+    if status == "rate_limited":
+        return _cooldown_error_response(result)
+
+    if status == "skipped" and reason == "no_balance_value":
+        # Plaid was called and billed, but returned no usable balance value.
+        # Surface a successful 200 response so the client can show a friendly
+        # message; the cooldown is already recorded so the next call is
+        # blocked for 24 hours.
+        return api_ok(
+            {
+                "success": False,
+                "message": "Plaid did not return a balance for this account.",
+                "balance": None,
+                "balance_source": None,
+                "refreshed_at": result.get("refreshed_at"),
+                "next_available_refresh_at": result.get("next_available_refresh_at"),
+            }
+        )
+
+    if status == "error":
         return api_error(
             "Could not refresh balance from Plaid.",
             "plaid_error",
             502,
         )
-    return api_ok(result)
+
+    # status == "ok"
+    return api_ok(
+        {
+            "success": True,
+            "message": "Live balance refreshed.",
+            "balance": result.get("amount"),
+            "balance_source": result.get("source"),
+            "refreshed_at": result.get("refreshed_at"),
+            "next_available_refresh_at": result.get("next_available_refresh_at"),
+        }
+    )

--- a/app/api/routes/plaid.py
+++ b/app/api/routes/plaid.py
@@ -1,34 +1,47 @@
 """API endpoints for the Plaid Balance integration.
 
 Endpoints:
-- GET    /api/v1/plaid/status         – is Plaid configured, and is the
-                                        current user connected?
-- POST   /api/v1/plaid/link-token     – create a Plaid Link token
-- POST   /api/v1/plaid/exchange-token – exchange public_token + metadata
-- POST   /api/v1/plaid/remove         – disconnect the current user's account
-- DELETE /api/v1/plaid/remove         – same as POST /remove
-- POST   /api/v1/plaid/update-balance – manual balance refresh trigger
+- GET    /api/v1/plaid/status            – is Plaid configured, and is the
+                                           current user connected?
+- POST   /api/v1/plaid/link-token        – create a Plaid Link token
+- POST   /api/v1/plaid/exchange-token    – exchange public_token + metadata
+- POST   /api/v1/plaid/remove            – disconnect the current user's account
+- DELETE /api/v1/plaid/remove            – same as POST /remove
+- POST   /api/v1/plaid/update-balance    – manual balance refresh trigger
+- POST   /api/v1/plaid/realtime-balance  – paid /accounts/balance/get refresh
+                                           (rate-limited to once per 24h)
 
 All endpoints require login and operate strictly on the authenticated user.
 None of them return access tokens, encrypted tokens, or raw Plaid payloads.
 """
 
-from flask import request
+from flask import jsonify, request
 
 from app import limiter
 from app.api import api
 from app.api.auth_utils import api_login_required, get_api_user
 from app.api.errors import api_error, forbidden
 from app.api.responses import api_ok, api_no_content
+from app.models import User
 from app.plaid_service import (
     PlaidServiceError,
     create_link_token_for_user,
     exchange_public_token_for_user,
     get_plaid_connection_status,
     log_plaid_link_exit_for_user,
+    realtime_update_plaid_balance_for_user,
     remove_plaid_connection_for_user,
     update_plaid_balance_for_user,
 )
+
+
+def _balance_owner_user():
+    """Return the user object whose balance is the source of truth."""
+    user = get_api_user()
+    effective_id = user.owner_user_id or user.account_owner_id or user.id
+    if effective_id == user.id:
+        return user
+    return User.query.get(effective_id)
 
 
 def _service_error(exc: PlaidServiceError):
@@ -115,6 +128,51 @@ def api_plaid_update_balance():
     try:
         result = update_plaid_balance_for_user(user)
     except Exception:
+        return api_error(
+            "Could not refresh balance from Plaid.",
+            "plaid_error",
+            502,
+        )
+    return api_ok(result)
+
+
+@api.route("/plaid/realtime-balance", methods=["POST"])
+@api_login_required(require_bearer=True)
+@limiter.limit("60 per hour")
+def api_plaid_realtime_balance():
+    """Force-refresh today's balance via Plaid's billed /accounts/balance/get.
+
+    Server-enforced: at most one successful refresh per connection every 24
+    hours. Callers that hit the cooldown receive HTTP 429 with a
+    ``retry_after_seconds`` field so the UI can disable the button.
+    """
+    if (resp := _forbid_guest_writes()) is not None:
+        return resp
+    owner = _balance_owner_user()
+    try:
+        result = realtime_update_plaid_balance_for_user(owner)
+    except Exception:
+        return api_error(
+            "Could not refresh balance from Plaid.",
+            "plaid_error",
+            502,
+        )
+
+    if result.get("status") == "rate_limited":
+        retry_after = int(result.get("retry_after_seconds") or 0)
+        body = {
+            "error": "Balance refresh is available once every 24 hours.",
+            "code": "plaid_realtime_cooldown",
+            "status": 429,
+            "retry_after_seconds": retry_after,
+            "last_realtime_balance_at": result.get("last_realtime_balance_at"),
+        }
+        response = jsonify(body)
+        response.status_code = 429
+        if retry_after > 0:
+            response.headers["Retry-After"] = str(retry_after)
+        return response
+    if result.get("status") == "error":
         return api_error(
             "Could not refresh balance from Plaid.",
             "plaid_error",

--- a/app/main.py
+++ b/app/main.py
@@ -607,24 +607,33 @@ def refresh_realtime_balance():
         return redirect(url_for('main.index'))
 
     status = result.get("status")
+    reason = result.get("reason")
     if status == "ok":
-        flash("Balance refreshed from your bank.")
+        flash("Live balance refreshed.")
     elif status == "rate_limited":
         retry_after = int(result.get("retry_after_seconds") or 0)
         hours = max(1, (retry_after + 1800) // 3600)
         flash(
-            f"Balance refresh is limited to once every 24 hours. "
+            "Live refresh is available once every 24 hours. "
             f"Try again in about {hours} hour(s)."
         )
-    elif status == "skipped" and result.get("reason") == "no_connection":
-        flash("Connect a Plaid account in Settings to refresh your balance.")
-    elif status == "skipped" and result.get("reason") == "not_configured":
-        flash("Plaid is not configured.")
-    elif status == "skipped" and result.get("reason") == "no_balance_value":
+    elif status == "skipped" and reason == "no_connection":
+        flash("Connect a Plaid account in Settings > More Settings.")
+    elif status == "skipped" and reason == "not_configured":
+        flash(
+            "Live refresh is unavailable right now. Your cached Plaid balance "
+            "will still update automatically."
+        )
+    elif status == "skipped" and reason == "no_balance_value":
         flash("Plaid did not return a balance for this account.")
     else:
-        flash("Could not refresh balance from Plaid. Please try again later.")
+        flash(
+            "Live refresh is unavailable right now. Your cached Plaid balance "
+            "will still update automatically."
+        )
 
+    # The dashboard route re-runs after this redirect, so any new balance row
+    # is picked up immediately via the existing dashboard calculation helper.
     return redirect(url_for('main.index'))
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -36,6 +36,7 @@ from .ai_insights import (
 from .password_setup import create_password_setup_link
 from .plaid_service import (
     safe_update_plaid_balance_for_user,
+    realtime_update_plaid_balance_for_user,
     remove_plaid_connections_for_user_ids,
 )
 from .totp_utils import (
@@ -581,6 +582,50 @@ def healthz():
     # redirect-free, and side-effect-free so it doesn't pollute access logs
     # or trigger the dashboard Plaid balance refresh.
     return Response('ok', status=200, mimetype='text/plain')
+
+
+@main.route('/refresh_realtime_balance', methods=['POST'])
+@login_required
+@admin_required
+@limiter.limit("60 per hour")
+def refresh_realtime_balance():
+    """Trigger a paid Plaid /accounts/balance/get refresh from the dashboard.
+
+    Rate-limited server-side to once every 24 hours per connection. The
+    dashboard route re-runs after the redirect, so any new balance is
+    reflected immediately.
+    """
+    owner = _get_balance_owner_user()
+    try:
+        result = realtime_update_plaid_balance_for_user(owner)
+    except Exception:
+        logger.exception(
+            "Real-time Plaid balance refresh failed for user %s",
+            getattr(owner, "id", None),
+        )
+        flash("Could not refresh balance from Plaid. Please try again later.")
+        return redirect(url_for('main.index'))
+
+    status = result.get("status")
+    if status == "ok":
+        flash("Balance refreshed from your bank.")
+    elif status == "rate_limited":
+        retry_after = int(result.get("retry_after_seconds") or 0)
+        hours = max(1, (retry_after + 1800) // 3600)
+        flash(
+            f"Balance refresh is limited to once every 24 hours. "
+            f"Try again in about {hours} hour(s)."
+        )
+    elif status == "skipped" and result.get("reason") == "no_connection":
+        flash("Connect a Plaid account in Settings to refresh your balance.")
+    elif status == "skipped" and result.get("reason") == "not_configured":
+        flash("Plaid is not configured.")
+    elif status == "skipped" and result.get("reason") == "no_balance_value":
+        flash("Plaid did not return a balance for this account.")
+    else:
+        flash("Could not refresh balance from Plaid. Please try again later.")
+
+    return redirect(url_for('main.index'))
 
 
 @main.route('/balance', methods=('GET', 'POST'))

--- a/app/models.py
+++ b/app/models.py
@@ -275,9 +275,17 @@ class PlaidConnection(db.Model):
     last_balance_sync_at = db.Column(db.DateTime, nullable=True)
     last_sync_status = db.Column(db.String(64), nullable=True)
     last_sync_error = db.Column(db.String(255), nullable=True)
-    # Last successful /accounts/balance/get call. Used to rate-limit the
+    # Last attempted /accounts/balance/get call. Used to rate-limit the
     # paid real-time refresh to once every 24 hours per user/connection.
+    # Set BEFORE calling Plaid so a failed-but-billed call still consumes
+    # the cooldown window and rapid double-clicks cannot duplicate paid
+    # calls.
     last_realtime_balance_at = db.Column(db.DateTime, nullable=True)
+    # Dedicated status/error columns for the real-time refresh so a Plaid
+    # /accounts/balance/get failure does not overwrite the unrelated status
+    # of the automatic /accounts/get sync (last_sync_status/last_sync_error).
+    last_realtime_refresh_status = db.Column(db.String(64), nullable=True)
+    last_realtime_refresh_error = db.Column(db.String(255), nullable=True)
     created_at = db.Column(
         db.DateTime,
         nullable=False,

--- a/app/models.py
+++ b/app/models.py
@@ -275,6 +275,9 @@ class PlaidConnection(db.Model):
     last_balance_sync_at = db.Column(db.DateTime, nullable=True)
     last_sync_status = db.Column(db.String(64), nullable=True)
     last_sync_error = db.Column(db.String(255), nullable=True)
+    # Last successful /accounts/balance/get call. Used to rate-limit the
+    # paid real-time refresh to once every 24 hours per user/connection.
+    last_realtime_balance_at = db.Column(db.DateTime, nullable=True)
     created_at = db.Column(
         db.DateTime,
         nullable=False,

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -598,6 +598,28 @@ def _today_date() -> date:
     return datetime.today().date()
 
 
+def _normalize_naive_utc(value):
+    """Coerce an ISO datetime string or aware/naive datetime to naive UTC.
+
+    Plaid returns ``balances.last_updated_datetime`` as an ISO 8601 string
+    (per SDK version, sometimes as a parsed ``datetime``). Internal
+    timestamps like ``last_realtime_balance_at`` are naive UTC, so cast
+    both sides to the same form before comparing.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        try:
+            value = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    if not isinstance(value, datetime):
+        return None
+    if value.tzinfo is not None:
+        value = value.astimezone(timezone.utc).replace(tzinfo=None)
+    return value
+
+
 def _upsert_today_balance(user_id: int, amount: float) -> Balance:
     today = _today_date()
     existing = (
@@ -745,6 +767,26 @@ def update_plaid_balance_for_user(user) -> dict:
     balances = getattr(target, "balances", None)
     available = getattr(balances, "available", None) if balances is not None else None
     current = getattr(balances, "current", None) if balances is not None else None
+    cache_updated_at = (
+        getattr(balances, "last_updated_datetime", None)
+        if balances is not None
+        else None
+    )
+
+    # Defense in depth: if Plaid tells us when its cached balance was last
+    # refreshed and that timestamp is older than our most recent real-time
+    # refresh, the cached value is stale relative to the live one we already
+    # wrote. Don't overwrite. (The 5-minute brute-force protection above
+    # covers institutions that don't populate last_updated_datetime.)
+    if (
+        conn.last_realtime_balance_at is not None
+        and cache_updated_at is not None
+        and _normalize_naive_utc(cache_updated_at) < conn.last_realtime_balance_at
+    ):
+        result = {"status": "skipped", "reason": "cache_older_than_realtime"}
+        if cache is not None:
+            cache[user.id] = result
+        return result
 
     if available is not None:
         balance_value = float(available)

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -51,6 +51,13 @@ _BALANCE_SOURCE_REALTIME_CURRENT_FALLBACK = "plaid_realtime_current_balance_fall
 # refresh is rate-limited to once every 24 hours per connection.
 REALTIME_BALANCE_COOLDOWN_SECONDS = 24 * 60 * 60
 
+# How long after a real-time /accounts/balance/get refresh the cached
+# /accounts/get auto-sync is skipped. Plaid does not guarantee that the
+# cached path immediately reflects the freshly-refreshed value, so the
+# auto-sync triggered by the next dashboard load could otherwise overwrite
+# the live balance with stale data.
+REALTIME_BALANCE_PROTECTION_SECONDS = 5 * 60
+
 
 class PlaidServiceError(Exception):
     """Raised for any Plaid-related failure surfaced to a route.
@@ -641,6 +648,21 @@ def update_plaid_balance_for_user(user) -> dict:
         if cache is not None:
             cache[user.id] = result
         return result
+
+    # Don't clobber a freshly-written real-time balance with a possibly-stale
+    # /accounts/get cached value. Plaid does not guarantee that calling
+    # /accounts/get immediately after /accounts/balance/get returns the new
+    # value, so skip the auto-sync briefly after a real-time refresh.
+    if conn.last_realtime_balance_at is not None:
+        age = (
+            datetime.now(timezone.utc).replace(tzinfo=None)
+            - conn.last_realtime_balance_at
+        ).total_seconds()
+        if age < REALTIME_BALANCE_PROTECTION_SECONDS:
+            result = {"status": "skipped", "reason": "realtime_recent"}
+            if cache is not None:
+                cache[user.id] = result
+            return result
 
     from plaid.exceptions import ApiException
     from plaid.model.accounts_get_request import AccountsGetRequest

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -12,12 +12,12 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 from urllib.parse import urlsplit, urlunsplit
 
 from flask import current_app, g
-from sqlalchemy import desc
+from sqlalchemy import desc, or_
 
 from app import db
 from app.crypto_utils import encrypt_password, decrypt_password
@@ -200,12 +200,11 @@ def get_plaid_connection_status(user) -> dict:
         ),
         "last_sync_status": conn.last_sync_status,
         "last_sync_error": conn.last_sync_error,
-        "last_realtime_balance_at": (
-            conn.last_realtime_balance_at.replace(microsecond=0).isoformat() + "Z"
-            if conn.last_realtime_balance_at
-            else None
-        ),
+        "last_realtime_balance_at": _iso_utc(conn.last_realtime_balance_at),
+        "last_realtime_refresh_status": conn.last_realtime_refresh_status,
+        "last_realtime_refresh_error": conn.last_realtime_refresh_error,
         "realtime_refresh_retry_after_seconds": _seconds_until_realtime_refresh(conn),
+        "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
     }
     return payload
 
@@ -767,6 +766,12 @@ def safe_update_plaid_balance_for_user(user) -> None:
 # ── Real-time balance refresh (/accounts/balance/get) ────────────────────────
 
 
+def _iso_utc(value: Optional[datetime]) -> Optional[str]:
+    if value is None:
+        return None
+    return value.replace(microsecond=0).isoformat() + "Z"
+
+
 def _seconds_until_realtime_refresh(conn: PlaidConnection) -> int:
     """Return seconds remaining before the next real-time refresh is allowed.
 
@@ -781,13 +786,66 @@ def _seconds_until_realtime_refresh(conn: PlaidConnection) -> int:
     return max(remaining, 0)
 
 
+def _next_available_refresh_at(conn: PlaidConnection) -> Optional[datetime]:
+    if conn.last_realtime_balance_at is None:
+        return None
+    return conn.last_realtime_balance_at + timedelta(
+        seconds=REALTIME_BALANCE_COOLDOWN_SECONDS
+    )
+
+
+def _record_realtime_status(
+    conn: PlaidConnection, status: str, error: Optional[str]
+) -> None:
+    """Write the dedicated real-time refresh status/error columns.
+
+    Kept separate from ``_record_sync_status`` so a failed paid call cannot
+    overwrite the unrelated status of the automatic /accounts/get sync.
+    """
+    conn.last_realtime_refresh_status = status[:64] if status else None
+    conn.last_realtime_refresh_error = error[:255] if error else None
+
+
+def _claim_realtime_refresh_slot(conn_id: int) -> bool:
+    """Atomically reserve the next 24-hour real-time refresh window.
+
+    Updates ``last_realtime_balance_at`` to *now* only when the previous
+    value is null or older than the cooldown. Returns True if this caller
+    won the race and may now call Plaid; False if another caller is already
+    inside (or has just consumed) the window. The pre-call write ensures
+    that even a failed-but-billed Plaid call consumes the cooldown.
+    """
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    cutoff = now - timedelta(seconds=REALTIME_BALANCE_COOLDOWN_SECONDS)
+    updated = (
+        db.session.query(PlaidConnection)
+        .filter(
+            PlaidConnection.id == conn_id,
+            or_(
+                PlaidConnection.last_realtime_balance_at.is_(None),
+                PlaidConnection.last_realtime_balance_at <= cutoff,
+            ),
+        )
+        .update(
+            {PlaidConnection.last_realtime_balance_at: now},
+            synchronize_session=False,
+        )
+    )
+    db.session.commit()
+    return updated == 1
+
+
 def realtime_update_plaid_balance_for_user(user) -> dict:
     """Force-refresh today's balance from Plaid's /accounts/balance/get endpoint.
 
-    Plaid charges per call for this product, so callers are rate-limited to one
-    successful refresh every ``REALTIME_BALANCE_COOLDOWN_SECONDS`` per
-    connection. Returns a status dict; never returns Plaid secrets or raw
-    payloads.
+    Plaid charges per call for this product, so callers are rate-limited to
+    one *attempted* refresh every ``REALTIME_BALANCE_COOLDOWN_SECONDS`` per
+    connection. The cooldown timestamp is reserved with an atomic conditional
+    UPDATE before the Plaid call is made — that way a failed-but-billed call
+    still consumes the window, and rapid double-clicks cannot trigger
+    duplicate paid calls.
+
+    Returns a status dict; never returns Plaid secrets or raw payloads.
     """
     if user is None or not getattr(user, "id", None):
         return {"status": "skipped", "reason": "no_user"}
@@ -799,18 +857,22 @@ def realtime_update_plaid_balance_for_user(user) -> dict:
     if conn is None:
         return {"status": "skipped", "reason": "no_connection"}
 
-    retry_after = _seconds_until_realtime_refresh(conn)
-    if retry_after > 0:
+    # Atomic pre-call cooldown claim: succeeds only when the previous
+    # refresh was >= 24 hours ago (or never).
+    if not _claim_realtime_refresh_slot(conn.id):
+        # Reload to see the existing timestamp written by whoever owns the slot.
+        db.session.refresh(conn)
         return {
             "status": "rate_limited",
             "reason": "cooldown_active",
-            "retry_after_seconds": retry_after,
-            "last_realtime_balance_at": (
-                conn.last_realtime_balance_at.replace(microsecond=0).isoformat() + "Z"
-                if conn.last_realtime_balance_at
-                else None
-            ),
+            "retry_after_seconds": _seconds_until_realtime_refresh(conn),
+            "last_realtime_balance_at": _iso_utc(conn.last_realtime_balance_at),
+            "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
         }
+
+    # Slot reserved — refresh local state so we see the new timestamp.
+    db.session.refresh(conn)
+    refreshed_at = conn.last_realtime_balance_at
 
     from plaid.exceptions import ApiException
     from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
@@ -825,9 +887,16 @@ def realtime_update_plaid_balance_for_user(user) -> dict:
             "Could not decrypt Plaid access token for user %s (realtime refresh)",
             user.id,
         )
-        _record_sync_status(conn, "decrypt_failed", "Stored Plaid token could not be read.")
+        _record_realtime_status(
+            conn, "decrypt_failed", "Stored Plaid token could not be read."
+        )
         db.session.commit()
-        return {"status": "error", "reason": "decrypt_failed"}
+        return {
+            "status": "error",
+            "reason": "decrypt_failed",
+            "refreshed_at": _iso_utc(refreshed_at),
+            "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
+        }
 
     try:
         client = _plaid_client()
@@ -849,23 +918,33 @@ def realtime_update_plaid_balance_for_user(user) -> dict:
             info.get("error_code"),
             info.get("error_message"),
         )
-        _record_sync_status(
+        _record_realtime_status(
             conn, "plaid_realtime_api_error", "Plaid real-time balance request failed."
         )
         db.session.commit()
-        return {"status": "error", "reason": "plaid_api_error"}
+        return {
+            "status": "error",
+            "reason": "plaid_api_error",
+            "refreshed_at": _iso_utc(refreshed_at),
+            "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
+        }
     except Exception:
         logger.exception(
             "Unexpected error calling Plaid /accounts/balance/get for user %s", user.id
         )
-        _record_sync_status(
+        _record_realtime_status(
             conn, "plaid_realtime_unexpected_error", "Unexpected Plaid error."
         )
         try:
             db.session.commit()
         except Exception:
             db.session.rollback()
-        return {"status": "error", "reason": "unexpected_error"}
+        return {
+            "status": "error",
+            "reason": "unexpected_error",
+            "refreshed_at": _iso_utc(refreshed_at),
+            "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
+        }
 
     target = None
     try:
@@ -878,13 +957,18 @@ def realtime_update_plaid_balance_for_user(user) -> dict:
             break
 
     if target is None:
-        _record_sync_status(
+        _record_realtime_status(
             conn,
             "account_not_found",
             "Connected Plaid account was not in the balance response.",
         )
         db.session.commit()
-        return {"status": "error", "reason": "account_not_found"}
+        return {
+            "status": "error",
+            "reason": "account_not_found",
+            "refreshed_at": _iso_utc(refreshed_at),
+            "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
+        }
 
     balances = getattr(target, "balances", None)
     available = getattr(balances, "available", None) if balances is not None else None
@@ -897,26 +981,26 @@ def realtime_update_plaid_balance_for_user(user) -> dict:
         balance_value = float(current)
         source = _BALANCE_SOURCE_REALTIME_CURRENT_FALLBACK
     else:
-        # The call still counts against Plaid billing, so record the cooldown
-        # to prevent rapid retries even when no usable balance was returned.
-        now = datetime.now(timezone.utc).replace(tzinfo=None)
-        conn.last_realtime_balance_at = now
-        _record_sync_status(
+        _record_realtime_status(
             conn,
             "no_balance_value",
             "Plaid did not return available or current balance.",
         )
         db.session.commit()
-        return {"status": "skipped", "reason": "no_balance_value"}
+        return {
+            "status": "skipped",
+            "reason": "no_balance_value",
+            "refreshed_at": _iso_utc(refreshed_at),
+            "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
+        }
 
     _upsert_today_balance(user.id, balance_value)
-    now = datetime.now(timezone.utc).replace(tzinfo=None)
-    conn.last_realtime_balance_at = now
-    _record_sync_status(conn, source, None)
+    _record_realtime_status(conn, source, None)
     db.session.commit()
     return {
         "status": "ok",
         "source": source,
         "amount": balance_value,
-        "last_realtime_balance_at": now.replace(microsecond=0).isoformat() + "Z",
+        "refreshed_at": _iso_utc(refreshed_at),
+        "next_available_refresh_at": _iso_utc(_next_available_refresh_at(conn)),
     }

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -44,6 +44,12 @@ _ALLOWED_ACCOUNT_SUBTYPES = {
 
 _BALANCE_SOURCE_AVAILABLE = "plaid_available_balance"
 _BALANCE_SOURCE_CURRENT_FALLBACK = "plaid_current_balance_fallback"
+_BALANCE_SOURCE_REALTIME_AVAILABLE = "plaid_realtime_available_balance"
+_BALANCE_SOURCE_REALTIME_CURRENT_FALLBACK = "plaid_realtime_current_balance_fallback"
+
+# Plaid charges per /accounts/balance/get call, so the manual real-time
+# refresh is rate-limited to once every 24 hours per connection.
+REALTIME_BALANCE_COOLDOWN_SECONDS = 24 * 60 * 60
 
 
 class PlaidServiceError(Exception):
@@ -194,6 +200,12 @@ def get_plaid_connection_status(user) -> dict:
         ),
         "last_sync_status": conn.last_sync_status,
         "last_sync_error": conn.last_sync_error,
+        "last_realtime_balance_at": (
+            conn.last_realtime_balance_at.replace(microsecond=0).isoformat() + "Z"
+            if conn.last_realtime_balance_at
+            else None
+        ),
+        "realtime_refresh_retry_after_seconds": _seconds_until_realtime_refresh(conn),
     }
     return payload
 
@@ -750,3 +762,161 @@ def safe_update_plaid_balance_for_user(user) -> None:
             db.session.rollback()
         except Exception:
             pass
+
+
+# ── Real-time balance refresh (/accounts/balance/get) ────────────────────────
+
+
+def _seconds_until_realtime_refresh(conn: PlaidConnection) -> int:
+    """Return seconds remaining before the next real-time refresh is allowed.
+
+    Zero means a refresh is allowed now. Treat any value > 0 as rate-limited.
+    """
+    last = conn.last_realtime_balance_at
+    if last is None:
+        return 0
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    elapsed = (now - last).total_seconds()
+    remaining = REALTIME_BALANCE_COOLDOWN_SECONDS - int(elapsed)
+    return max(remaining, 0)
+
+
+def realtime_update_plaid_balance_for_user(user) -> dict:
+    """Force-refresh today's balance from Plaid's /accounts/balance/get endpoint.
+
+    Plaid charges per call for this product, so callers are rate-limited to one
+    successful refresh every ``REALTIME_BALANCE_COOLDOWN_SECONDS`` per
+    connection. Returns a status dict; never returns Plaid secrets or raw
+    payloads.
+    """
+    if user is None or not getattr(user, "id", None):
+        return {"status": "skipped", "reason": "no_user"}
+
+    if not plaid_is_configured():
+        return {"status": "skipped", "reason": "not_configured"}
+
+    conn = get_active_connection(user)
+    if conn is None:
+        return {"status": "skipped", "reason": "no_connection"}
+
+    retry_after = _seconds_until_realtime_refresh(conn)
+    if retry_after > 0:
+        return {
+            "status": "rate_limited",
+            "reason": "cooldown_active",
+            "retry_after_seconds": retry_after,
+            "last_realtime_balance_at": (
+                conn.last_realtime_balance_at.replace(microsecond=0).isoformat() + "Z"
+                if conn.last_realtime_balance_at
+                else None
+            ),
+        }
+
+    from plaid.exceptions import ApiException
+    from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
+    from plaid.model.accounts_balance_get_request_options import (
+        AccountsBalanceGetRequestOptions,
+    )
+
+    try:
+        access_token = decrypt_password(conn.encrypted_access_token)
+    except Exception:
+        logger.warning(
+            "Could not decrypt Plaid access token for user %s (realtime refresh)",
+            user.id,
+        )
+        _record_sync_status(conn, "decrypt_failed", "Stored Plaid token could not be read.")
+        db.session.commit()
+        return {"status": "error", "reason": "decrypt_failed"}
+
+    try:
+        client = _plaid_client()
+        request = AccountsBalanceGetRequest(
+            access_token=access_token,
+            options=AccountsBalanceGetRequestOptions(
+                account_ids=[conn.plaid_account_id]
+            ),
+        )
+        response = client.accounts_balance_get(request)
+    except ApiException as exc:
+        info = _plaid_error_info(exc)
+        logger.warning(
+            "Plaid accounts_balance_get failed for user %s "
+            "(request_id=%s, error_type=%s, error_code=%s, error_message=%s)",
+            user.id,
+            info.get("request_id"),
+            info.get("error_type"),
+            info.get("error_code"),
+            info.get("error_message"),
+        )
+        _record_sync_status(
+            conn, "plaid_realtime_api_error", "Plaid real-time balance request failed."
+        )
+        db.session.commit()
+        return {"status": "error", "reason": "plaid_api_error"}
+    except Exception:
+        logger.exception(
+            "Unexpected error calling Plaid /accounts/balance/get for user %s", user.id
+        )
+        _record_sync_status(
+            conn, "plaid_realtime_unexpected_error", "Unexpected Plaid error."
+        )
+        try:
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+        return {"status": "error", "reason": "unexpected_error"}
+
+    target = None
+    try:
+        accounts = list(response.accounts or [])
+    except Exception:
+        accounts = []
+    for acct in accounts:
+        if str(getattr(acct, "account_id", "")) == conn.plaid_account_id:
+            target = acct
+            break
+
+    if target is None:
+        _record_sync_status(
+            conn,
+            "account_not_found",
+            "Connected Plaid account was not in the balance response.",
+        )
+        db.session.commit()
+        return {"status": "error", "reason": "account_not_found"}
+
+    balances = getattr(target, "balances", None)
+    available = getattr(balances, "available", None) if balances is not None else None
+    current = getattr(balances, "current", None) if balances is not None else None
+
+    if available is not None:
+        balance_value = float(available)
+        source = _BALANCE_SOURCE_REALTIME_AVAILABLE
+    elif current is not None:
+        balance_value = float(current)
+        source = _BALANCE_SOURCE_REALTIME_CURRENT_FALLBACK
+    else:
+        # The call still counts against Plaid billing, so record the cooldown
+        # to prevent rapid retries even when no usable balance was returned.
+        now = datetime.now(timezone.utc).replace(tzinfo=None)
+        conn.last_realtime_balance_at = now
+        _record_sync_status(
+            conn,
+            "no_balance_value",
+            "Plaid did not return available or current balance.",
+        )
+        db.session.commit()
+        return {"status": "skipped", "reason": "no_balance_value"}
+
+    _upsert_today_balance(user.id, balance_value)
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    conn.last_realtime_balance_at = now
+    _record_sync_status(conn, source, None)
+    db.session.commit()
+    return {
+        "status": "ok",
+        "source": source,
+        "amount": balance_value,
+        "last_realtime_balance_at": now.replace(microsecond=0).isoformat() + "Z",
+    }

--- a/app/static/css/improved.css
+++ b/app/static/css/improved.css
@@ -362,6 +362,44 @@ body::before {
   background: linear-gradient(135deg, rgba(59, 130, 246, 0.1) 0%, var(--primary-dark) 100%);
 }
 
+/* Plaid real-time balance refresh icon button (top-right of Balance card). */
+.balance-card {
+  position: relative;
+}
+
+.balance-refresh-form {
+  position: absolute;
+  top: var(--spacing-md);
+  right: var(--spacing-md);
+  margin: 0;
+}
+
+.balance-refresh-btn {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding: 0;
+  transition: all 0.2s ease;
+}
+
+.balance-refresh-btn:hover:not(:disabled) {
+  background-color: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.balance-refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 .metric-card.warning {
   border: 2px solid var(--warning);
   background: linear-gradient(135deg, rgba(245, 158, 11, 0.1) 0%, var(--primary-dark) 100%);

--- a/app/static/css/improved.css
+++ b/app/static/css/improved.css
@@ -400,6 +400,10 @@ body::before {
   cursor: not-allowed;
 }
 
+.balance-refresh-icon--spinning {
+  animation: rotate 1s linear infinite;
+}
+
 .metric-card.warning {
   border: 2px solid var(--warning);
   background: linear-gradient(135deg, rgba(245, 158, 11, 0.1) 0%, var(--primary-dark) 100%);

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,7 +14,13 @@
 <!-- Metrics Grid -->
 <div class="metrics-grid">
     <!-- Current Balance Card -->
-    <div class="metric-card highlight">
+    <div class="metric-card highlight balance-card">
+        <form action="{{ url_for('main.refresh_realtime_balance') }}" method="POST" class="balance-refresh-form">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+            <button type="submit" class="balance-refresh-btn" title="Refresh balance from your bank" aria-label="Refresh balance from your bank">
+                <i class="fa-solid fa-arrows-rotate"></i>
+            </button>
+        </form>
         <div class="metric-label">
             <i class="fa-solid fa-wallet"></i> Current Balance
         </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -15,10 +15,10 @@
 <div class="metrics-grid">
     <!-- Current Balance Card -->
     <div class="metric-card highlight balance-card">
-        <form action="{{ url_for('main.refresh_realtime_balance') }}" method="POST" class="balance-refresh-form">
+        <form action="{{ url_for('main.refresh_realtime_balance') }}" method="POST" class="balance-refresh-form" onsubmit="onRealtimeRefreshSubmit(this);">
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <button type="submit" class="balance-refresh-btn" title="Refresh balance from your bank" aria-label="Refresh balance from your bank">
-                <i class="fa-solid fa-arrows-rotate"></i>
+            <button type="submit" class="balance-refresh-btn" title="Refresh live balance — available once every 24 hours" aria-label="Refresh live balance">
+                <i class="fa-solid fa-arrows-rotate balance-refresh-icon"></i>
             </button>
         </form>
         <div class="metric-label">
@@ -603,6 +603,16 @@
         const localStr = new Date(utc).toLocaleString([], {year:'numeric', month:'short', day:'numeric', hour:'numeric', minute:'2-digit'});
         el.innerHTML = '<i class="fa-solid fa-clock"></i> Last updated: ' + localStr;
     })();
+
+    // Prevent rapid double-clicks on the live balance refresh button while
+    // the POST is in flight; the dashboard reload after the redirect will
+    // re-render the (re-enabled) button automatically.
+    function onRealtimeRefreshSubmit(form) {
+        const btn = form.querySelector('.balance-refresh-btn');
+        const icon = form.querySelector('.balance-refresh-icon');
+        if (btn) btn.disabled = true;
+        if (icon) icon.classList.add('balance-refresh-icon--spinning');
+    }
 </script>
 
 {% endblock %}

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
@@ -125,12 +125,12 @@ struct BalanceDTO: Decodable, Identifiable {
 }
 
 struct PlaidRealtimeBalanceDTO: Decodable {
-    let status: String?
-    let source: String?
-    let amount: Double?
-    let reason: String?
-    let last_realtime_balance_at: String?
-    let retry_after_seconds: Int?
+    let success: Bool?
+    let message: String?
+    let balance: Double?
+    let balance_source: String?
+    let refreshed_at: String?
+    let next_available_refresh_at: String?
 }
 
 struct ScheduleDTO: Decodable, Identifiable {

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Models/APIModels.swift
@@ -124,6 +124,15 @@ struct BalanceDTO: Decodable, Identifiable {
     let date: String
 }
 
+struct PlaidRealtimeBalanceDTO: Decodable {
+    let status: String?
+    let source: String?
+    let amount: Double?
+    let reason: String?
+    let last_realtime_balance_at: String?
+    let retry_after_seconds: Int?
+}
+
 struct ScheduleDTO: Decodable, Identifiable {
     let id: Int
     let name: String

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
@@ -6,15 +6,37 @@ struct BalanceView: View {
     @State private var history: [BalanceDTO] = []
     @State private var newAmount = ""
     @State private var errorText: String?
+    @State private var statusText: String?
+    @State private var isRefreshing: Bool = false
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
                 if let balance {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Current Balance")
-                            .font(.caption)
-                            .foregroundStyle(AppTheme.textMuted)
+                        HStack(spacing: 8) {
+                            Text("Current Balance")
+                                .font(.caption)
+                                .foregroundStyle(AppTheme.textMuted)
+                            Spacer()
+                            Button {
+                                Task { await refreshRealtimeBalance() }
+                            } label: {
+                                Image(systemName: "arrow.clockwise.circle")
+                                    .font(.title3)
+                                    .foregroundStyle(AppTheme.textSecondary)
+                                    .rotationEffect(.degrees(isRefreshing ? 360 : 0))
+                                    .animation(
+                                        isRefreshing
+                                            ? .linear(duration: 1).repeatForever(autoreverses: false)
+                                            : .default,
+                                        value: isRefreshing
+                                    )
+                            }
+                            .buttonStyle(.plain)
+                            .disabled(isRefreshing)
+                            .accessibilityLabel("Refresh balance from your bank")
+                        }
                         HStack(spacing: 8) {
                             Text("$\(balance.amount)")
                                 .font(.headline)
@@ -29,6 +51,14 @@ struct BalanceView: View {
                         }
                     }
                     .cardRow()
+                }
+
+                if let statusText {
+                    Text(statusText)
+                        .font(.caption)
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 VStack(spacing: 8) {
@@ -109,6 +139,38 @@ struct BalanceView: View {
             newAmount = ""
         } catch {
             errorText = (error as? APIErrorEnvelope)?.error ?? "Failed to save balance"
+        }
+    }
+
+    private func refreshRealtimeBalance() async {
+        guard let token = session.token else { return }
+        await MainActor.run {
+            isRefreshing = true
+            errorText = nil
+            statusText = nil
+        }
+        defer {
+            Task { @MainActor in isRefreshing = false }
+        }
+        do {
+            _ = try await APIClient.shared.request(
+                "plaid/realtime-balance",
+                method: "POST",
+                token: token,
+                as: APIEnvelope<PlaidRealtimeBalanceDTO>.self
+            )
+            await load()
+            await MainActor.run { statusText = "Balance refreshed from your bank." }
+        } catch let envelope as APIErrorEnvelope {
+            await MainActor.run {
+                if envelope.code == "plaid_realtime_cooldown" {
+                    statusText = envelope.error
+                } else {
+                    errorText = envelope.error
+                }
+            }
+        } catch {
+            await MainActor.run { errorText = "Failed to refresh balance" }
         }
     }
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
@@ -145,6 +145,8 @@ struct BalanceView: View {
     private func refreshRealtimeBalance() async {
         guard let token = session.token else { return }
         await MainActor.run {
+            // Prevent double-taps while the request is in flight.
+            guard !isRefreshing else { return }
             isRefreshing = true
             errorText = nil
             statusText = nil
@@ -153,18 +155,26 @@ struct BalanceView: View {
             Task { @MainActor in isRefreshing = false }
         }
         do {
-            _ = try await APIClient.shared.request(
+            let response: APIEnvelope<PlaidRealtimeBalanceDTO> = try await APIClient.shared.request(
                 "plaid/realtime-balance",
                 method: "POST",
                 token: token,
                 as: APIEnvelope<PlaidRealtimeBalanceDTO>.self
             )
+            // Reload the local balance card from the existing balance API so
+            // the new amount/date show immediately, and trigger a dashboard
+            // reload notification so the Dashboard view picks up the change.
             await load()
-            await MainActor.run { statusText = "Balance refreshed from your bank." }
+            NotificationCenter.default.post(name: .pycashflowDashboardShouldReload, object: nil)
+            await MainActor.run {
+                statusText = response.data.message ?? "Live balance refreshed."
+            }
         } catch let envelope as APIErrorEnvelope {
             await MainActor.run {
                 if envelope.code == "plaid_realtime_cooldown" {
                     statusText = envelope.error
+                } else if envelope.code == "plaid_no_connection" {
+                    errorText = envelope.error
                 } else {
                     errorText = envelope.error
                 }
@@ -173,4 +183,12 @@ struct BalanceView: View {
             await MainActor.run { errorText = "Failed to refresh balance" }
         }
     }
+}
+
+extension Notification.Name {
+    /// Posted by features that mutate the user's balance so the Dashboard
+    /// view can re-fetch its data without a full app refresh.
+    static let pycashflowDashboardShouldReload = Notification.Name(
+        "PyCashFlowDashboardShouldReload"
+    )
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Dashboard/DashboardView.swift
@@ -66,6 +66,11 @@ struct DashboardView: View {
         }
         .task { await loadAll() }
         .refreshable { await loadAll() }
+        .onReceive(
+            NotificationCenter.default.publisher(for: .pycashflowDashboardShouldReload)
+        ) { _ in
+            Task { await loadAll() }
+        }
         .appBackground()
         .navigationTitle("Dashboard")
     }

--- a/migrations/versions/5a7c8e9f1234_add_last_realtime_balance_at.py
+++ b/migrations/versions/5a7c8e9f1234_add_last_realtime_balance_at.py
@@ -1,0 +1,28 @@
+"""add last_realtime_balance_at to plaid_connections
+
+Revision ID: 5a7c8e9f1234
+Revises: 4553e3440cb6
+Create Date: 2026-05-22 20:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '5a7c8e9f1234'
+down_revision = '4553e3440cb6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('plaid_connections', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('last_realtime_balance_at', sa.DateTime(), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('plaid_connections', schema=None) as batch_op:
+        batch_op.drop_column('last_realtime_balance_at')

--- a/migrations/versions/5a7c8e9f1234_add_last_realtime_balance_at.py
+++ b/migrations/versions/5a7c8e9f1234_add_last_realtime_balance_at.py
@@ -1,4 +1,13 @@
-"""add last_realtime_balance_at to plaid_connections
+"""add plaid realtime balance refresh fields
+
+Adds the columns needed to support the manual /accounts/balance/get refresh:
+
+- last_realtime_balance_at: cooldown timestamp claimed before the Plaid call
+  so a failed-but-billed call still consumes the 24-hour window and rapid
+  double-clicks cannot trigger duplicate paid calls.
+- last_realtime_refresh_status / last_realtime_refresh_error: dedicated
+  status/error columns so a real-time refresh failure does not overwrite
+  the unrelated status of the automatic /accounts/get sync.
 
 Revision ID: 5a7c8e9f1234
 Revises: 4553e3440cb6
@@ -21,8 +30,16 @@ def upgrade():
         batch_op.add_column(
             sa.Column('last_realtime_balance_at', sa.DateTime(), nullable=True)
         )
+        batch_op.add_column(
+            sa.Column('last_realtime_refresh_status', sa.String(length=64), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column('last_realtime_refresh_error', sa.String(length=255), nullable=True)
+        )
 
 
 def downgrade():
     with op.batch_alter_table('plaid_connections', schema=None) as batch_op:
+        batch_op.drop_column('last_realtime_refresh_error')
+        batch_op.drop_column('last_realtime_refresh_status')
         batch_op.drop_column('last_realtime_balance_at')

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -1110,3 +1110,455 @@ class TestModelInvariants:
             with pytest.raises(IntegrityError):
                 db.session.commit()
             db.session.rollback()
+
+
+# ── Real-time balance refresh (/accounts/balance/get) ────────────────────────
+
+
+class TestRealtimeBalanceRefresh:
+    """Service-layer tests for ``realtime_update_plaid_balance_for_user``.
+
+    Covers the 24-hour cooldown, the available/current fallback, today-row
+    upsert, and the requirement that no /accounts/get behavior is changed.
+    """
+
+    def test_noop_when_not_configured(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            result = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert result["status"] == "skipped"
+            assert result["reason"] == "not_configured"
+
+    def test_noop_when_no_active_connection(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            user = User.query.get(plaid_user)
+            result = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert result["status"] == "skipped"
+            assert result["reason"] == "no_connection"
+            _deconfigure_plaid(flask_app)
+
+    def test_calls_accounts_balance_get_with_account_id_option(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=123.45, current=200.00)
+                )
+                # The legacy /accounts/get path must not be invoked.
+                mock_client.return_value.accounts_get.side_effect = AssertionError(
+                    "realtime refresh must not call /accounts/get"
+                )
+                result = plaid_service.realtime_update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                assert result["source"] == "plaid_realtime_available_balance"
+                assert result["amount"] == pytest.approx(123.45)
+                # Plaid SDK was called with the stored plaid_account_id filter.
+                args, kwargs = mock_client.return_value.accounts_balance_get.call_args
+                req = args[0] if args else kwargs.get("request")
+                options = getattr(req, "options", None)
+                account_ids = getattr(options, "account_ids", None)
+                assert list(account_ids) == ["acct-1"]
+            _deconfigure_plaid(flask_app)
+
+    def test_prefers_available_over_current(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=500.25, current=600.00)
+                )
+                result = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert result["source"] == "plaid_realtime_available_balance"
+            row = Balance.query.filter_by(user_id=plaid_user, date=date.today()).first()
+            assert float(row.amount) == pytest.approx(500.25)
+            _deconfigure_plaid(flask_app)
+
+    def test_falls_back_to_current_when_available_is_none(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=None, current=800.10)
+                )
+                result = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert result["source"] == "plaid_realtime_current_balance_fallback"
+            row = Balance.query.filter_by(user_id=plaid_user, date=date.today()).first()
+            assert float(row.amount) == pytest.approx(800.10)
+            _deconfigure_plaid(flask_app)
+
+    def test_does_not_overwrite_when_both_balances_are_none(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=999.99, date=date.today())
+            )
+            db.session.commit()
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=None, current=None)
+                )
+                result = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert result["status"] == "skipped"
+            row = Balance.query.filter_by(user_id=plaid_user, date=date.today()).first()
+            assert float(row.amount) == pytest.approx(999.99)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            # Cooldown still consumed because Plaid was called and billed.
+            assert conn.last_realtime_balance_at is not None
+            assert conn.last_realtime_refresh_status == "no_balance_value"
+            _deconfigure_plaid(flask_app)
+
+    def test_updates_existing_today_row_instead_of_creating_duplicate(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=100.0, date=date.today())
+            )
+            db.session.commit()
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=250.0, current=300.0)
+                )
+                plaid_service.realtime_update_plaid_balance_for_user(user)
+            rows = Balance.query.filter_by(
+                user_id=plaid_user, date=date.today()
+            ).all()
+            assert len(rows) == 1
+            assert float(rows[0].amount) == pytest.approx(250.0)
+            _deconfigure_plaid(flask_app)
+
+    def test_creates_today_row_when_missing(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=42.0, current=None)
+                )
+                plaid_service.realtime_update_plaid_balance_for_user(user)
+            row = Balance.query.filter_by(
+                user_id=plaid_user, date=date.today()
+            ).first()
+            assert row is not None
+            assert float(row.amount) == pytest.approx(42.0)
+            _deconfigure_plaid(flask_app)
+
+    def test_24h_cooldown_blocks_second_call(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=10.0, current=20.0)
+                )
+                first = plaid_service.realtime_update_plaid_balance_for_user(user)
+                second = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert first["status"] == "ok"
+            assert second["status"] == "rate_limited"
+            assert second["reason"] == "cooldown_active"
+            assert second["retry_after_seconds"] > 0
+            # Only one paid Plaid call should have been made.
+            assert mock_client.return_value.accounts_balance_get.call_count == 1
+            _deconfigure_plaid(flask_app)
+
+    def test_cooldown_expires_after_24_hours(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            # Pretend the last refresh was just over 24h ago.
+            conn.last_realtime_balance_at = datetime.utcnow() - timedelta(
+                hours=24, minutes=1
+            )
+            db.session.commit()
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=77.0, current=None)
+                )
+                result = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert result["status"] == "ok"
+            assert mock_client.return_value.accounts_balance_get.call_count == 1
+            _deconfigure_plaid(flask_app)
+
+    def test_failed_call_still_consumes_cooldown(self, flask_app, plaid_user):
+        """Plaid charges per attempt — failures must consume the 24h window."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.side_effect = (
+                    RuntimeError("boom")
+                )
+                first = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert first["status"] == "error"
+            assert first["reason"] == "unexpected_error"
+            # Second call within the window must NOT trigger another Plaid call.
+            with patch.object(plaid_service, "_plaid_client") as mock_client2:
+                second = plaid_service.realtime_update_plaid_balance_for_user(user)
+            assert second["status"] == "rate_limited"
+            assert mock_client2.return_value.accounts_balance_get.call_count == 0
+            _deconfigure_plaid(flask_app)
+
+    def test_does_not_overwrite_regular_sync_status(self, flask_app, plaid_user):
+        """A realtime failure must not clobber last_sync_status from /accounts/get."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            conn.last_sync_status = "plaid_available_balance"
+            conn.last_sync_error = None
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.side_effect = (
+                    RuntimeError("boom")
+                )
+                plaid_service.realtime_update_plaid_balance_for_user(user)
+
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            # Automatic sync status is untouched.
+            assert conn.last_sync_status == "plaid_available_balance"
+            assert conn.last_sync_error is None
+            # Dedicated realtime status reflects the failure.
+            assert conn.last_realtime_refresh_status == "plaid_realtime_unexpected_error"
+            assert conn.last_realtime_refresh_error
+            _deconfigure_plaid(flask_app)
+
+    def test_does_not_run_on_dashboard_load(self, auth_client, flask_app):
+        """The dashboard load must continue to use /accounts/get only, never the paid endpoint."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        with patch.object(
+            plaid_service, "realtime_update_plaid_balance_for_user"
+        ) as mock_realtime:
+            resp = auth_client.get("/")
+            assert resp.status_code == 200
+            assert not mock_realtime.called
+        with patch("app.api.routes.data.safe_update_plaid_balance_for_user"):
+            with patch.object(
+                plaid_service, "realtime_update_plaid_balance_for_user"
+            ) as mock_realtime:
+                resp = auth_client.get("/api/v1/dashboard")
+                assert resp.status_code == 200
+                assert not mock_realtime.called
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+
+
+def _csrf_headers_for(client):
+    """Fetch a CSRF token via the settings page so cookie-auth API writes work.
+
+    The realtime-balance route uses ``require_bearer=True``; tests using
+    Flask-Login cookie auth must therefore also send a valid X-CSRFToken.
+    """
+    html = client.get("/settings").get_data(as_text=True)
+    marker = 'meta name="csrf-token" content="'
+    idx = html.find(marker)
+    assert idx != -1, "CSRF token meta tag not found in /settings"
+    start = idx + len(marker)
+    end = html.find('"', start)
+    return {"X-CSRFToken": html[start:end]}
+
+
+class TestRealtimeBalanceAPIRoute:
+    def test_requires_authentication(self, flask_app):
+        client = flask_app.test_client()
+        resp = client.post("/api/v1/plaid/realtime-balance")
+        # Unauthenticated requests should be rejected (401 or 403, not 200).
+        assert resp.status_code in (401, 403)
+
+    def test_does_not_accept_user_id_from_client(
+        self, auth_client, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        headers = _csrf_headers_for(auth_client)
+        with patch.object(plaid_service, "_plaid_client") as mock_client:
+            mock_client.return_value.accounts_balance_get.return_value = (
+                _make_balances_response("acct-1", available=1.0, current=2.0)
+            )
+            # Spoofing a different user_id in the body must be ignored —
+            # the route operates only on the authenticated user.
+            resp = auth_client.post(
+                "/api/v1/plaid/realtime-balance",
+                headers=headers,
+                json={"user_id": plaid_user},
+            )
+        # The seeded admin user has no Plaid connection, so the call returns
+        # plaid_no_connection — NOT a successful refresh of the spoofed user.
+        assert resp.status_code == 400
+        body = resp.get_json()
+        assert body["code"] == "plaid_no_connection"
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)
+
+    def test_returns_429_with_retry_after_on_cooldown(
+        self, auth_client, flask_app
+    ):
+        from conftest import _ADMIN_USER_ID
+
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(_ADMIN_USER_ID)
+        try:
+            headers = _csrf_headers_for(auth_client)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=5.0, current=6.0)
+                )
+                first = auth_client.post(
+                    "/api/v1/plaid/realtime-balance", headers=headers
+                )
+                second = auth_client.post(
+                    "/api/v1/plaid/realtime-balance", headers=headers
+                )
+            assert first.status_code == 200
+            assert first.get_json()["data"]["success"] is True
+            assert second.status_code == 429
+            body = second.get_json()
+            assert body["code"] == "plaid_realtime_cooldown"
+            assert body["retry_after_seconds"] > 0
+            assert body["next_available_refresh_at"]
+            assert "Retry-After" in second.headers
+        finally:
+            with flask_app.app_context():
+                PlaidConnection.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                Balance.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_response_never_includes_access_token(
+        self, auth_client, flask_app
+    ):
+        from conftest import _ADMIN_USER_ID
+
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(_ADMIN_USER_ID)
+        try:
+            headers = _csrf_headers_for(auth_client)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.accounts_balance_get.return_value = (
+                    _make_balances_response("acct-1", available=11.0, current=12.0)
+                )
+                resp = auth_client.post(
+                    "/api/v1/plaid/realtime-balance", headers=headers
+                )
+            assert resp.status_code == 200
+            raw = resp.get_data(as_text=True)
+            for forbidden_substr in (
+                "access_token",
+                "encrypted_access_token",
+                "access-sandbox-test",
+            ):
+                assert forbidden_substr not in raw
+        finally:
+            with flask_app.app_context():
+                PlaidConnection.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                Balance.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+
+class TestRealtimeBalanceGuestRestrictions:
+    """Guest (admin=False) users must not be able to trigger a paid refresh."""
+
+    @pytest.fixture()
+    def guest_client(self, flask_app):
+        with flask_app.app_context():
+            owner = User(
+                email=f"plaid-rt-owner-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="Owner",
+                admin=True,
+                is_account_owner=True,
+                is_active=True,
+            )
+            db.session.add(owner)
+            db.session.commit()
+            guest = User(
+                email=f"plaid-rt-guest-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="Guest",
+                admin=False,
+                is_active=True,
+                is_account_owner=False,
+                owner_user_id=owner.id,
+                account_owner_id=owner.id,
+            )
+            db.session.add(guest)
+            db.session.commit()
+            guest_id = guest.id
+            owner_id = owner.id
+
+        c = flask_app.test_client()
+        with c.session_transaction() as sess:
+            sess["_user_id"] = str(guest_id)
+            sess["_fresh"] = True
+
+        yield c
+
+        with flask_app.app_context():
+            PlaidConnection.query.filter(
+                PlaidConnection.user_id.in_([guest_id, owner_id])
+            ).delete(synchronize_session=False)
+            User.query.filter(User.id.in_([guest_id, owner_id])).delete(
+                synchronize_session=False
+            )
+            db.session.commit()
+
+    def _csrf_headers(self, client):
+        html = client.get("/settings").get_data(as_text=True)
+        marker = 'meta name="csrf-token" content="'
+        idx = html.find(marker)
+        assert idx != -1
+        start = idx + len(marker)
+        end = html.find('"', start)
+        return {"X-CSRFToken": html[start:end]}
+
+    def test_guest_forbidden(self, flask_app, guest_client):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+        with patch.object(plaid_service, "realtime_update_plaid_balance_for_user") as mock_upd:
+            resp = guest_client.post(
+                "/api/v1/plaid/realtime-balance",
+                headers=self._csrf_headers(guest_client),
+            )
+        assert resp.status_code == 403
+        assert resp.get_json()["code"] == "forbidden"
+        assert not mock_upd.called
+        with flask_app.app_context():
+            _deconfigure_plaid(flask_app)

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -911,6 +911,42 @@ class TestUpdateBalance:
                 plaid_service.safe_update_plaid_balance_for_user(user)
             _deconfigure_plaid(flask_app)
 
+    def test_skips_after_recent_realtime_refresh(self, flask_app, plaid_user):
+        """A just-written real-time balance must not be clobbered by the cached sync.
+
+        Plaid does not guarantee /accounts/get reflects a fresh
+        /accounts/balance/get immediately, so the dashboard auto-sync must
+        skip while the realtime value is still within the protection window.
+        """
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            conn.last_realtime_balance_at = datetime.utcnow()
+            db.session.commit()
+            db.session.add(
+                Balance(user_id=plaid_user, amount=1234.56, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                # Simulate a stale cached value that would clobber the live one.
+                mock_client.return_value.accounts_get.return_value = (
+                    _make_balances_response("acct-1", available=100.0, current=100.0)
+                )
+                result = plaid_service.update_plaid_balance_for_user(user)
+            assert result["status"] == "skipped"
+            assert result["reason"] == "realtime_recent"
+            # Live value is untouched.
+            row = Balance.query.filter_by(
+                user_id=plaid_user, date=date.today()
+            ).first()
+            assert float(row.amount) == pytest.approx(1234.56)
+            _deconfigure_plaid(flask_app)
+
 
 # ── Dashboard integration ───────────────────────────────────────────────────
 

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -8,7 +8,7 @@ storage paths exist.
 All Plaid SDK interactions are mocked; tests never hit the network.
 """
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -82,8 +82,12 @@ def _deconfigure_plaid(flask_app):
         flask_app.config[k] = ""
 
 
-def _make_balances_response(account_id, *, available, current):
-    balances = SimpleNamespace(available=available, current=current)
+def _make_balances_response(account_id, *, available, current, last_updated_datetime=None):
+    balances = SimpleNamespace(
+        available=available,
+        current=current,
+        last_updated_datetime=last_updated_datetime,
+    )
     account = SimpleNamespace(account_id=account_id, balances=balances)
     return SimpleNamespace(accounts=[account])
 
@@ -909,6 +913,86 @@ class TestUpdateBalance:
                 )
                 # Must not raise.
                 plaid_service.safe_update_plaid_balance_for_user(user)
+            _deconfigure_plaid(flask_app)
+
+    def test_skips_when_cache_older_than_last_realtime(self, flask_app, plaid_user):
+        """Plaid's cached balance is stale relative to our live one — don't overwrite.
+
+        Belt-and-suspenders alongside the 5-minute time guard: when Plaid
+        explicitly tells us ``balances.last_updated_datetime`` is older than
+        our last real-time refresh, we know /accounts/get is returning
+        stale data and the live row must stay put — even if the time guard
+        has already elapsed.
+        """
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            # Pretend the real-time refresh ran ~10 minutes ago — past the
+            # 5-minute time guard, so we rely on the cache-timestamp check.
+            conn.last_realtime_balance_at = datetime.utcnow() - timedelta(minutes=10)
+            db.session.commit()
+            db.session.add(
+                Balance(user_id=plaid_user, amount=1234.56, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                # Plaid's cache was last refreshed BEFORE our real-time call.
+                stale_cache_ts = (
+                    datetime.utcnow() - timedelta(hours=2)
+                ).replace(tzinfo=timezone.utc).isoformat()
+                mock_client.return_value.accounts_get.return_value = (
+                    _make_balances_response(
+                        "acct-1",
+                        available=100.0,
+                        current=100.0,
+                        last_updated_datetime=stale_cache_ts,
+                    )
+                )
+                result = plaid_service.update_plaid_balance_for_user(user)
+            assert result["status"] == "skipped"
+            assert result["reason"] == "cache_older_than_realtime"
+            # Live value is untouched.
+            row = Balance.query.filter_by(
+                user_id=plaid_user, date=date.today()
+            ).first()
+            assert float(row.amount) == pytest.approx(1234.56)
+            _deconfigure_plaid(flask_app)
+
+    def test_proceeds_when_cache_newer_than_last_realtime(self, flask_app, plaid_user):
+        """If Plaid's cache caught up after our real-time refresh, sync as normal."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            conn.last_realtime_balance_at = datetime.utcnow() - timedelta(hours=2)
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                fresh_cache_ts = (
+                    datetime.utcnow() - timedelta(minutes=5)
+                ).replace(tzinfo=timezone.utc).isoformat()
+                mock_client.return_value.accounts_get.return_value = (
+                    _make_balances_response(
+                        "acct-1",
+                        available=200.0,
+                        current=250.0,
+                        last_updated_datetime=fresh_cache_ts,
+                    )
+                )
+                result = plaid_service.update_plaid_balance_for_user(user)
+            assert result["status"] == "ok"
+            row = Balance.query.filter_by(
+                user_id=plaid_user, date=date.today()
+            ).first()
+            assert float(row.amount) == pytest.approx(200.0)
             _deconfigure_plaid(flask_app)
 
     def test_skips_after_recent_realtime_refresh(self, flask_app, plaid_user):


### PR DESCRIPTION
Adds a paid /accounts/balance/get refresh path alongside the existing
/accounts/get dashboard sync. The new path is server-rate-limited to one
successful call per connection every 24 hours so users can't run up Plaid
charges, and is exposed both as POST /api/v1/plaid/realtime-balance for
the iOS app and POST /refresh_realtime_balance for the Flask web UI.

The web dashboard's Current Balance card and the iOS Balance card each
get a circular refresh icon that triggers the new endpoint and then
re-renders the dashboard so any new balance shows immediately.

https://claude.ai/code/session_01J5MRgrGrVC1xohsbxtGnrm