### PR TITLE
Streamline iOS Cloud activation flow

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Login/LoginView.swift
@@ -70,6 +70,24 @@ struct LoginView: View {
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
+                if session.appMode == .cloud {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("New to PyCashFlow Cloud?")
+                            .foregroundStyle(AppTheme.textSecondary)
+                        NavigationLink {
+                            CloudActivationEmailView()
+                        } label: {
+                            Text("Start 7-Day Free Trial")
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                    Text("Already have an account?")
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
                 VStack(spacing: 12) {
                     if challenge == nil && showPasswordLoginFields {
                         TextField("Email", text: $email)
@@ -186,11 +204,6 @@ struct LoginView: View {
                         }
                     }
                     .surfaceCard()
-                } else {
-                    NavigationLink("Sign up for PyCashFlow Cloud") {
-                        SubscriptionPaywallView()
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
                 }
 
             }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/CloudActivationEmailView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/CloudActivationEmailView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// Lightweight email collector shown before the StoreKit paywall. It captures
+/// only the address the customer wants to use for PyCashFlow Cloud, then hands
+/// it off to `SubscriptionPaywallView` so the subscribe/restore flow is
+/// pre-filled without asking for any other registration details.
+struct CloudActivationEmailView: View {
+    @State private var email = ""
+    @FocusState private var emailFocused: Bool
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Create your Cloud account")
+                        .font(.title2.bold())
+                        .foregroundStyle(AppTheme.textPrimary)
+                    Text("Enter the email you want to use for PyCashFlow Cloud.")
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                VStack(alignment: .leading, spacing: 12) {
+                    TextField("Email", text: $email)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .keyboardType(.emailAddress)
+                        .submitLabel(.continue)
+                        .focused($emailFocused)
+                        .onSubmit { emailFocused = false }
+                        .fieldStyle()
+
+                    Text("We’ll send your setup link here after Apple confirms your subscription.")
+                        .font(.caption)
+                        .foregroundStyle(AppTheme.textMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    NavigationLink {
+                        SubscriptionPaywallView(prefilledEmail: trimmedEmail, showsEmailField: false)
+                    } label: {
+                        Text("Continue")
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(!isValidEmail)
+                    .simultaneousGesture(TapGesture().onEnded { dismissKeyboard() })
+                }
+                .surfaceCard()
+            }
+            .padding(20)
+        }
+        .appBackground()
+        .navigationTitle("Cloud Account")
+        .navigationBarTitleDisplayMode(.inline)
+        .scrollDismissesKeyboard(.immediately)
+    }
+
+    private var trimmedEmail: String {
+        email.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Non-empty and shaped like an address (`local@domain.tld`). Kept
+    /// deliberately permissive — final ownership is confirmed via the setup
+    /// link emailed after Apple verifies the subscription.
+    private var isValidEmail: Bool {
+        let value = trimmedEmail
+        guard !value.isEmpty else { return false }
+        let pattern = "^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$"
+        return value.range(of: pattern, options: .regularExpression) != nil
+    }
+}

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -4,23 +4,34 @@ import StoreKit
 struct SubscriptionPaywallView: View {
     @EnvironmentObject var session: SessionManager
     @StateObject private var manager = StoreKitSubscriptionManager()
-    @State private var cloudEmail = ""
+    @State private var cloudEmail: String
+    private let showsEmailField: Bool
+
+    init(prefilledEmail: String? = nil, showsEmailField: Bool = true) {
+        _cloudEmail = State(initialValue: prefilledEmail ?? "")
+        self.showsEmailField = showsEmailField
+    }
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
-                Text("Enter the email address you would like to use for your PyCashFlow Cloud account.")
-                    .font(.footnote)
-                    .foregroundStyle(AppTheme.textSecondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if showsEmailField {
+                    Text("Enter the email address you would like to use for your PyCashFlow Cloud account.")
+                        .font(.footnote)
+                        .foregroundStyle(AppTheme.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
 
-                TextField("Cloud account email", text: $cloudEmail)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .padding(12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
-                    .foregroundStyle(AppTheme.textPrimary)
+                    TextField("Cloud account email", text: $cloudEmail)
+                        .textInputAutocapitalization(.never)
+                        .autocorrectionDisabled()
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(AppTheme.surfaceLight.opacity(0.45), in: RoundedRectangle(cornerRadius: 10))
+                        .foregroundStyle(AppTheme.textPrimary)
+                } else if !resolvedEmail.isEmpty {
+                    statusLine(label: "Cloud account email", value: resolvedEmail)
+                        .cardRow()
+                }
 
                 if let status = session.billingStatus {
                     VStack(alignment: .leading, spacing: 8) {
@@ -45,7 +56,7 @@ struct SubscriptionPaywallView: View {
                                 .font(.footnote)
                                 .foregroundStyle(AppTheme.textSecondary)
                                 .fixedSize(horizontal: false, vertical: true)
-                            Button("Subscribe • \(product.displayPrice)") {
+                            Button("Start 7-Day Free Trial") {
                                 Task {
                                     await manager.purchase(
                                         product,
@@ -94,7 +105,7 @@ struct SubscriptionPaywallView: View {
         .appBackground()
         .task {
             await manager.loadProducts()
-            if cloudEmail.isEmpty {
+            if showsEmailField && cloudEmail.isEmpty {
                 cloudEmail = session.user?.email ?? ""
             }
         }


### PR DESCRIPTION
Rearrange the login page so the Cloud mode flow leads with a renamed
"Start 7-Day Free Trial" subscribe button under a "New to PyCashFlow
Cloud?" heading, followed by an "Already have an account?" heading
above the existing login card. The cloud selector stays first.

Add CloudActivationEmailView, a minimal email collector shown before the
paywall. It asks only for the email (validated as non-empty and
well-formed) and forwards it to SubscriptionPaywallView with the field
hidden.

SubscriptionPaywallView gains an initializer
(prefilledEmail:showsEmailField:) so it can pre-fill the cloud email and
hide the entry field, showing a read-only email row instead. The
subscribe button is renamed to "Start 7-Day Free Trial". Purchase and
restore continue to use resolvedEmail, and the existing product display,
App Store disclosure, restore button, and status/error messaging are
unchanged.