### PR TITLE
Skip cached Plaid sync when manual balance entry is newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,39 +532,54 @@ appropriate for your account (typically `auth`); **do not** include
 - Errors are swallowed by the dashboard call site — Plaid problems never
   break dashboard load.
 
-### Email balance vs cached Plaid balance
+### Protecting newer balances from stale cached Plaid data
 
 `/accounts/get` returns **cached** balance data — Plaid exposes its own
 freshness for that cached value via `balances.last_updated_datetime`. A
-newer email-derived balance must not be silently overwritten by an older
-cached Plaid value the next time the dashboard loads.
+balance that PyCashFlow already obtained more recently must not be silently
+overwritten by an older cached Plaid value the next time the dashboard
+loads. On every cached `/accounts/get` sync, PyCashFlow compares Plaid's
+stored cached freshness timestamp against three protected freshness
+timestamps and skips the cached update if any of them is newer:
 
-On every cached `/accounts/get` sync, PyCashFlow compares Plaid's stored
-cached freshness timestamp against the most recent email balance timestamp
-recorded on the user's `email` configuration (`balance_email_datetime`,
-captured from the message's `Date` header):
+1. **Manual balance entry** — `user.last_manual_balance_entry_at`, set
+   whenever a user successfully saves a balance through the web form
+   (`POST /balance`) or the iOS API (`POST /api/v1/balance`).
+2. **Email balance** — the most recent `balance_email_datetime` recorded on
+   the user's `email` configuration (captured from the message `Date`
+   header).
+3. **Real-time refresh** — the connection's `last_realtime_balance_at`,
+   written by the user-triggered `/accounts/balance/get` refresh.
 
-- If the email balance timestamp is **newer** than Plaid's cached freshness
-  timestamp, the cached sync is skipped
-  (`skipped_cached_plaid_update_email_newer`) and the email value remains
-  in the balance row.
-- If Plaid's cached freshness timestamp is missing/unknown and any email
-  balance timestamp exists, the cached sync is skipped.
-- Otherwise (Plaid's cached value is newer than the email, or no email
-  balance timestamp exists) the normal `/accounts/get` upsert runs.
+The skip rules for each protected timestamp are the same:
+
+- If the protected timestamp is **newer** than Plaid's cached freshness
+  timestamp, the cached sync is skipped and the existing balance row is
+  left untouched. The skip reasons are
+  `skipped_cached_plaid_update_manual_newer`,
+  `skipped_cached_plaid_update_email_newer`, and
+  `cache_older_than_realtime` respectively.
+- If Plaid's cached freshness timestamp is missing/unknown and a protected
+  manual/email/real-time timestamp exists, the cached sync is skipped.
+- The cached `/accounts/get` upsert proceeds only when Plaid's cached
+  freshness is newer than (or equal to) **every** protected timestamp, or
+  when no protected timestamp exists at all.
 
 The comparison is purely timestamp-vs-timestamp — it does not consider the
 calendar day of either side or the date of the balance row. The balance
 row's date is used only as the insert/update key for today's row.
 
-No balance source/source-timestamp columns are added — the balance table
-keeps storing balance values as before. The comparison reuses the existing
-Plaid freshness field (`balances.last_updated_datetime`) that already
-governs the cached-vs-real-time precedence rule.
+No balance source/source-timestamp columns or provenance tracking are added
+— the balance table keeps storing balance values as before.
+`last_manual_balance_entry_at` is a freshness timestamp on the `user` table
+only; it is **not** the balance row date or the user-selected balance date.
+The comparison reuses the existing Plaid freshness field
+(`balances.last_updated_datetime`) that already governs the
+cached-vs-email and cached-vs-real-time precedence rules.
 
 The manual real-time `/accounts/balance/get` refresh remains user-triggered
-and is **not** affected by the email-vs-cache skip rule — it may always
-update today's balance.
+and is **not** affected by these skip rules — it may always update today's
+balance.
 
 ### Scope and non-goals
 
@@ -608,13 +623,16 @@ After deploying changes, verify the Plaid flow end-to-end:
 
 The integration adds a single `plaid_connections` table. The follow-on
 email-balance freshness migration adds one nullable
