### PR TITLE
Fix Codex review nits in realtime balance flow

### DIFF
--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -778,10 +778,11 @@ def update_plaid_balance_for_user(user) -> dict:
     # refresh, the cached value is stale relative to the live one we already
     # wrote. Don't overwrite. (The 5-minute brute-force protection above
     # covers institutions that don't populate last_updated_datetime.)
+    normalized_cache_updated_at = _normalize_naive_utc(cache_updated_at)
     if (
         conn.last_realtime_balance_at is not None
-        and cache_updated_at is not None
-        and _normalize_naive_utc(cache_updated_at) < conn.last_realtime_balance_at
+        and normalized_cache_updated_at is not None
+        and normalized_cache_updated_at < conn.last_realtime_balance_at
     ):
         result = {"status": "skipped", "reason": "cache_older_than_realtime"}
         if cache is not None:

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Balance/BalanceView.swift
@@ -144,13 +144,17 @@ struct BalanceView: View {
 
     private func refreshRealtimeBalance() async {
         guard let token = session.token else { return }
-        await MainActor.run {
-            // Prevent double-taps while the request is in flight.
-            guard !isRefreshing else { return }
+        // Prevent double-taps while the request is in flight. The guard
+        // must exit the function, not just the MainActor closure, or a
+        // second tap can still fire a duplicate network request.
+        let shouldProceed = await MainActor.run { () -> Bool in
+            guard !isRefreshing else { return false }
             isRefreshing = true
             errorText = nil
             statusText = nil
+            return true
         }
+        guard shouldProceed else { return }
         defer {
             Task { @MainActor in isRefreshing = false }
         }


### PR DESCRIPTION
- iOS: move the in-flight guard out of MainActor.run so a duplicate
  tap actually skips the function instead of falling through and
  firing a second /plaid/realtime-balance request.
- Plaid sync: normalize cache_updated_at once and require a non-null
  result before comparing to last_realtime_balance_at — unparseable
  SDK values returned None, which raised TypeError and aborted the
  whole sync path.