### PR TITLE
Drop today-date gate from cached Plaid skip rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,14 +544,18 @@ cached freshness timestamp against the most recent email balance timestamp
 recorded on the user's `email` configuration (`balance_email_datetime`,
 captured from the message's `Date` header):
 
-- If today's email balance timestamp is **newer** than Plaid's cached
-  freshness timestamp, the cached sync is skipped
+- If the email balance timestamp is **newer** than Plaid's cached freshness
+  timestamp, the cached sync is skipped
   (`skipped_cached_plaid_update_email_newer`) and the email value remains
   in the balance row.
-- If Plaid's cached freshness timestamp is missing/unknown and a same-date
-  email balance timestamp exists, the cached sync is skipped.
-- Otherwise (cached value is newer than email, or no same-date email
-  exists) the normal `/accounts/get` upsert runs.
+- If Plaid's cached freshness timestamp is missing/unknown and any email
+  balance timestamp exists, the cached sync is skipped.
+- Otherwise (Plaid's cached value is newer than the email, or no email
+  balance timestamp exists) the normal `/accounts/get` upsert runs.
+
+The comparison is purely timestamp-vs-timestamp — it does not consider the
+calendar day of either side or the date of the balance row. The balance
+row's date is used only as the insert/update key for today's row.
 
 No balance source/source-timestamp columns are added — the balance table
 keeps storing balance values as before. The comparison reuses the existing

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -654,8 +654,8 @@ def _newest_email_balance_datetime(user_id: int) -> Optional[datetime]:
     """Return the most recent email balance timestamp for *user_id*, or None.
 
     Multiple Email configs per user are allowed by the schema; the newest
-    ``balance_email_datetime`` across them wins so a same-date email balance
-    is reliably detected.
+    ``balance_email_datetime`` across them wins so the freshest email-derived
+    balance drives the cached-Plaid comparison.
     """
     row = (
         db.session.query(Email.balance_email_datetime)
@@ -667,20 +667,6 @@ def _newest_email_balance_datetime(user_id: int) -> Optional[datetime]:
         .first()
     )
     return row[0] if row else None
-
-
-def _email_balance_local_date(email_dt: datetime) -> Optional[date]:
-    """Convert a naive-UTC email balance timestamp to a local date.
-
-    Balance rows are keyed by local date (``datetime.today().date()``), so
-    the email datetime must be projected into local time before matching.
-    """
-    if email_dt is None:
-        return None
-    try:
-        return email_dt.replace(tzinfo=timezone.utc).astimezone().date()
-    except (ValueError, OverflowError):
-        return None
 
 
 def _upsert_today_balance(user_id: int, amount: float) -> Balance:
@@ -866,29 +852,29 @@ def update_plaid_balance_for_user(user) -> dict:
             cache[user.id] = result
         return result
 
-    # Don't overwrite a same-date email-derived balance with a possibly-stale
-    # Plaid cached value. Plaid's /accounts/get returns cached data whose
-    # freshness is exposed via ``balances.last_updated_datetime``; if that is
-    # older than (or unknown relative to) the latest balance email we processed
-    # for today, the email value is authoritative.
+    # Don't overwrite an email-derived balance with a possibly-stale Plaid
+    # cached value. Plaid's /accounts/get returns cached data whose freshness
+    # is exposed via ``balances.last_updated_datetime``; if that is older than
+    # (or unknown relative to) the most recent balance email we've processed,
+    # the email value is authoritative regardless of which calendar day either
+    # falls on.
     email_balance_dt = _newest_email_balance_datetime(user.id)
-    if email_balance_dt is not None:
-        if _email_balance_local_date(email_balance_dt) == _today_date() and (
-            normalized_cache_updated_at is None
-            or normalized_cache_updated_at < email_balance_dt
-        ):
-            logger.info(
-                "Plaid cached /accounts/get sync skipped for user %s: "
-                "email balance is newer than Plaid cached freshness",
-                user.id,
-            )
-            result = {
-                "status": "skipped",
-                "reason": "skipped_cached_plaid_update_email_newer",
-            }
-            if cache is not None:
-                cache[user.id] = result
-            return result
+    if email_balance_dt is not None and (
+        normalized_cache_updated_at is None
+        or normalized_cache_updated_at < email_balance_dt
+    ):
+        logger.info(
+            "Plaid cached /accounts/get sync skipped for user %s: "
+            "email balance is newer than Plaid cached freshness",
+            user.id,
+        )
+        result = {
+            "status": "skipped",
+            "reason": "skipped_cached_plaid_update_email_newer",
+        }
+        if cache is not None:
+            cache[user.id] = result
+        return result
 
     if available is not None:
         balance_value = float(available)

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -1283,21 +1283,31 @@ class TestEmailBalanceVsPlaidCachedSync:
                 db.session.commit()
                 _deconfigure_plaid(flask_app)
 
-    def test_updates_when_no_same_date_email_timestamp(self, flask_app, plaid_user):
-        """An old email balance from a previous day must not block today's sync."""
+    def test_updates_when_old_email_predates_fresh_plaid_cache(
+        self, flask_app, plaid_user
+    ):
+        """An old email balance must not block a Plaid cached value whose
+        freshness is newer than the email — the comparison is purely
+        timestamp-vs-timestamp.
+        """
         with flask_app.app_context():
             _configure_plaid(flask_app)
             _add_connection(plaid_user)
-            # Email datetime from several days ago — different local date.
             email_ts = datetime.utcnow() - timedelta(days=3)
             _add_email_config(plaid_user, balance_email_datetime=email_ts)
 
             user = User.query.get(plaid_user)
             try:
                 with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    fresh_cache_ts = (
+                        datetime.utcnow() - timedelta(minutes=5)
+                    ).replace(tzinfo=timezone.utc).isoformat()
                     mock_client.return_value.accounts_get.return_value = (
                         _make_balances_response(
-                            "acct-1", available=321.0, current=400.0
+                            "acct-1",
+                            available=321.0,
+                            current=400.0,
+                            last_updated_datetime=fresh_cache_ts,
                         )
                     )
                     result = plaid_service.update_plaid_balance_for_user(user)
@@ -1344,7 +1354,7 @@ class TestEmailBalanceVsPlaidCachedSync:
         self, flask_app, plaid_user
     ):
         """If a user has more than one Email row, the newest balance timestamp
-        wins — a stale one must not be picked over a fresh same-date one.
+        wins — a stale one must not be picked over a fresher one.
         """
         with flask_app.app_context():
             _configure_plaid(flask_app)


### PR DESCRIPTION
The skip condition keyed off the email Date header's local date equaling
today, but the balance row uses processing date. An email delivered or
processed across midnight could have a previous-day Date header while
populating today's balance row, causing the guard to misfire and let the
cached /accounts/get value overwrite it.

The balance row's date is purely the insert/update key; freshness is
already captured by the timestamp comparison. Reduce the guard to a
pure timestamp-vs-timestamp check (Plaid cached freshness vs newest
email balance datetime) and drop the unused
_email_balance_local_date helper.

https://claude.ai/code/session_01EQes1zixLqJvYcCSCWL5rs