-`balance_email_datetime` column on the existing `email` table — no other
-schema changes.
+`balance_email_datetime` column on the existing `email` table. The
+manual-balance freshness migration
+(`f8b1c2d3e4a5_add_last_manual_balance_entry_at_to_user`) adds one nullable
+`last_manual_balance_entry_at` column on the existing `user` table — no
+other schema changes.
 
 ```bash
 flask db current
 flask db heads
-flask db migrate -m "track email balance datetime"   # only during development
+flask db migrate -m "track manual balance entry freshness"   # only during development
 flask db upgrade
 ```
 

--- a/app/api/routes/data.py
+++ b/app/api/routes/data.py
@@ -20,7 +20,10 @@ from app.ai_insights import (
     select_provider,
 )
 from app.files import version
-from app.plaid_service import safe_update_plaid_balance_for_user
+from app.plaid_service import (
+    safe_update_plaid_balance_for_user,
+    record_manual_balance_entry,
+)
 from app.models import User
 
 from app.api import api
@@ -677,6 +680,7 @@ def api_set_balance():
         return validation_error(errors)
 
     balance_date = datetime.strptime(body.get("date") or datetime.today().date().isoformat(), "%Y-%m-%d").date()
+    owner = _balance_owner_user()
     existing = (
         Balance.query.filter_by(user_id=user_id, date=balance_date)
         .order_by(desc(Balance.id))
@@ -684,10 +688,12 @@ def api_set_balance():
     )
     if existing is not None:
         existing.amount = body["amount"]
+        record_manual_balance_entry(owner)
         db.session.commit()
         return api_ok(serialize_balance(existing))
     balance = Balance(user_id=user_id, amount=body["amount"], date=balance_date)
     db.session.add(balance)
+    record_manual_balance_entry(owner)
     try:
         db.session.commit()
     except IntegrityError:
@@ -698,6 +704,7 @@ def api_set_balance():
         if existing is None:
             raise
         existing.amount = body["amount"]
+        record_manual_balance_entry(owner)
         db.session.commit()
         return api_ok(serialize_balance(existing))
     return api_created(serialize_balance(balance))

