### PR TITLE
Prefer Transactions freshness from /item/get when resolving Plaid cached balances

### DIFF
--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -631,8 +631,8 @@ def _today_date() -> date:
 def _normalize_naive_utc(value):
     """Coerce an ISO datetime string or aware/naive datetime to naive UTC.
 
-    Plaid returns ``balances.last_updated_datetime`` as an ISO 8601 string
-    (per SDK version, sometimes as a parsed ``datetime``). Internal
+    Plaid freshness fields are ISO 8601 strings (per SDK version, sometimes
+    parsed ``datetime`` objects). Internal
     timestamps like ``last_realtime_balance_at`` are naive UTC, so cast
     both sides to the same form before comparing.
     """
@@ -648,6 +648,39 @@ def _normalize_naive_utc(value):
     if value.tzinfo is not None:
         value = value.astimezone(timezone.utc).replace(tzinfo=None)
     return value
+
+
+def _nested_get(obj, *path):
+    """Return a nested value from SDK model objects or dictionaries.
+
+    Plaid SDK responses are model objects in production, while tests and some
+    SDK versions may expose dict-like shapes. Keep this helper intentionally
+    small so freshness resolution can support both without storing raw payloads.
+    """
+    current = obj
+    for key in path:
+        if current is None:
+            return None
+        if isinstance(current, dict):
+            current = current.get(key)
+        else:
+            current = getattr(current, key, None)
+    return current
+
+
+def _transactions_last_successful_update(item_response):
+    """Return Plaid Item Transactions freshness, when present.
+
+    Plaid exposes the Transactions product's cached-data freshness on
+    ``item.status.transactions.last_successful_update`` from /item/get.
+    """
+    return _nested_get(
+        item_response,
+        "item",
+        "status",
+        "transactions",
+        "last_successful_update",
+    )
 
 
 def _newest_email_balance_datetime(user_id: int) -> Optional[datetime]:
@@ -752,6 +785,7 @@ def update_plaid_balance_for_user(user) -> dict:
     from plaid.exceptions import ApiException
     from plaid.model.accounts_get_request import AccountsGetRequest
     from plaid.model.accounts_get_request_options import AccountsGetRequestOptions
+    from plaid.model.item_get_request import ItemGetRequest
 
     try:
         access_token = decrypt_password(conn.encrypted_access_token)
@@ -804,6 +838,28 @@ def update_plaid_balance_for_user(user) -> dict:
             cache[user.id] = result
         return result
 
+    item_response = None
+    try:
+        item_response = client.item_get(ItemGetRequest(access_token=access_token))
+    except ApiException as exc:
+        info = _plaid_error_info(exc)
+        logger.warning(
+            "Plaid item_get failed while resolving cached balance freshness for "
+            "user %s (request_id=%s, error_type=%s, error_code=%s, "
+            "error_message=%s); falling back to account balance freshness",
+            user.id,
+            info.get("request_id"),
+            info.get("error_type"),
+            info.get("error_code"),
+            info.get("error_message"),
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected Plaid item_get error while resolving cached balance "
+            "freshness for user %s; falling back to account balance freshness",
+            user.id,
+        )
+
     # Pull the matching account from the response.
     target = None
     try:
@@ -830,18 +886,26 @@ def update_plaid_balance_for_user(user) -> dict:
     balances = getattr(target, "balances", None)
     available = getattr(balances, "available", None) if balances is not None else None
     current = getattr(balances, "current", None) if balances is not None else None
