### PR TITLE
Keep newest realtime cooldown when preserving across delete

### DIFF
--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -564,6 +564,11 @@ def _preserve_realtime_cooldown(conn: PlaidConnection) -> None:
     The PlaidConnection row is about to be deleted; persisting
     ``last_realtime_balance_at`` on the user prevents a delete-and-re-add
     cycle from resetting the 24-hour /accounts/balance/get rate limit.
+
+    Keeps the newest of the user-level and connection-level timestamps:
+    bulk deletes may iterate multiple connections per user (and SQL row
+    order is not guaranteed), so a blind overwrite could move the
+    cooldown backward and let a reconnect bypass the rate limit.
     """
     if conn.last_realtime_balance_at is None:
         return
@@ -572,7 +577,9 @@ def _preserve_realtime_cooldown(conn: PlaidConnection) -> None:
         user = User.query.get(conn.user_id)
     if user is None:
         return
-    user.last_plaid_realtime_balance_at = conn.last_realtime_balance_at
+    existing = user.last_plaid_realtime_balance_at
+    if existing is None or conn.last_realtime_balance_at > existing:
+        user.last_plaid_realtime_balance_at = conn.last_realtime_balance_at
 
 
 def remove_plaid_connection_for_user(user) -> bool:

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -810,6 +810,38 @@ class TestRealtimeCooldownSurvivesReconnect:
             assert user.last_plaid_realtime_balance_at == cooldown_at
             _deconfigure_plaid(flask_app)
 
+    def test_remove_bulk_keeps_newest_cooldown_across_multiple_connections(
+        self, flask_app, plaid_user
+    ):
+        """Multiple PlaidConnection rows for one user (e.g. an inactive
+        leftover + an active one) must not let bulk delete move the user's
+        cooldown backward — keep the newest timestamp regardless of row
+        iteration order."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            older = datetime.utcnow() - timedelta(hours=20)
+            newer = datetime.utcnow() - timedelta(hours=1)
+            _add_connection(
+                plaid_user,
+                plaid_item_id="item-old",
+                plaid_account_id="acct-old",
+                is_active=False,
+                last_realtime_balance_at=older,
+            )
+            _add_connection(
+                plaid_user,
+                plaid_item_id="item-new",
+                plaid_account_id="acct-new",
+                last_realtime_balance_at=newer,
+            )
+            with patch.object(plaid_service, "_plaid_client"):
+                plaid_service.remove_plaid_connections_for_user_ids(
+                    [plaid_user], commit=True
+                )
+            user = User.query.get(plaid_user)
+            assert user.last_plaid_realtime_balance_at == newer
+            _deconfigure_plaid(flask_app)
+
     def test_remove_without_prior_realtime_call_leaves_user_null(
         self, flask_app, plaid_user
     ):


### PR DESCRIPTION
remove_plaid_connections_for_user_ids() can iterate multiple
PlaidConnection rows for the same user (e.g. an active row plus a
leftover inactive row). The previous blind assignment in
_preserve_realtime_cooldown could move the user-level cooldown
backward if SQL iterated the older row last, letting a reconnect
bypass the 24-hour /accounts/balance/get rate limit. Take the max of
the existing user value and the connection's timestamp instead.

https://claude.ai/code/session_01N71qEadTXBbFQYRL3XPkhw