### PR TITLE
Preserve Plaid real-time refresh cooldown across reconnects

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -24,6 +24,10 @@ class User(UserMixin, db.Model):
     is_review_user = db.Column(
         db.Boolean, default=False, server_default=db.false(), nullable=False
     )
+    # Last consumed Plaid /accounts/balance/get cooldown slot for this user.
+    # Persisted on the user (not just the PlaidConnection) so deleting and
+    # re-adding the Plaid account does not reset the 24-hour rate limit.
+    last_plaid_realtime_balance_at = db.Column(db.DateTime, nullable=True)
 
     # Relationships
     guests = db.relationship(

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -21,7 +21,7 @@ from sqlalchemy import desc, or_
 
 from app import db
 from app.crypto_utils import encrypt_password, decrypt_password
-from app.models import Balance, PlaidConnection
+from app.models import Balance, PlaidConnection, User
 
 logger = logging.getLogger(__name__)
 
@@ -507,6 +507,9 @@ def exchange_public_token_for_user(user, public_token: str, metadata: dict) -> P
         account_subtype=(selected.get("subtype") or None),
         iso_currency_code=(selected.get("iso_currency_code") or None),
         is_active=True,
+        # Carry the user-level cooldown timestamp into the new connection so
+        # delete-and-re-add cannot bypass the 24-hour real-time refresh limit.
+        last_realtime_balance_at=getattr(user, "last_plaid_realtime_balance_at", None),
     )
     db.session.add(conn)
     db.session.commit()
@@ -555,6 +558,23 @@ def _detach_plaid_item(conn: PlaidConnection) -> None:
         )
 
 
+def _preserve_realtime_cooldown(conn: PlaidConnection) -> None:
+    """Copy the connection's real-time refresh cooldown timestamp onto its user.
+
+    The PlaidConnection row is about to be deleted; persisting
+    ``last_realtime_balance_at`` on the user prevents a delete-and-re-add
+    cycle from resetting the 24-hour /accounts/balance/get rate limit.
+    """
+    if conn.last_realtime_balance_at is None:
+        return
+    user = getattr(conn, "user", None)
+    if user is None:
+        user = User.query.get(conn.user_id)
+    if user is None:
+        return
+    user.last_plaid_realtime_balance_at = conn.last_realtime_balance_at
+
+
 def remove_plaid_connection_for_user(user) -> bool:
     """Remove the active Plaid connection for ``user``. Returns True if removed."""
     conn = get_active_connection(user)
@@ -562,6 +582,7 @@ def remove_plaid_connection_for_user(user) -> bool:
         return False
 
     _detach_plaid_item(conn)
+    _preserve_realtime_cooldown(conn)
     db.session.delete(conn)
     db.session.commit()
     return True
@@ -583,6 +604,7 @@ def remove_plaid_connections_for_user_ids(user_ids, *, commit: bool = False) -> 
     )
     for conn in connections:
         _detach_plaid_item(conn)
+        _preserve_realtime_cooldown(conn)
         db.session.delete(conn)
 
     if commit and connections:

