### PR TITLE
Skip cached Plaid sync when email balance is newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ appropriate for your account (typically `auth`); **do not** include
   stored. Only one active connection per user is allowed; remove it before
   connecting a new one.
 - On every dashboard load (web `/` and `GET /api/v1/dashboard`),
-  `update_plaid_balance_for_user()` calls `/accounts/balance/get`:
+  `update_plaid_balance_for_user()` calls Plaid's cached `/accounts/get`:
   - Uses `balances.available` if present.
   - Falls back to `balances.current` if available is `null`.
   - If both are `null`, the existing balance row is **not** overwritten and
@@ -531,6 +531,36 @@ appropriate for your account (typically `auth`); **do not** include
   history is kept.
 - Errors are swallowed by the dashboard call site — Plaid problems never
   break dashboard load.
+
+### Email balance vs cached Plaid balance
+
+`/accounts/get` returns **cached** balance data — Plaid exposes its own
+freshness for that cached value via `balances.last_updated_datetime`. A
+newer email-derived balance must not be silently overwritten by an older
+cached Plaid value the next time the dashboard loads.
+
+On every cached `/accounts/get` sync, PyCashFlow compares Plaid's stored
+cached freshness timestamp against the most recent email balance timestamp
+recorded on the user's `email` configuration (`balance_email_datetime`,
+captured from the message's `Date` header):
+
+- If today's email balance timestamp is **newer** than Plaid's cached
+  freshness timestamp, the cached sync is skipped
+  (`skipped_cached_plaid_update_email_newer`) and the email value remains
+  in the balance row.
+- If Plaid's cached freshness timestamp is missing/unknown and a same-date
+  email balance timestamp exists, the cached sync is skipped.
+- Otherwise (cached value is newer than email, or no same-date email
+  exists) the normal `/accounts/get` upsert runs.
+
+No balance source/source-timestamp columns are added — the balance table
+keeps storing balance values as before. The comparison reuses the existing
+Plaid freshness field (`balances.last_updated_datetime`) that already
+governs the cached-vs-real-time precedence rule.
+
+The manual real-time `/accounts/balance/get` refresh remains user-triggered
+and is **not** affected by the email-vs-cache skip rule — it may always
+update today's balance.
 
 ### Scope and non-goals
 
@@ -572,11 +602,15 @@ After deploying changes, verify the Plaid flow end-to-end:
 
 ### Running the migration
 
-The integration adds a single `plaid_connections` table.
+The integration adds a single `plaid_connections` table. The follow-on
+email-balance freshness migration adds one nullable
+`balance_email_datetime` column on the existing `email` table — no other
+schema changes.
 
 ```bash
 flask db current
 flask db heads
+flask db migrate -m "track email balance datetime"   # only during development
 flask db upgrade
 ```
 

--- a/app/getemail.py
+++ b/app/getemail.py
@@ -21,10 +21,10 @@ import email
 import smtplib
 from flask import current_app
 from email.header import decode_header
-from email.utils import parseaddr
+from email.utils import parseaddr, parsedate_to_datetime
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from app import db
 from app.models import User, Email, Balance, GlobalEmailSettings
 from app.crypto_utils import decrypt_password
@@ -61,6 +61,27 @@ def _sender_is_allowed(sender_address: str, allowed_sender: str) -> bool:
     if allowed.startswith("@"):
         return sender.endswith(allowed)
     return sender == allowed
+
+
+def _email_message_datetime_utc(msg) -> datetime:
+    """Return the best-available send timestamp for *msg*, as naive UTC.
+
+    Prefers the message ``Date`` header (RFC 5322); falls back to the
+    current processing time if the header is missing or unparseable.
+    Naive datetimes parsed from the header are assumed to be UTC, matching
+    the app's stored-datetime convention.
+    """
+    raw = msg.get("Date") if msg is not None else None
+    if raw:
+        try:
+            parsed = parsedate_to_datetime(raw)
+        except (TypeError, ValueError, IndexError):
+            parsed = None
+        if isinstance(parsed, datetime):
+            if parsed.tzinfo is not None:
+                parsed = parsed.astimezone(timezone.utc).replace(tzinfo=None)
+            return parsed
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 def _parse_auth_results(msg) -> dict:
@@ -133,6 +154,10 @@ def process_email_balances():
             logger.info("Found %d email(s) from the past day for user %s", emails_scanned, user_id)
 
             email_content = {}
