### PR TITLE
Show realtime refresh flashes on dashboard, format Plaid sync times

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,6 +11,27 @@
     </p>
 </div>
 
+<!-- Flash Messages -->
+{% with messages = get_flashed_messages(with_categories=True) %}
+{% if messages %}
+    {% for category, message in messages %}
+    {% if category == 'error' %}
+    <div class="alert alert-dismissible fade show" role="alert" style="background-color: rgba(239, 68, 68, 0.1); border: 1px solid var(--danger); color: var(--text-primary); border-radius: var(--radius-md); margin-bottom: 1.5rem;">
+        <i class="fa-solid fa-circle-exclamation"></i>
+        <strong>Error!</strong> {{ message }}
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% else %}
+    <div class="alert alert-dismissible fade show" role="alert" style="background-color: rgba(16, 185, 129, 0.1); border: 1px solid var(--success); color: var(--text-primary); border-radius: var(--radius-md); margin-bottom: 1.5rem;">
+        <i class="fa-solid fa-circle-check"></i>
+        <strong>Success!</strong> {{ message }}
+        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endif %}
+    {% endfor %}
+{% endif %}
+{% endwith %}
+
 <!-- Metrics Grid -->
 <div class="metrics-grid">
     <!-- Current Balance Card -->

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -941,8 +941,19 @@
             '</p></div>';
     }
 
+    function formatLocalDateTime(utcString) {
+        if (!utcString) return 'never';
+        var d = new Date(utcString);
+        if (isNaN(d.getTime())) return 'never';
+        return d.toLocaleString([], {
+            year: 'numeric', month: 'short', day: 'numeric',
+            hour: 'numeric', minute: '2-digit'
+        });
+    }
+
     function renderConnected(conn) {
-        var lastSync = conn.last_balance_sync_at ? conn.last_balance_sync_at : 'never';
+        var lastSync = formatLocalDateTime(conn.last_balance_sync_at);
+        var lastRealtime = formatLocalDateTime(conn.last_realtime_balance_at);
         var html =
             '<div style="padding: 0.75rem; background-color: rgba(16,185,129,0.08); border-left: 4px solid var(--success); border-radius: var(--radius-md); margin-bottom: 1rem;">' +
             '<p style="margin: 0 0 0.25rem 0; font-weight: 600;">Plaid setup: configured</p>' +
@@ -954,6 +965,7 @@
             '<dt style="color: var(--text-secondary);">Mask:</dt><dd style="margin:0;">' + escapeHtml(conn.account_mask || '—') + '</dd>' +
             '<dt style="color: var(--text-secondary);">Type:</dt><dd style="margin:0;">' + escapeHtml(conn.account_type || '—') + (conn.account_subtype ? ' / ' + escapeHtml(conn.account_subtype) : '') + '</dd>' +
             '<dt style="color: var(--text-secondary);">Last sync:</dt><dd style="margin:0;">' + escapeHtml(lastSync) + '</dd>' +
+            '<dt style="color: var(--text-secondary);">Last real-time refresh:</dt><dd style="margin:0;">' + escapeHtml(lastRealtime) + '</dd>' +
             '<dt style="color: var(--text-secondary);">Status:</dt><dd style="margin:0;">' + escapeHtml(conn.last_sync_status || '—') + '</dd>' +
             '</dl>' +
             '<button id="plaid-remove-btn" type="button" class="btn-modern" style="background: linear-gradient(135deg, #ef4444, #f87171); color: white; border: none; width: 100%;">' +


### PR DESCRIPTION
The /refresh_realtime_balance route redirects to the dashboard, but
index.html did not render flashed messages, so the success/error
banners ended up appearing on the next page that did (e.g. settings).
Add the standard flash-message block to the dashboard so the result
of pressing the live refresh button is shown where the button lives.

Also surface last_realtime_balance_at under last_balance_sync_at in
the Plaid settings card, and format both timestamps using the user's
local timezone via toLocaleString, matching the dashboard's existing
"Last updated" pill style.