--- a/migrations/versions/6b8d9f0a2345_add_last_plaid_realtime_balance_at_to_user.py
+++ b/migrations/versions/6b8d9f0a2345_add_last_plaid_realtime_balance_at_to_user.py
@@ -1,0 +1,63 @@
+"""add last_plaid_realtime_balance_at to user
+
+Persist the Plaid /accounts/balance/get cooldown timestamp on the user so
+that deleting and re-adding a Plaid connection does not reset the 24-hour
+rate limit. The value is mirrored onto the new PlaidConnection on re-add
+and refreshed onto the user when the connection is removed.
+
+Revision ID: 6b8d9f0a2345
+Revises: 5a7c8e9f1234
+Create Date: 2026-05-22 21:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6b8d9f0a2345'
+down_revision = '5a7c8e9f1234'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('last_plaid_realtime_balance_at', sa.DateTime(), nullable=True)
+        )
+
+    # Backfill from any existing PlaidConnection rows so users who already
+    # consumed their cooldown window keep it across the upgrade. Uses a
+    # correlated subquery for SQLite/PostgreSQL portability.
+    bind = op.get_bind()
+    user_table = sa.table(
+        'user',
+        sa.column('id', sa.Integer),
+        sa.column('last_plaid_realtime_balance_at', sa.DateTime),
+    )
+    pc_table = sa.table(
+        'plaid_connections',
+        sa.column('user_id', sa.Integer),
+        sa.column('last_realtime_balance_at', sa.DateTime),
+    )
+    rows = bind.execute(
+        sa.select(
+            pc_table.c.user_id,
+            sa.func.max(pc_table.c.last_realtime_balance_at).label('ts'),
+        )
+        .where(pc_table.c.last_realtime_balance_at.isnot(None))
+        .group_by(pc_table.c.user_id)
+    ).fetchall()
+    for user_id, ts in rows:
+        bind.execute(
+            sa.update(user_table)
+            .where(user_table.c.id == user_id)
+            .where(user_table.c.last_plaid_realtime_balance_at.is_(None))
+            .values(last_plaid_realtime_balance_at=ts)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('last_plaid_realtime_balance_at')

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -778,6 +778,90 @@ class TestRemoveConnectionsBulk:
             _deconfigure_plaid(flask_app)
 
 
+class TestRealtimeCooldownSurvivesReconnect:
+    """Deleting and re-adding a Plaid account must not reset the 24-hour
+    /accounts/balance/get rate limit."""
+
+    def _mock_exchange(self, item_id="item-x", access_token="access-x"):
+        return SimpleNamespace(item_id=item_id, access_token=access_token)
+
+    def test_remove_preserves_cooldown_on_user(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            cooldown_at = datetime.utcnow() - timedelta(hours=1)
+            _add_connection(plaid_user, last_realtime_balance_at=cooldown_at)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client"):
+                plaid_service.remove_plaid_connection_for_user(user)
+            db.session.refresh(user)
+            assert user.last_plaid_realtime_balance_at == cooldown_at
+            _deconfigure_plaid(flask_app)
+
+    def test_remove_bulk_preserves_cooldown_on_user(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            cooldown_at = datetime.utcnow() - timedelta(hours=2)
+            _add_connection(plaid_user, last_realtime_balance_at=cooldown_at)
+            with patch.object(plaid_service, "_plaid_client"):
+                plaid_service.remove_plaid_connections_for_user_ids(
+                    [plaid_user], commit=True
+                )
+            user = User.query.get(plaid_user)
+            assert user.last_plaid_realtime_balance_at == cooldown_at
+            _deconfigure_plaid(flask_app)
+
+    def test_remove_without_prior_realtime_call_leaves_user_null(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            with patch.object(plaid_service, "_plaid_client"):
+                plaid_service.remove_plaid_connection_for_user(user)
+            db.session.refresh(user)
+            assert user.last_plaid_realtime_balance_at is None
+            _deconfigure_plaid(flask_app)
+
+    def test_reconnect_restores_cooldown_on_new_connection(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            cooldown_at = datetime.utcnow() - timedelta(hours=1)
+            _add_connection(plaid_user, last_realtime_balance_at=cooldown_at)
+            user = User.query.get(plaid_user)
+
+            with patch.object(plaid_service, "_plaid_client"):
+                plaid_service.remove_plaid_connection_for_user(user)
+
+            metadata = {
+                "institution": {"institution_id": "ins_9", "name": "Re-Add Bank"},
+                "accounts": [
+                    {
+                        "id": "acct-reconnect-1",
+                        "name": "Checking",
+                        "mask": "9999",
+                        "type": "depository",
+                        "subtype": "checking",
+                        "iso_currency_code": "USD",
+                    }
+                ],
+            }
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                mock_client.return_value.item_public_token_exchange.return_value = (
+                    self._mock_exchange(
+                        item_id="item-reconnect", access_token="access-reconnect"
+                    )
+                )
+                new_conn = plaid_service.exchange_public_token_for_user(
+                    user, "public-token-reconnect", metadata
+                )
+
+            assert new_conn.last_realtime_balance_at == cooldown_at
+            _deconfigure_plaid(flask_app)
+
+
 # ── Balance update ──────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
A user could previously bypass the 24-hour /accounts/balance/get rate
limit by removing their Plaid connection and adding it back, because
last_realtime_balance_at lived only on the PlaidConnection row that was
deleted. Persist the timestamp on the user instead: copy from the
connection onto the user during removal, and seed the new connection
from the user on re-add. Backfilled from existing connections.