+            # Best-available send timestamp (naive UTC) for the message that
+            # populated email_content[subject]. The newest timestamp wins so
+            # the recorded balance datetime tracks the most recent email.
+            email_datetimes: dict = {}
 
             # INNER LOOP: Process only emails from the past day
             for email_id in email_ids:
@@ -208,6 +233,14 @@ def process_email_balances():
                                         user_id, mech.upper(),
                                     )
 
+                            msg_datetime = _email_message_datetime_utc(msg)
+
+                            def _record_body(subj, body_text):
+                                existing_ts = email_datetimes.get(subj)
+                                if existing_ts is None or msg_datetime >= existing_ts:
+                                    email_content[subj] = body_text
+                                    email_datetimes[subj] = msg_datetime
+
                             # Extract email body
                             if msg.is_multipart():
                                 for part in msg.walk():
@@ -226,12 +259,12 @@ def process_email_balances():
                                         and "attachment" not in content_disposition
                                         and body is not None
                                     ):
-                                        email_content[subject] = body
+                                        _record_body(subject, body)
                             else:
                                 content_type = msg.get_content_type()
                                 body = msg.get_payload(decode=True).decode()
                                 if content_type == "text/plain":
-                                    email_content[subject] = body
+                                    _record_body(subject, body)
                 except Exception as exc:
                     logger.debug(
                         "Skipping an email for user %s due to error: %s",
@@ -252,13 +285,24 @@ def process_email_balances():
                 new_balance = new_balance.replace('$', '')
                 new_balance = float(new_balance)
                 balance_date = datetime.today().date()
+                email_message_datetime = email_datetimes.get(subjectstr) or (
+                    datetime.now(timezone.utc).replace(tzinfo=None)
+                )
 
                 existing_balance = Balance.query.filter_by(
                     user_id=user_id,
                     date=balance_date,
                 ).first()
 
+                # Record the email balance timestamp on the Email config row
+                # regardless of duplicate detection — the Plaid cached sync
+                # uses this to detect that today's balance was email-sourced.
+                existing_ts = email_config.balance_email_datetime
+                if existing_ts is None or email_message_datetime > existing_ts:
+                    email_config.balance_email_datetime = email_message_datetime
+
                 if existing_balance is not None and float(existing_balance.amount) == new_balance:
+                    db.session.commit()
                     logger.info(
                         "Duplicate balance ignored for user %s",
                         user_id,

--- a/app/models.py
+++ b/app/models.py
@@ -168,6 +168,11 @@ class Email(db.Model):
     # Exact match: 'alerts@bank.com'  Domain match: '@bank.com'
     # NULL means no restriction is configured (ingestion proceeds with a warning).
     allowed_sender = db.Column(db.String(200), nullable=True)
+    # Timestamp of the most recent balance email this config produced. Stored
+    # as naive UTC (Date header → UTC; processing time fallback). The Plaid
+    # cached /accounts/get sync compares this against Plaid's cached freshness
+    # so a stale cached balance cannot overwrite a newer email-derived one.
+    balance_email_datetime = db.Column(db.DateTime, nullable=True)
 
     # Relationships
     user = db.relationship('User', backref='email_configs')

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -22,7 +22,7 @@ from sqlalchemy.exc import IntegrityError
 
 from app import db
 from app.crypto_utils import encrypt_password, decrypt_password
-from app.models import Balance, PlaidConnection, User
+from app.models import Balance, Email, PlaidConnection, User
 
 logger = logging.getLogger(__name__)
 
@@ -650,6 +650,39 @@ def _normalize_naive_utc(value):
     return value
 
 
+def _newest_email_balance_datetime(user_id: int) -> Optional[datetime]:
+    """Return the most recent email balance timestamp for *user_id*, or None.
+
+    Multiple Email configs per user are allowed by the schema; the newest
+    ``balance_email_datetime`` across them wins so a same-date email balance
+    is reliably detected.
+    """
+    row = (
+        db.session.query(Email.balance_email_datetime)
+        .filter(
+            Email.user_id == user_id,
+            Email.balance_email_datetime.isnot(None),
+        )
+        .order_by(desc(Email.balance_email_datetime))
+        .first()
+    )
+    return row[0] if row else None
+
+
+def _email_balance_local_date(email_dt: datetime) -> Optional[date]:
+    """Convert a naive-UTC email balance timestamp to a local date.
+
+    Balance rows are keyed by local date (``datetime.today().date()``), so
+    the email datetime must be projected into local time before matching.
+    """
+    if email_dt is None:
+        return None
+    try:
+        return email_dt.replace(tzinfo=timezone.utc).astimezone().date()
+    except (ValueError, OverflowError):
+        return None
+
+
 def _upsert_today_balance(user_id: int, amount: float) -> Balance:
     today = _today_date()
     existing = (
@@ -832,6 +865,30 @@ def update_plaid_balance_for_user(user) -> dict:
         if cache is not None:
             cache[user.id] = result
         return result
+
+    # Don't overwrite a same-date email-derived balance with a possibly-stale
+    # Plaid cached value. Plaid's /accounts/get returns cached data whose
+    # freshness is exposed via ``balances.last_updated_datetime``; if that is
+    # older than (or unknown relative to) the latest balance email we processed
+    # for today, the email value is authoritative.
+    email_balance_dt = _newest_email_balance_datetime(user.id)
+    if email_balance_dt is not None:
+        if _email_balance_local_date(email_balance_dt) == _today_date() and (
+            normalized_cache_updated_at is None
+            or normalized_cache_updated_at < email_balance_dt
+        ):
+            logger.info(
+                "Plaid cached /accounts/get sync skipped for user %s: "
+                "email balance is newer than Plaid cached freshness",
+                user.id,
+            )
+            result = {
+                "status": "skipped",
+                "reason": "skipped_cached_plaid_update_email_newer",
+            }
+            if cache is not None:
+                cache[user.id] = result
+            return result
 
     if available is not None:
         balance_value = float(available)

--- a/migrations/versions/c2d4e8a9b1f3_add_balance_email_datetime_to_email.py
+++ b/migrations/versions/c2d4e8a9b1f3_add_balance_email_datetime_to_email.py
@@ -1,0 +1,33 @@
+"""add balance_email_datetime to email table
+
+Tracks the timestamp of the most recent balance email a user's Email
+configuration produced. The Plaid cached /accounts/get auto-sync compares
+this against Plaid's cached freshness timestamp so a stale cached balance
+cannot overwrite a newer email-derived value.
+
+Revision ID: c2d4e8a9b1f3
+Revises: e7f8a9b0c1d2
+Create Date: 2026-05-24 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c2d4e8a9b1f3'
+down_revision = 'e7f8a9b0c1d2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('email') as batch_op:
+        batch_op.add_column(
+            sa.Column('balance_email_datetime', sa.DateTime(), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('email') as batch_op:
+        batch_op.drop_column('balance_email_datetime')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,8 +40,10 @@ from app.models import (
     PasskeyCredential as _PasskeyCredential,
     PasswordSetupToken as _PasswordSetupToken,
     PlaidConnection as _PlaidConnection,
+    Email as _Email,
 )  # noqa: E402
 from app import plaid_service as _plaid_service  # noqa: E402
+from app import getemail as _getemail  # noqa: E402
 from app.password_setup import (  # noqa: E402
     build_password_setup_url as _build_password_setup_url,
     create_password_setup_token as _create_password_setup_token,

--- a/tests/test_getemail_balance_datetime.py
+++ b/tests/test_getemail_balance_datetime.py
@@ -1,0 +1,233 @@
+"""Tests for the email balance timestamp capture in getemail.process_email_balances.
+
+Covers the helper that derives a UTC timestamp from a message's Date header
+plus the end-to-end ingestion path that persists ``balance_email_datetime``
+on the Email config row. IMAP is mocked — no network is touched.
+"""
+
+from __future__ import annotations
+
+import email as email_pkg
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+from werkzeug.security import generate_password_hash
+
+from conftest import (  # noqa: E402
+    _db as db,
+    _Balance as Balance,
+    _User as User,
+    _Email as Email,
+    _getemail as getemail,
+)
+from app.crypto_utils import encrypt_password
+
+
+# ── _email_message_datetime_utc ─────────────────────────────────────────────
+
+
+class TestEmailMessageDatetimeHelper:
+    def _build_msg(self, date_header: str | None):
+        raw_parts = []
+        if date_header is not None:
+            raw_parts.append(f"Date: {date_header}")
+        raw_parts.extend(
+            [
+                "From: alerts@bank.com",
+                "Subject: balance",
+                "Content-Type: text/plain",
+                "",
+                "Balance: $1234.56",
+            ]
+        )
+        raw = ("\r\n".join(raw_parts)).encode()
+        return email_pkg.message_from_bytes(raw)
+
+    def test_parses_rfc5322_date_header_into_naive_utc(self):
+        msg = self._build_msg("Sun, 24 May 2026 14:00:00 +0200")
+        result = getemail._email_message_datetime_utc(msg)
+        assert result == datetime(2026, 5, 24, 12, 0, 0)
+        assert result.tzinfo is None
+
+    def test_naive_date_header_assumed_utc(self):
+        msg = self._build_msg("Sun, 24 May 2026 14:00:00 -0000")
+        result = getemail._email_message_datetime_utc(msg)
+        assert result == datetime(2026, 5, 24, 14, 0, 0)
+
+    def test_missing_date_header_falls_back_to_now_utc(self):
+        msg = self._build_msg(None)
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        result = getemail._email_message_datetime_utc(msg)
+        after = datetime.now(timezone.utc).replace(tzinfo=None)
+        assert before - timedelta(seconds=2) <= result <= after + timedelta(seconds=2)
+        assert result.tzinfo is None
+
+    def test_unparseable_date_header_falls_back_to_now_utc(self):
+        msg = self._build_msg("not a real date")
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        result = getemail._email_message_datetime_utc(msg)
+        after = datetime.now(timezone.utc).replace(tzinfo=None)
+        assert before - timedelta(seconds=2) <= result <= after + timedelta(seconds=2)
+
+
+# ── End-to-end: balance_email_datetime persisted on Email config ────────────
+
+
+def _build_balance_email_bytes(
+    subject: str = "balance alert",
+    sender: str = "alerts@bank.com",
+    date_header: str = "Sun, 24 May 2026 09:30:00 +0000",
+    body: str = "Your balance is $1234.56 USD today.",
+) -> bytes:
+    lines = [
+        f"From: {sender}",
+        f"Subject: {subject}",
+        f"Date: {date_header}",
+        "Content-Type: text/plain",
+        "",
+        body,
+    ]
+    return ("\r\n".join(lines)).encode()
+
+
+class TestProcessEmailBalancesPersistsDatetime:
+    @pytest.fixture()
+    def email_user(self, flask_app):
+        """Create a fresh user with an Email config; clean up after the test."""
+        with flask_app.app_context():
+            user = User(
+                email=f"getemail-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="Email User",
+                admin=True,
+                is_active=True,
+            )
+            db.session.add(user)
+            db.session.commit()
+            cfg = Email(
+                user_id=user.id,
+                email="ingest@example.com",
+                password=encrypt_password("imap-pw"),
+                server="imap.example.com",
+                subjectstr="balance alert",
+                startstr="$",
+                endstr=" USD",
+                allowed_sender=None,
+            )
+            db.session.add(cfg)
+            db.session.commit()
+            user_id = user.id
+
+        yield user_id
+
+        with flask_app.app_context():
+            Email.query.filter_by(user_id=user_id).delete()
+            Balance.query.filter_by(user_id=user_id).delete()
+            User.query.filter_by(id=user_id).delete()
+            db.session.commit()
+
+    def _mock_imap(self, raw_emails: list[bytes]) -> MagicMock:
+        imap = MagicMock()
+        imap.select.return_value = ("OK", [b"1"])
+        imap.search.return_value = (
+            "OK",
+            [b" ".join(str(i + 1).encode() for i in range(len(raw_emails)))],
+        )
+
+        def _fetch(eid, _spec):
+            idx = int(eid) - 1
+            return (
+                "OK",
+                [(b"1 (RFC822 {1})", raw_emails[idx])],
+            )
+
+        imap.fetch.side_effect = _fetch
+        return imap
+
+    def test_stores_balance_email_datetime_from_date_header(
+        self, flask_app, email_user
+    ):
+        raw = _build_balance_email_bytes(
+            date_header="Sun, 24 May 2026 09:30:00 +0000"
+        )
+        with flask_app.app_context():
+            with patch("app.getemail.imaplib.IMAP4_SSL") as mock_ssl:
+                mock_ssl.return_value = self._mock_imap([raw])
+                getemail.process_email_balances()
+
+            cfg = Email.query.filter_by(user_id=email_user).first()
+            assert cfg.balance_email_datetime == datetime(2026, 5, 24, 9, 30, 0)
+            assert cfg.balance_email_datetime.tzinfo is None
+
+    def test_records_datetime_even_when_balance_is_duplicate(
+        self, flask_app, email_user
+    ):
+        # Pre-seed today's balance to match the email value so the parser
+        # treats it as a duplicate. The email timestamp must still be saved.
+        with flask_app.app_context():
+            db.session.add(
+                Balance(user_id=email_user, amount=1234.56, date=datetime.today().date())
+            )
+            db.session.commit()
+
+            raw = _build_balance_email_bytes(
+                date_header="Sun, 24 May 2026 09:30:00 +0000"
+            )
+            with patch("app.getemail.imaplib.IMAP4_SSL") as mock_ssl:
+                mock_ssl.return_value = self._mock_imap([raw])
+                getemail.process_email_balances()
+
+            cfg = Email.query.filter_by(user_id=email_user).first()
+            assert cfg.balance_email_datetime == datetime(2026, 5, 24, 9, 30, 0)
+
+    def test_newest_email_timestamp_wins_when_multiple_messages(
+        self, flask_app, email_user
+    ):
+        older = _build_balance_email_bytes(
+            date_header="Sun, 24 May 2026 08:00:00 +0000",
+            body="Your balance is $100.00 USD today.",
+        )
+        newer = _build_balance_email_bytes(
+            date_header="Sun, 24 May 2026 10:00:00 +0000",
+            body="Your balance is $200.00 USD today.",
+        )
+        with flask_app.app_context():
+            with patch("app.getemail.imaplib.IMAP4_SSL") as mock_ssl:
+                mock_ssl.return_value = self._mock_imap([older, newer])
+                getemail.process_email_balances()
+
+            cfg = Email.query.filter_by(user_id=email_user).first()
+            # Newer Date header is the persisted timestamp.
+            assert cfg.balance_email_datetime == datetime(2026, 5, 24, 10, 0, 0)
+            # The newest email's body is what set the balance.
+            row = Balance.query.filter_by(
+                user_id=email_user, date=datetime.today().date()
+            ).first()
+            assert float(row.amount) == pytest.approx(200.00)
+
+    def test_falls_back_to_processing_time_when_date_header_missing(
+        self, flask_app, email_user
+    ):
+        lines = [
+            "From: alerts@bank.com",
+            "Subject: balance alert",
+            "Content-Type: text/plain",
+            "",
+            "Your balance is $42.00 USD today.",
+        ]
+        raw = ("\r\n".join(lines)).encode()
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        with flask_app.app_context():
+            with patch("app.getemail.imaplib.IMAP4_SSL") as mock_ssl:
+                mock_ssl.return_value = self._mock_imap([raw])
+                getemail.process_email_balances()
+
+            cfg = Email.query.filter_by(user_id=email_user).first()
+            after = datetime.now(timezone.utc).replace(tzinfo=None)
+            assert cfg.balance_email_datetime is not None
+            assert (
+                before - timedelta(seconds=5)
+                <= cfg.balance_email_datetime
+                <= after + timedelta(seconds=5)
+            )

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -25,6 +25,7 @@ from conftest import (  # noqa: E402
     _Balance as Balance,
     _User as User,
     _PlaidConnection as PlaidConnection,
+    _Email as Email,
     _plaid_service as plaid_service,
 )
 from app.crypto_utils import encrypt_password  # crypto_utils is never stubbed
@@ -1146,6 +1147,342 @@ class TestUpdateBalance:
             ).first()
             assert float(row.amount) == pytest.approx(1234.56)
             _deconfigure_plaid(flask_app)
+
+
+# ── Email balance vs Plaid cached sync precedence ───────────────────────────
+
+
+def _add_email_config(user_id: int, balance_email_datetime=None, **overrides):
+    """Insert an Email config row for *user_id* with optional timestamp."""
+    defaults = dict(
+        user_id=user_id,
+        email="bank-alerts@example.com",
+        password=encrypt_password("imap-pw"),
+        server="imap.example.com",
+        subjectstr="Daily balance",
+        startstr="$",
+        endstr=" USD",
+        balance_email_datetime=balance_email_datetime,
+    )
+    defaults.update(overrides)
+    cfg = Email(**defaults)
+    db.session.add(cfg)
+    db.session.commit()
+    return cfg
+
+
+class TestEmailBalanceVsPlaidCachedSync:
+    """The dashboard /accounts/get sync must not overwrite a newer email-derived
+    balance with stale Plaid cached data.
+    """
+
+    def test_skips_when_email_newer_than_plaid_cache(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            email_ts = datetime.utcnow() - timedelta(minutes=5)
+            _add_email_config(plaid_user, balance_email_datetime=email_ts)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=1234.56, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    stale_cache_ts = (
+                        datetime.utcnow() - timedelta(hours=2)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=10.0,
+                            current=10.0,
+                            last_updated_datetime=stale_cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "skipped"
+                assert result["reason"] == "skipped_cached_plaid_update_email_newer"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(1234.56)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_skips_when_plaid_cache_freshness_missing(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            email_ts = datetime.utcnow() - timedelta(minutes=10)
+            _add_email_config(plaid_user, balance_email_datetime=email_ts)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=2222.22, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=50.0,
+                            current=50.0,
+                            last_updated_datetime=None,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "skipped"
+                assert result["reason"] == "skipped_cached_plaid_update_email_newer"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(2222.22)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_updates_when_plaid_cache_newer_than_email(self, flask_app, plaid_user):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            email_ts = datetime.utcnow() - timedelta(hours=3)
+            _add_email_config(plaid_user, balance_email_datetime=email_ts)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=100.0, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    fresh_cache_ts = (
+                        datetime.utcnow() - timedelta(minutes=5)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=777.0,
+                            current=800.0,
+                            last_updated_datetime=fresh_cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(777.0)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_updates_when_no_same_date_email_timestamp(self, flask_app, plaid_user):
+        """An old email balance from a previous day must not block today's sync."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            # Email datetime from several days ago — different local date.
+            email_ts = datetime.utcnow() - timedelta(days=3)
+            _add_email_config(plaid_user, balance_email_datetime=email_ts)
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1", available=321.0, current=400.0
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(321.0)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_updates_when_email_config_has_no_balance_timestamp(
+        self, flask_app, plaid_user
+    ):
+        """An Email config without a recorded balance timestamp is a no-op
+        for the skip rule — the normal Plaid sync still proceeds."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            _add_email_config(plaid_user, balance_email_datetime=None)
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1", available=55.5, current=60.0
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(55.5)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_uses_newest_timestamp_across_multiple_email_configs(
+        self, flask_app, plaid_user
+    ):
+        """If a user has more than one Email row, the newest balance timestamp
+        wins — a stale one must not be picked over a fresh same-date one.
+        """
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            old_ts = datetime.utcnow() - timedelta(days=2)
+            fresh_ts = datetime.utcnow() - timedelta(minutes=2)
+            _add_email_config(plaid_user, balance_email_datetime=old_ts)
+            _add_email_config(
+                plaid_user,
+                balance_email_datetime=fresh_ts,
+                email="bank-alerts-2@example.com",
+            )
+            db.session.add(
+                Balance(user_id=plaid_user, amount=4242.42, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    stale_cache_ts = (
+                        datetime.utcnow() - timedelta(hours=1)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=1.0,
+                            current=1.0,
+                            last_updated_datetime=stale_cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "skipped"
+                assert result["reason"] == "skipped_cached_plaid_update_email_newer"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(4242.42)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_realtime_refresh_not_blocked_by_email_skip_rule(
+        self, flask_app, plaid_user
+    ):
+        """Manual /accounts/balance/get is user-triggered and must remain
+        free to update today's balance even when an email balance is newer.
+        """
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            email_ts = datetime.utcnow() - timedelta(minutes=1)
+            _add_email_config(plaid_user, balance_email_datetime=email_ts)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=10.0, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_balance_get.return_value = (
+                        _make_balances_response(
+                            "acct-1", available=999.0, current=1000.0
+                        )
+                    )
+                    result = plaid_service.realtime_update_plaid_balance_for_user(
+                        user
+                    )
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(999.0)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_dashboard_still_loads_when_email_skip_fires(
+        self, auth_client, flask_app
+    ):
+        """The dashboard must continue to render and use the existing balance
+        row when the Plaid cached sync is skipped because the email balance
+        is newer.
+        """
+        from conftest import _ADMIN_USER_ID
+
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(_ADMIN_USER_ID)
+            email_ts = datetime.utcnow() - timedelta(minutes=3)
+            _add_email_config(_ADMIN_USER_ID, balance_email_datetime=email_ts)
+            # Replace the seeded admin balance with a known email-derived value.
+            Balance.query.filter_by(
+                user_id=_ADMIN_USER_ID, date=date.today()
+            ).delete()
+            db.session.add(
+                Balance(user_id=_ADMIN_USER_ID, amount=8888.88, date=date.today())
+            )
+            db.session.commit()
+        try:
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                stale_cache_ts = (
+                    datetime.utcnow() - timedelta(hours=2)
+                ).replace(tzinfo=timezone.utc).isoformat()
+                mock_client.return_value.accounts_get.return_value = (
+                    _make_balances_response(
+                        "acct-1",
+                        available=1.0,
+                        current=1.0,
+                        last_updated_datetime=stale_cache_ts,
+                    )
+                )
+                resp = auth_client.get("/")
+            assert resp.status_code == 200
+            with flask_app.app_context():
+                row = Balance.query.filter_by(
+                    user_id=_ADMIN_USER_ID, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(8888.88)
+        finally:
+            with flask_app.app_context():
+                Email.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                PlaidConnection.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                Balance.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                # Re-seed the original admin balance so other tests using the
+                # same fixture see the expected starting state.
+                db.session.add(
+                    Balance(
+                        user_id=_ADMIN_USER_ID,
+                        amount="5000.00",
+                        date=date.today(),
+                    )
+                )
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
 
 
 # ── Dashboard integration ───────────────────────────────────────────────────


### PR DESCRIPTION
The dashboard auto-runs the cached /accounts/get sync on every load. If
an email-derived balance was just written for today, an older cached
Plaid value could overwrite it on the next refresh — the cache is not
"now," it's whenever Plaid last refreshed.

Track the source datetime of each balance email on the Email config row
(parsed from the message Date header, falling back to processing time)
and compare it against Plaid's existing cached freshness timestamp
(balances.last_updated_datetime). When today's email balance is newer
than the cached value, skip the upsert and keep the email value. The
manual /accounts/balance/get refresh is untouched.

No balance source/provenance columns added; the existing Plaid
freshness field is reused for the comparison.

https://claude.ai/code/session_01EQes1zixLqJvYcCSCWL5rs