### PR TITLE
Fix Plaid transactions freshness lookup

### DIFF
--- a/app/plaid_service.py
+++ b/app/plaid_service.py
@@ -672,14 +672,25 @@ def _transactions_last_successful_update(item_response):
     """Return Plaid Item Transactions freshness, when present.
 
     Plaid exposes the Transactions product's cached-data freshness on
-    ``item.status.transactions.last_successful_update`` from /item/get.
+    ``status.transactions.last_successful_update`` from /item/get. Older
+    mocks and SDK-shaped fixtures may have placed ``status`` under ``item``,
+    so keep that as a compatibility fallback after checking the production
+    shape first.
     """
-    return _nested_get(
-        item_response,
-        "item",
-        "status",
-        "transactions",
-        "last_successful_update",
+    return (
+        _nested_get(
+            item_response,
+            "status",
+            "transactions",
+            "last_successful_update",
+        )
+        or _nested_get(
+            item_response,
+            "item",
+            "status",
+            "transactions",
+            "last_successful_update",
+        )
     )
 
 
@@ -895,7 +906,7 @@ def update_plaid_balance_for_user(user) -> dict:
 
     # Defense in depth: resolve Plaid cached freshness by preferring the
     # Transactions product timestamp from /item/get
-    # (item.status.transactions.last_successful_update), then falling back to
+    # (status.transactions.last_successful_update), then falling back to
     # the account balance timestamp from /accounts/get
     # (balances.last_updated_datetime). If neither is present, freshness stays
     # unknown and the manual/email guards below preserve the local balance.

--- a/tests/test_plaid_integration.py
+++ b/tests/test_plaid_integration.py
@@ -96,8 +96,7 @@ def _make_balances_response(account_id, *, available, current, last_updated_date
 def _make_item_response(last_successful_update=None):
     transactions = SimpleNamespace(last_successful_update=last_successful_update)
     status = SimpleNamespace(transactions=transactions)
-    item = SimpleNamespace(status=status)
-    return SimpleNamespace(item=item)
+    return SimpleNamespace(status=status)
 
 
 def _add_connection(user_id, **overrides):
@@ -118,6 +117,49 @@ def _add_connection(user_id, **overrides):
     db.session.add(conn)
     db.session.commit()
     return conn
+
+
+# ── Freshness helpers ────────────────────────────────────────────────────────
+
+
+def test_transactions_freshness_reads_top_level_item_get_status():
+    stale_nested = SimpleNamespace(
+        status=SimpleNamespace(
+            transactions=SimpleNamespace(
+                last_successful_update="2026-01-01T00:00:00Z"
+            )
+        )
+    )
+    response = SimpleNamespace(
+        status=SimpleNamespace(
+            transactions=SimpleNamespace(
+                last_successful_update="2026-01-02T00:00:00Z"
+            )
+        ),
+        item=stale_nested,
+    )
+
+    assert (
+        plaid_service._transactions_last_successful_update(response)
+        == "2026-01-02T00:00:00Z"
+    )
+
+
+def test_transactions_freshness_keeps_legacy_nested_fallback():
+    response = {
+        "item": {
+            "status": {
+                "transactions": {
+                    "last_successful_update": "2026-01-03T00:00:00Z"
+                }
+            }
+        }
+    }
+
+    assert (
+        plaid_service._transactions_last_successful_update(response)
+        == "2026-01-03T00:00:00Z"
+    )
 
 
 # ── Configuration ────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Plaid's /item/get response exposes the Transactions freshness on the top-level `status.transactions.last_successful_update`, but the code previously only looked under `item.status...`, which could cause stale cached balances to win over fresher transaction-driven timestamps.

### Description
- Change `_transactions_last_successful_update()` to prefer `status.transactions.last_successful_update` and fall back to the legacy `item.status.transactions.last_successful_update` for compatibility.
- Update the nearby comment in `update_plaid_balance_for_user()` to reflect the corrected production response path.
- Update the Plaid test fixture shape in `tests/test_plaid_integration.py` to mirror the production response and add two unit tests that verify top-level precedence and legacy fallback.
- Keep the legacy nested fallback so older mocks/fixtures and test shapes remain supported.

### Testing
- Ran the specific new/affected tests with `python -m pytest -q tests/test_plaid_integration.py::test_transactions_freshness_reads_top_level_item_get_status tests/test_plaid_integration.py::test_transactions_freshness_keeps_legacy_nested_fallback tests/test_plaid_integration.py::TestEmailBalanceVsPlaidCachedSync::test_transactions_freshness_wins_over_newer_balance_timestamp` and they passed.
- Ran the full test suite with `python -m pytest -q` and all tests passed (457 passed, 305 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257e4412288320b53b47061f86943d)