--- a/app/main.py
+++ b/app/main.py
@@ -39,6 +39,7 @@ from .plaid_service import (
     safe_update_plaid_balance_for_user,
     realtime_update_plaid_balance_for_user,
     remove_plaid_connections_for_user_ids,
+    record_manual_balance_entry,
 )
 from .totp_utils import (
     generate_totp_secret, encrypt_totp_secret, decrypt_totp_secret,
@@ -664,6 +665,7 @@ def balance():
         amount = request.form['amount']
         dateentry = request.form['date']
         balance_date = datetime.strptime(dateentry, format).date()
+        owner = _get_balance_owner_user()
         existing = (
             Balance.query.filter_by(user_id=user_id, date=balance_date)
             .order_by(desc(Balance.id))
@@ -671,9 +673,11 @@ def balance():
         )
         if existing is not None:
             existing.amount = amount
+            record_manual_balance_entry(owner)
             db.session.commit()
         else:
             db.session.add(Balance(amount=amount, date=balance_date, user_id=user_id))
+            record_manual_balance_entry(owner)
             try:
                 db.session.commit()
             except IntegrityError:
@@ -682,6 +686,7 @@ def balance():
                 if existing is None:
                     raise
                 existing.amount = amount
+                record_manual_balance_entry(owner)
                 db.session.commit()
 
         return redirect(url_for('main.index'))

--- a/app/models.py
+++ b/app/models.py
@@ -28,6 +28,11 @@ class User(UserMixin, db.Model):
     # Persisted on the user (not just the PlaidConnection) so deleting and
     # re-adding the Plaid account does not reset the 24-hour rate limit.
     last_plaid_realtime_balance_at = db.Column(db.DateTime, nullable=True)
+    # When PyCashFlow last accepted a manual balance entry for this user
+    # (web form or iOS API). Stored as naive UTC. The Plaid cached
+    # /accounts/get sync compares this against Plaid's cached freshness so a
+    # stale cached balance cannot overwrite a newer manually-entered value.
+    last_manual_balance_entry_at = db.Column(db.DateTime, nullable=True)
 
     # Relationships
     guests = db.relationship(

--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -852,6 +852,32 @@ def update_plaid_balance_for_user(user) -> dict:
             cache[user.id] = result
         return result
 
+    # Don't overwrite a manually-entered balance with a possibly-stale Plaid
+    # cached value. If the user keyed in a balance more recently than Plaid's
+    # cached freshness (or Plaid did not report its freshness at all), the
+    # manual value is authoritative regardless of which calendar day either
+    # falls on. This sits alongside the email and real-time refresh checks;
+    # the cached update may only proceed when all of them allow it.
+    manual_balance_dt = _normalize_naive_utc(
+        getattr(user, "last_manual_balance_entry_at", None)
+    )
+    if manual_balance_dt is not None and (
+        normalized_cache_updated_at is None
+        or normalized_cache_updated_at < manual_balance_dt
+    ):
+        logger.info(
+            "Plaid cached /accounts/get sync skipped for user %s: "
+            "manual balance entry is newer than Plaid cached freshness",
+            user.id,
+        )
+        result = {
+            "status": "skipped",
+            "reason": "skipped_cached_plaid_update_manual_newer",
+        }
+        if cache is not None:
+            cache[user.id] = result
+        return result
+
     # Don't overwrite an email-derived balance with a possibly-stale Plaid
     # cached value. Plaid's /accounts/get returns cached data whose freshness
     # is exposed via ``balances.last_updated_datetime``; if that is older than
@@ -913,6 +939,20 @@ def safe_update_plaid_balance_for_user(user) -> None:
             db.session.rollback()
         except Exception:
             pass
+
+
+def record_manual_balance_entry(user) -> None:
+    """Stamp *user*'s last manual balance entry time (naive UTC).
+
+    Call from the web/API manual balance entry paths after validation
+    succeeds and the balance write is staged to commit. The cached
+    /accounts/get sync compares this against Plaid's cached freshness so a
+    stale cached balance cannot immediately overwrite a newer manual entry.
+    Does not commit — the caller commits it alongside the balance write.
+    """
+    if user is None or not getattr(user, "id", None):
+        return
+    user.last_manual_balance_entry_at = datetime.now(timezone.utc).replace(tzinfo=None)
 
 
 # ── Real-time balance refresh (/accounts/balance/get) ────────────────────────

--- a/migrations/versions/f8b1c2d3e4a5_add_last_manual_balance_entry_at_to_user.py
+++ b/migrations/versions/f8b1c2d3e4a5_add_last_manual_balance_entry_at_to_user.py
@@ -1,0 +1,34 @@
+"""add last_manual_balance_entry_at to user
+
+Tracks when PyCashFlow last accepted a manual balance entry (web form or
+iOS API) for a user. The Plaid cached /accounts/get auto-sync compares this
+against Plaid's cached freshness timestamp so a stale cached balance cannot
+overwrite a newer manually-entered value. This is purely a freshness
+timestamp; it is not the balance row date and carries no balance provenance.
+
+Revision ID: f8b1c2d3e4a5
+Revises: c2d4e8a9b1f3
+Create Date: 2026-05-27 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f8b1c2d3e4a5'
+down_revision = 'c2d4e8a9b1f3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('last_manual_balance_entry_at', sa.DateTime(), nullable=True)
+        )
+
+
+def downgrade():
+    with op.batch_alter_table('user', schema=None) as batch_op:
+        batch_op.drop_column('last_manual_balance_entry_at')

--- a/tests/test_api_data.py
+++ b/tests/test_api_data.py
@@ -14,7 +14,7 @@ Covers:
 """
 
 import pytest
-from datetime import date, timedelta, datetime
+from datetime import date, timedelta, datetime, timezone
 
 from werkzeug.security import generate_password_hash
 
@@ -846,6 +846,62 @@ class TestWriteEndpoints:
         body = _json(resp)
         assert body["code"] == "validation_error"
         assert "date" in body["fields"]
+
+    def test_balance_post_stamps_manual_timestamp(self, client, flask_app):
+        """A successful iOS/API manual balance entry records the owner's
+        last_manual_balance_entry_at for the cached Plaid staleness gate."""
+        from conftest import _ADMIN_USER_ID
+
+        with flask_app.app_context():
+            User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at = None
+            _db.session.commit()
+
+        token = _login(client)
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        resp = client.post(
+            "/api/v1/balance",
+            headers=_bearer(token),
+            json={"amount": "1500.00", "date": date.today().isoformat()},
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        try:
+            with flask_app.app_context():
+                ts = User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at
+                assert ts is not None
+                assert ts >= before
+        finally:
+            with flask_app.app_context():
+                User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at = None
+                # Restore the seeded today balance so other tests that assert
+                # the 5000.00 seed value are not affected by this write.
+                row = Balance.query.filter_by(
+                    user_id=_ADMIN_USER_ID, date=date.today()
+                ).first()
+                if row is not None:
+                    row.amount = "5000.00"
+                _db.session.commit()
+
+    def test_balance_post_validation_failure_does_not_stamp_manual_timestamp(
+        self, client, flask_app
+    ):
+        from conftest import _ADMIN_USER_ID
+
+        with flask_app.app_context():
+            User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at = None
+            _db.session.commit()
+
+        token = _login(client)
+        resp = client.post(
+            "/api/v1/balance",
+            headers=_bearer(token),
+            json={"amount": "not-a-number", "date": date.today().isoformat()},
+            content_type="application/json",
+        )
+        assert resp.status_code == 422
+        with flask_app.app_context():
+            ts = User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at
+            assert ts is None
 
     def test_settings_and_insights_read(self, client):
         token = _login(client)

--- a/tests/test_getemail_balance_datetime.py
+++ b/tests/test_getemail_balance_datetime.py
@@ -206,6 +206,22 @@ class TestProcessEmailBalancesPersistsDatetime:
             ).first()
             assert float(row.amount) == pytest.approx(200.00)
 
+    def test_email_ingestion_does_not_stamp_manual_balance_timestamp(
+        self, flask_app, email_user
+    ):
+        """Email-derived balances must not set the user's manual entry
+        timestamp — that field is reserved for genuine manual entries."""
+        raw = _build_balance_email_bytes(
+            date_header="Sun, 24 May 2026 09:30:00 +0000"
+        )
+        with flask_app.app_context():
+            assert User.query.get(email_user).last_manual_balance_entry_at is None
+            with patch("app.getemail.imaplib.IMAP4_SSL") as mock_ssl:
+                mock_ssl.return_value = self._mock_imap([raw])
+                getemail.process_email_balances()
+
+            assert User.query.get(email_user).last_manual_balance_entry_at is None
+
     def test_falls_back_to_processing_time_when_date_header_missing(
         self, flask_app, email_user
     ):

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -1495,6 +1495,406 @@ class TestEmailBalanceVsPlaidCachedSync:
                 _deconfigure_plaid(flask_app)
 
 
+# ── Manual balance entry vs Plaid cached sync precedence ────────────────────
+
+
+class TestManualBalanceVsPlaidCachedSync:
+    """The dashboard /accounts/get sync must not overwrite a newer manually
+    entered balance with stale Plaid cached data. This sits alongside the
+    existing email and real-time refresh staleness checks.
+    """
+
+    def test_skips_when_manual_entry_newer_than_plaid_cache(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(minutes=5)
+            )
+            db.session.add(
+                Balance(user_id=plaid_user, amount=1234.56, date=date.today())
+            )
+            db.session.commit()
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    stale_cache_ts = (
+                        datetime.utcnow() - timedelta(hours=2)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=10.0,
+                            current=10.0,
+                            last_updated_datetime=stale_cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "skipped"
+                assert result["reason"] == "skipped_cached_plaid_update_manual_newer"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(1234.56)
+            finally:
+                _deconfigure_plaid(flask_app)
+
+    def test_skips_when_manual_exists_and_cache_freshness_missing(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(minutes=10)
+            )
+            db.session.add(
+                Balance(user_id=plaid_user, amount=2222.22, date=date.today())
+            )
+            db.session.commit()
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=50.0,
+                            current=50.0,
+                            last_updated_datetime=None,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "skipped"
+                assert result["reason"] == "skipped_cached_plaid_update_manual_newer"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(2222.22)
+            finally:
+                _deconfigure_plaid(flask_app)
+
+    def test_updates_when_plaid_cache_newer_than_manual_entry(
+        self, flask_app, plaid_user
+    ):
+        """Cache freshness newer than the manual entry must not be blocked by
+        the manual timestamp (email/real-time checks also pass here)."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(hours=3)
+            )
+            db.session.add(
+                Balance(user_id=plaid_user, amount=100.0, date=date.today())
+            )
+            db.session.commit()
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    fresh_cache_ts = (
+                        datetime.utcnow() - timedelta(minutes=5)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=777.0,
+                            current=800.0,
+                            last_updated_datetime=fresh_cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(777.0)
+            finally:
+                _deconfigure_plaid(flask_app)
+
+    def test_old_manual_entry_does_not_block_fresh_plaid_cache(
+        self, flask_app, plaid_user
+    ):
+        """An old manual entry must not block a Plaid cached value whose
+        freshness is newer — the comparison is purely timestamp-vs-timestamp,
+        never the balance row date or today's calendar day."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(days=3)
+            )
+            db.session.commit()
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    fresh_cache_ts = (
+                        datetime.utcnow() - timedelta(minutes=5)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=321.0,
+                            current=400.0,
+                            last_updated_datetime=fresh_cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(321.0)
+            finally:
+                _deconfigure_plaid(flask_app)
+
+    def test_proceeds_only_when_manual_email_and_realtime_all_allow(
+        self, flask_app, plaid_user
+    ):
+        """Cached update proceeds when the cache is fresher than every
+        protected timestamp (manual + email + real-time)."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            conn.last_realtime_balance_at = datetime.utcnow() - timedelta(hours=6)
+            user = User.query.get(plaid_user)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(hours=4)
+            )
+            _add_email_config(
+                plaid_user,
+                balance_email_datetime=datetime.utcnow() - timedelta(hours=5),
+            )
+            db.session.commit()
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    fresh_cache_ts = (
+                        datetime.utcnow() - timedelta(minutes=1)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=555.0,
+                            current=600.0,
+                            last_updated_datetime=fresh_cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(555.0)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_manual_blocks_even_when_email_and_realtime_would_allow(
+        self, flask_app, plaid_user
+    ):
+        """A newer manual entry alone is enough to skip, even if the email and
+        real-time checks would individually permit the update."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            conn = PlaidConnection.query.filter_by(
+                user_id=plaid_user, is_active=True
+            ).first()
+            # Real-time well in the past (past the 5-minute window and older
+            # than the cache), email old too — only the manual entry is fresh.
+            conn.last_realtime_balance_at = datetime.utcnow() - timedelta(hours=6)
+            user = User.query.get(plaid_user)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(minutes=1)
+            )
+            _add_email_config(
+                plaid_user,
+                balance_email_datetime=datetime.utcnow() - timedelta(hours=5),
+            )
+            db.session.add(
+                Balance(user_id=plaid_user, amount=4321.0, date=date.today())
+            )
+            db.session.commit()
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    cache_ts = (
+                        datetime.utcnow() - timedelta(minutes=30)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=9.0,
+                            current=9.0,
+                            last_updated_datetime=cache_ts,
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "skipped"
+                assert result["reason"] == "skipped_cached_plaid_update_manual_newer"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(4321.0)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_realtime_refresh_not_blocked_by_manual_skip_rule(
+        self, flask_app, plaid_user
+    ):
+        """Manual /accounts/balance/get is user-triggered and must remain free
+        to update today's balance even when a manual entry is newer."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(minutes=1)
+            )
+            db.session.add(
+                Balance(user_id=plaid_user, amount=10.0, date=date.today())
+            )
+            db.session.commit()
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_balance_get.return_value = (
+                        _make_balances_response(
+                            "acct-1", available=999.0, current=1000.0
+                        )
+                    )
+                    result = plaid_service.realtime_update_plaid_balance_for_user(
+                        user
+                    )
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(999.0)
+            finally:
+                _deconfigure_plaid(flask_app)
+
+    def test_cached_sync_does_not_set_manual_timestamp(
+        self, flask_app, plaid_user
+    ):
+        """A cached /accounts/get update must never stamp the manual entry
+        timestamp — only genuine manual entries do."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            assert user.last_manual_balance_entry_at is None
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1", available=42.0, current=42.0
+                        )
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+                assert result["status"] == "ok"
+                refreshed = User.query.get(plaid_user)
+                assert refreshed.last_manual_balance_entry_at is None
+            finally:
+                _deconfigure_plaid(flask_app)
+
+    def test_realtime_refresh_does_not_set_manual_timestamp(
+        self, flask_app, plaid_user
+    ):
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            user = User.query.get(plaid_user)
+            assert user.last_manual_balance_entry_at is None
+
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    mock_client.return_value.accounts_balance_get.return_value = (
+                        _make_balances_response(
+                            "acct-1", available=88.0, current=88.0
+                        )
+                    )
+                    result = plaid_service.realtime_update_plaid_balance_for_user(
+                        user
+                    )
+                assert result["status"] == "ok"
+                refreshed = User.query.get(plaid_user)
+                assert refreshed.last_manual_balance_entry_at is None
+            finally:
+                _deconfigure_plaid(flask_app)
+
+    def test_dashboard_still_loads_when_manual_skip_fires(
+        self, auth_client, flask_app
+    ):
+        """The dashboard must continue to render and use the existing balance
+        row when the Plaid cached sync is skipped because a manual entry is
+        newer than Plaid's cached freshness."""
+        from conftest import _ADMIN_USER_ID
+
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(_ADMIN_USER_ID)
+            user = User.query.get(_ADMIN_USER_ID)
+            user.last_manual_balance_entry_at = (
+                datetime.utcnow() - timedelta(minutes=3)
+            )
+            Balance.query.filter_by(
+                user_id=_ADMIN_USER_ID, date=date.today()
+            ).delete()
+            db.session.add(
+                Balance(user_id=_ADMIN_USER_ID, amount=8888.88, date=date.today())
+            )
+            db.session.commit()
+        try:
+            with patch.object(plaid_service, "_plaid_client") as mock_client:
+                stale_cache_ts = (
+                    datetime.utcnow() - timedelta(hours=2)
+                ).replace(tzinfo=timezone.utc).isoformat()
+                mock_client.return_value.accounts_get.return_value = (
+                    _make_balances_response(
+                        "acct-1",
+                        available=1.0,
+                        current=1.0,
+                        last_updated_datetime=stale_cache_ts,
+                    )
+                )
+                resp = auth_client.get("/")
+            assert resp.status_code == 200
+            with flask_app.app_context():
+                row = Balance.query.filter_by(
+                    user_id=_ADMIN_USER_ID, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(8888.88)
+        finally:
+            with flask_app.app_context():
+                PlaidConnection.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                Balance.query.filter_by(user_id=_ADMIN_USER_ID).delete()
+                admin = User.query.get(_ADMIN_USER_ID)
+                admin.last_manual_balance_entry_at = None
+                db.session.add(
+                    Balance(
+                        user_id=_ADMIN_USER_ID,
+                        amount="5000.00",
+                        date=date.today(),
+                    )
+                )
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+
 # ── Dashboard integration ───────────────────────────────────────────────────
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -315,6 +315,37 @@ class TestBalanceUpdate:
             assert len(rows) == 1
             assert str(rows[0].amount) == "250.00"
 
+    def test_manual_balance_entry_stamps_manual_timestamp(self, auth_client, flask_app):
+        """A successful web manual balance entry records the owner's
+        last_manual_balance_entry_at so the cached Plaid sync won't overwrite it."""
+        from conftest import _User as User, _Balance as Balance, _ADMIN_USER_ID, _db as db
+
+        entry_date = datetime.strptime("2099-03-03", "%Y-%m-%d").date()
+        with flask_app.app_context():
+            User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at = None
+            db.session.commit()
+
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        resp = auth_client.post(
+            "/balance",
+            data={"amount": "4242.00", "date": "2099-03-03"},
+            follow_redirects=False,
+        )
+        assert resp.status_code in (301, 302)
+
+        try:
+            with flask_app.app_context():
+                ts = User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at
+                assert ts is not None
+                assert ts >= before
+        finally:
+            with flask_app.app_context():
+                User.query.get(_ADMIN_USER_ID).last_manual_balance_entry_at = None
+                Balance.query.filter_by(
+                    user_id=_ADMIN_USER_ID, date=entry_date
+                ).delete()
+                db.session.commit()
+
 
 # ── Tests: scenario creation (POST /create_scenario) ─────────────────────────
 


### PR DESCRIPTION
Manually entered balances (web /balance and iOS POST /api/v1/balance)
could be immediately overwritten by the automatic cached /accounts/get
sync on the next dashboard load, even when Plaid's cached balance was
stale. Add last_manual_balance_entry_at to the user table, stamp it on
every successful manual entry, and gate the cached sync on it alongside
the existing email and real-time refresh staleness checks. The cached
update now proceeds only when Plaid's cached freshness is newer than
every protected timestamp.

https://claude.ai/code/session_015geCfbYx4BNAWJQDm8yyeL