### PR TITLE
Add unique constraint on balance (user_id, date) with race condition handling

### DIFF
--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 import json
 
 from sqlalchemy import desc
+from sqlalchemy.exc import IntegrityError
 
 from flask import request, g
 
@@ -687,7 +688,18 @@ def api_set_balance():
         return api_ok(serialize_balance(existing))
     balance = Balance(user_id=user_id, amount=body["amount"], date=balance_date)
     db.session.add(balance)
-    db.session.commit()
+    try:
+        db.session.commit()
+    except IntegrityError:
+        # A concurrent request inserted a row for the same (user_id, date)
+        # between our SELECT and INSERT. Roll back, refetch, and update.
+        db.session.rollback()
+        existing = Balance.query.filter_by(user_id=user_id, date=balance_date).first()
+        if existing is None:
+            raise
+        existing.amount = body["amount"]
+        db.session.commit()
+        return api_ok(serialize_balance(existing))
     return api_created(serialize_balance(balance))
 
 

--- a/app/getemail.py
+++ b/app/getemail.py
@@ -256,14 +256,20 @@ def process_email_balances():
                 existing_balance = Balance.query.filter_by(
                     user_id=user_id,
                     date=balance_date,
-                    amount=new_balance,
                 ).first()
 
-                if existing_balance:
+                if existing_balance is not None and float(existing_balance.amount) == new_balance:
                     logger.info(
                         "Duplicate balance ignored for user %s",
                         user_id,
                     )
+                elif existing_balance is not None:
+                    # Upsert: same-day row already exists with a different
+                    # amount — update it instead of inserting a duplicate.
+                    existing_balance.amount = new_balance
+                    db.session.commit()
+                    balance_updated = True
+                    logger.info("Balance updated successfully for user %s", user_id)
                 else:
                     # Insert balance WITH user_id using SQLAlchemy ORM
                     balance = Balance(

--- a/app/main.py
+++ b/app/main.py
@@ -16,6 +16,7 @@ import json
 import logging
 from urllib.parse import urlparse
 from sqlalchemy import desc, extract, asc
+from sqlalchemy.exc import IntegrityError
 from werkzeug.security import generate_password_hash, check_password_hash
 from .cashflow import update_cash, plot_cash, calculate_cash_risk_score
 from .auth import admin_required, global_admin_required, account_owner_required
@@ -98,7 +99,13 @@ def index():
     if balance is None:
         balance = Balance(amount='0', date=datetime.today(), user_id=user_id)
         db.session.add(balance)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+            balance = Balance.query.filter_by(user_id=user_id).order_by(
+                desc(Balance.date), desc(Balance.id)
+            ).first()
     else:
         try:
             float(balance.amount)
@@ -664,9 +671,18 @@ def balance():
         )
         if existing is not None:
             existing.amount = amount
+            db.session.commit()
         else:
             db.session.add(Balance(amount=amount, date=balance_date, user_id=user_id))
-        db.session.commit()
+            try:
+                db.session.commit()
+            except IntegrityError:
+                db.session.rollback()
+                existing = Balance.query.filter_by(user_id=user_id, date=balance_date).first()
+                if existing is None:
+                    raise
+                existing.amount = amount
+                db.session.commit()
 
         return redirect(url_for('main.index'))
 

--- a/app/models.py
+++ b/app/models.py
@@ -106,6 +106,7 @@ class Balance(db.Model):
 
     __table_args__ = (
         db.Index('ix_balance_user_id_date_id', 'user_id', 'date', 'id'),
+        db.UniqueConstraint('user_id', 'date', name='uq_balance_user_id_date'),
     )
 
 

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -18,6 +18,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from flask import current_app, g
 from sqlalchemy import desc, or_
+from sqlalchemy.exc import IntegrityError
 
 from app import db
 from app.crypto_utils import encrypt_password, decrypt_password
@@ -659,9 +660,23 @@ def _upsert_today_balance(user_id: int, amount: float) -> Balance:
     if existing is not None:
         existing.amount = amount
         return existing
+    # Flush inside a SAVEPOINT so a concurrent insert for the same
+    # (user_id, date) surfaces as IntegrityError here without discarding
+    # any other dirty state on the outer transaction.
     row = Balance(user_id=user_id, amount=amount, date=today)
     db.session.add(row)
