### PR TITLE
Implement upsert behavior for balance entries on same date

### DIFF
--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -676,6 +676,15 @@ def api_set_balance():
         return validation_error(errors)
 
     balance_date = datetime.strptime(body.get("date") or datetime.today().date().isoformat(), "%Y-%m-%d").date()
+    existing = (
+        Balance.query.filter_by(user_id=user_id, date=balance_date)
+        .order_by(desc(Balance.id))
+        .first()
+    )
+    if existing is not None:
+        existing.amount = body["amount"]
+        db.session.commit()
+        return api_ok(serialize_balance(existing))
     balance = Balance(user_id=user_id, amount=body["amount"], date=balance_date)
     db.session.add(balance)
     db.session.commit()

--- a/app/main.py
+++ b/app/main.py
@@ -656,10 +656,16 @@ def balance():
     if request.method == 'POST':
         amount = request.form['amount']
         dateentry = request.form['date']
-        balance = Balance(amount=amount,
-                          date=datetime.strptime(dateentry, format).date(),
-                          user_id=user_id)
-        db.session.add(balance)
+        balance_date = datetime.strptime(dateentry, format).date()
+        existing = (
+            Balance.query.filter_by(user_id=user_id, date=balance_date)
+            .order_by(desc(Balance.id))
+            .first()
+        )
+        if existing is not None:
+            existing.amount = amount
+        else:
+            db.session.add(Balance(amount=amount, date=balance_date, user_id=user_id))
         db.session.commit()
 
         return redirect(url_for('main.index'))

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -788,13 +788,26 @@ class TestWriteEndpoints:
 
     def test_balance_post_and_history(self, client):
         token = _login(client)
+        # Seeded user already has a balance row for today, so POSTing for the
+        # same date updates the existing row (200) rather than creating one (201).
         resp = client.post(
             "/api/v1/balance",
             headers=_bearer(token),
             json={"amount": "999.00", "date": date.today().isoformat()},
             content_type="application/json",
         )
-        assert resp.status_code == 201
+        assert resp.status_code == 200
+        assert _json(resp)["data"]["amount"] == "999.00"
+
+        # Posting for a new date should create a new row.
+        new_date = (date.today() - timedelta(days=1)).isoformat()
+        resp_new = client.post(
+            "/api/v1/balance",
+            headers=_bearer(token),
+            json={"amount": "1234.00", "date": new_date},
+            content_type="application/json",
+        )
+        assert resp_new.status_code == 201
 
         history = client.get("/api/v1/balance/history?limit=1&offset=0", headers=_bearer(token))
         assert history.status_code == 200

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -296,6 +296,25 @@ class TestBalanceUpdate:
         # Should redirect back to the dashboard
         assert resp.status_code in (301, 302)
 
+    def test_balance_update_upserts_same_date(self, auth_client, flask_app):
+        from conftest import _Balance as Balance
+
+        target_date = "2099-02-02"
+        auth_client.post(
+            "/balance",
+            data={"amount": "100.00", "date": target_date},
+            follow_redirects=False,
+        )
+        auth_client.post(
+            "/balance",
+            data={"amount": "250.00", "date": target_date},
+            follow_redirects=False,
+        )
+        with flask_app.app_context():
+            rows = Balance.query.filter_by(date=datetime.strptime(target_date, "%Y-%m-%d").date()).all()
+            assert len(rows) == 1
+            assert str(rows[0].amount) == "250.00"
+
 
 # ── Tests: scenario creation (POST /create_scenario) ─────────────────────────
 


### PR DESCRIPTION
## Summary
This PR changes the balance creation endpoints to implement upsert semantics: when a balance entry is posted for a date that already has an entry for the user, the existing entry is updated instead of creating a duplicate.

## Key Changes
- **Web route (`/balance` POST)**: Modified to check for existing balance entries on the same date and update the amount if found, otherwise create a new entry
- **API route (`/api/v1/balance` POST)**: Implemented the same upsert logic with appropriate HTTP status codes (200 for updates, 201 for new entries)
- **Tests**: Added comprehensive test coverage for the upsert behavior in both the web and API test suites, including validation that duplicate dates result in a single updated row

## Implementation Details
- Both endpoints now query for existing balance entries filtered by `user_id` and `date` before deciding whether to insert or update
- The query uses `order_by(desc(Balance.id)).first()` to handle any edge cases with multiple entries
- API endpoint returns 200 status code for updates and 201 for new entries, following REST conventions
- Web endpoint continues to redirect to dashboard in both cases
- Existing tests were updated to reflect the new behavior (e.g., expecting 200 instead of 201 when updating today's balance)

https://claude.ai/code/session_01GcGkcKct1nNwwZQtAVs3YE