-    cache_updated_at = (
+    balance_cache_updated_at = (
         getattr(balances, "last_updated_datetime", None)
         if balances is not None
         else None
     )
+    transactions_cache_updated_at = _transactions_last_successful_update(item_response)
 
-    # Defense in depth: if Plaid tells us when its cached balance was last
-    # refreshed and that timestamp is older than our most recent real-time
-    # refresh, the cached value is stale relative to the live one we already
-    # wrote. Don't overwrite. (The 5-minute brute-force protection above
-    # covers institutions that don't populate last_updated_datetime.)
-    normalized_cache_updated_at = _normalize_naive_utc(cache_updated_at)
+    # Defense in depth: resolve Plaid cached freshness by preferring the
+    # Transactions product timestamp from /item/get
+    # (item.status.transactions.last_successful_update), then falling back to
+    # the account balance timestamp from /accounts/get
+    # (balances.last_updated_datetime). If neither is present, freshness stays
+    # unknown and the manual/email guards below preserve the local balance.
+    normalized_transactions_updated_at = _normalize_naive_utc(
+        transactions_cache_updated_at
+    )
+    normalized_balance_updated_at = _normalize_naive_utc(balance_cache_updated_at)
+    normalized_cache_updated_at = (
+        normalized_transactions_updated_at or normalized_balance_updated_at
+    )
     if (
         conn.last_realtime_balance_at is not None
         and normalized_cache_updated_at is not None
@@ -879,10 +943,9 @@ def update_plaid_balance_for_user(user) -> dict:
         return result
 
     # Don't overwrite an email-derived balance with a possibly-stale Plaid
-    # cached value. Plaid's /accounts/get returns cached data whose freshness
-    # is exposed via ``balances.last_updated_datetime``; if that is older than
-    # (or unknown relative to) the most recent balance email we've processed,
-    # the email value is authoritative regardless of which calendar day either
+    # cached value. If the resolved Plaid cached freshness is older than (or
+    # unknown relative to) the most recent balance email we've processed, the
+    # email value is authoritative regardless of which calendar day either
     # falls on.
     email_balance_dt = _newest_email_balance_datetime(user.id)
     if email_balance_dt is not None and (

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -93,6 +93,13 @@ def _make_balances_response(account_id, *, available, current, last_updated_date
     return SimpleNamespace(accounts=[account])
 
 
+def _make_item_response(last_successful_update=None):
+    transactions = SimpleNamespace(last_successful_update=last_successful_update)
+    status = SimpleNamespace(transactions=transactions)
+    item = SimpleNamespace(status=status)
+    return SimpleNamespace(item=item)
+
+
 def _add_connection(user_id, **overrides):
     defaults = dict(
         user_id=user_id,
@@ -1278,6 +1285,99 @@ class TestEmailBalanceVsPlaidCachedSync:
                     user_id=plaid_user, date=date.today()
                 ).first()
                 assert float(row.amount) == pytest.approx(777.0)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_transactions_freshness_can_allow_update_when_balance_timestamp_is_old(
+        self, flask_app, plaid_user
+    ):
+        """Prefer /item/get Transactions freshness over account balance freshness."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            email_ts = datetime.utcnow() - timedelta(hours=1)
+            _add_email_config(plaid_user, balance_email_datetime=email_ts)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=100.0, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    old_balance_ts = (
+                        datetime.utcnow() - timedelta(hours=3)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    fresh_transactions_ts = (
+                        datetime.utcnow() - timedelta(minutes=5)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=888.0,
+                            current=900.0,
+                            last_updated_datetime=old_balance_ts,
+                        )
+                    )
+                    mock_client.return_value.item_get.return_value = _make_item_response(
+                        last_successful_update=fresh_transactions_ts
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+
+                assert result["status"] == "ok"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(888.0)
+            finally:
+                Email.query.filter_by(user_id=plaid_user).delete()
+                db.session.commit()
+                _deconfigure_plaid(flask_app)
+
+    def test_transactions_freshness_wins_over_newer_balance_timestamp(
+        self, flask_app, plaid_user
+    ):
+        """A stale Transactions timestamp blocks even with fresher balance timestamp."""
+        with flask_app.app_context():
+            _configure_plaid(flask_app)
+            _add_connection(plaid_user)
+            email_ts = datetime.utcnow() - timedelta(hours=1)
+            _add_email_config(plaid_user, balance_email_datetime=email_ts)
+            db.session.add(
+                Balance(user_id=plaid_user, amount=1234.56, date=date.today())
+            )
+            db.session.commit()
+
+            user = User.query.get(plaid_user)
+            try:
+                with patch.object(plaid_service, "_plaid_client") as mock_client:
+                    fresh_balance_ts = (
+                        datetime.utcnow() - timedelta(minutes=5)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    stale_transactions_ts = (
+                        datetime.utcnow() - timedelta(hours=3)
+                    ).replace(tzinfo=timezone.utc).isoformat()
+                    mock_client.return_value.accounts_get.return_value = (
+                        _make_balances_response(
+                            "acct-1",
+                            available=10.0,
+                            current=10.0,
+                            last_updated_datetime=fresh_balance_ts,
+                        )
+                    )
+                    mock_client.return_value.item_get.return_value = _make_item_response(
+                        last_successful_update=stale_transactions_ts
+                    )
+                    result = plaid_service.update_plaid_balance_for_user(user)
+
+                assert result["status"] == "skipped"
+                assert result["reason"] == "skipped_cached_plaid_update_email_newer"
+                row = Balance.query.filter_by(
+                    user_id=plaid_user, date=date.today()
+                ).first()
+                assert float(row.amount) == pytest.approx(1234.56)
             finally:
                 Email.query.filter_by(user_id=plaid_user).delete()
                 db.session.commit()


### PR DESCRIPTION
### Motivation

- Improve correctness when deciding whether a Plaid cached `/accounts/get` balance is fresh by consulting the Transactions product freshness exposed by `/item/get` so we don't overwrite newer manual/email/realtime balances. 

### Description

- Added a small helper `_nested_get` to read nested fields from either SDK model objects or dict-like responses and `_transactions_last_successful_update` to extract `item.status.transactions.last_successful_update`.
- Call `ItemGetRequest`/`client.item_get` and prefer the Transactions `last_successful_update` timestamp when resolving Plaid cached freshness, falling back to `balances.last_updated_datetime` from `/accounts/get` if needed.
- Normalized and compared freshness timestamps (`_normalize_naive_utc`) and updated the cached-freshness logic to skip updates when Plaid cache is older than realtime/manual/email sources.
- Added test helper `_make_item_response` and two tests in `tests/test_plaid_integration.py` covering the Transactions freshness winning or blocking updates as intended.

### Testing

- Ran the affected integration tests in `tests/test_plaid_integration.py`, including the new `TestEmailBalanceVsPlaidCachedSync` cases, using `pytest` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a256fa110148320a22026c40f691ffa)