-    return row
+    savepoint = db.session.begin_nested()
+    try:
+        db.session.flush()
+        savepoint.commit()
+        return row
+    except IntegrityError:
+        savepoint.rollback()
+        existing = Balance.query.filter_by(user_id=user_id, date=today).first()
+        if existing is None:
+            raise
+        existing.amount = amount
+        return existing
 
 
 def _record_sync_status(conn: PlaidConnection, status: str, error: Optional[str]) -> None:

--- a/migrations/versions/e7f8a9b0c1d2_unique_balance_user_id_date.py
+++ b/migrations/versions/e7f8a9b0c1d2_unique_balance_user_id_date.py
@@ -1,0 +1,59 @@
+"""add unique constraint on balance (user_id, date)
+
+Deduplicates same-day balance rows per user, keeping the row with the
+highest ``id`` (most recently inserted), then enforces uniqueness at the
+database level so application-level upserts cannot race and reintroduce
+duplicates.
+
+Revision ID: e7f8a9b0c1d2
+Revises: 6b8d9f0a2345
+Create Date: 2026-05-23 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'e7f8a9b0c1d2'
+down_revision = '6b8d9f0a2345'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Remove duplicate (user_id, date) rows before adding the unique
+    # constraint. For each (user_id, date), keep the row with the largest
+    # id (most recently inserted). NULL dates are ignored because NULL is
+    # not considered equal in unique-constraint comparisons on either
+    # SQLite or PostgreSQL.
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT b1.id FROM balance b1 "
+            "WHERE b1.date IS NOT NULL "
+            "AND EXISTS ("
+            "  SELECT 1 FROM balance b2 "
+            "  WHERE b2.user_id = b1.user_id "
+            "    AND b2.date = b1.date "
+            "    AND b2.id > b1.id"
+            ")"
+        )
+    ).fetchall()
+    duplicate_ids = [row[0] for row in rows]
+    if duplicate_ids:
+        bind.execute(
+            sa.text("DELETE FROM balance WHERE id IN :ids").bindparams(
+                sa.bindparam('ids', duplicate_ids, expanding=True)
+            )
+        )
+
+    with op.batch_alter_table('balance', schema=None) as batch_op:
+        batch_op.create_unique_constraint(
+            'uq_balance_user_id_date', ['user_id', 'date']
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('balance', schema=None) as batch_op:
+        batch_op.drop_constraint('uq_balance_user_id_date', type_='unique')


### PR DESCRIPTION
## Summary
This PR adds a database-level unique constraint on the `balance` table for the `(user_id, date)` combination to prevent duplicate same-day balance entries. It also implements application-level race condition handling to gracefully handle concurrent upsert attempts.

## Key Changes

- **Database Migration**: Added a new migration that:
  - Deduplicates existing balance rows by keeping the most recently inserted row (highest `id`) for each `(user_id, date)` pair
  - Enforces uniqueness at the database level via a unique constraint

- **Model Update**: Added `UniqueConstraint` to the `Balance` model for `(user_id, date)`

- **Race Condition Handling**: Updated all balance upsert operations to catch `IntegrityError` exceptions and handle them gracefully:
  - `app/main.py`: Updated `index()` and `balance()` endpoints to retry on constraint violation
  - `app/plaid_service.py`: Enhanced `_upsert_today_balance()` with nested transaction (SAVEPOINT) to isolate flush operations and detect concurrent inserts without losing transaction state
  - `app/api/routes/data.py`: Updated `api_set_balance()` to rollback and refetch on constraint violation
  - `app/getemail.py`: Modified balance processing to properly handle existing rows with different amounts (true upsert behavior)

## Implementation Details

- The migration uses `NULL`-safe logic since `NULL` values are not considered equal in unique constraints on both SQLite and PostgreSQL
- The `plaid_service.py` implementation uses nested transactions (SAVEPOINT) to detect race conditions without discarding other pending changes
- All retry logic follows the pattern: catch `IntegrityError` → rollback → refetch → update existing row
- The `getemail.py` changes distinguish between duplicate detection (same amount) and true upserts (different amount)

https://claude.ai/code/session_01WjSpCf85ANmTocAstcgKUu