### PR TITLE
Handle out-of-band StoreKit transactions with background listener

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -9,6 +9,24 @@ final class StoreKitSubscriptionManager: ObservableObject {
     @Published var errorMessage: String?
     @Published var statusMessage: String?
 
+    /// Long-lived task that observes transactions arriving outside the direct
+    /// `purchase()` flow (Ask to Buy approvals, renewals, or purchases that were
+    /// interrupted by app termination).
+    private var updatesListenerTask: Task<Void, Never>?
+
+    /// Account context from the most recent purchase/restore, used to submit
+    /// out-of-band transaction updates to the backend.
+    private var lastKnownEmail: String?
+    private var lastKnownToken: String?
+
+    init() {
+        startObservingTransactionUpdates()
+    }
+
+    deinit {
+        updatesListenerTask?.cancel()
+    }
+
     func loadProducts() async {
         guard !AppEnvironment.appStoreProductIDs.isEmpty else {
             errorMessage = "Subscription products are not configured for this build."
@@ -37,6 +55,9 @@ final class StoreKitSubscriptionManager: ObservableObject {
             errorMessage = "Please enter a valid email address to activate your subscription."
             return
         }
+
+        lastKnownEmail = email
+        lastKnownToken = token
 
         isBusy = true
         errorMessage = nil
@@ -74,6 +95,9 @@ final class StoreKitSubscriptionManager: ObservableObject {
             return
         }
 
+        lastKnownEmail = email
+        lastKnownToken = token
+
         isBusy = true
         errorMessage = nil
         statusMessage = "Restoring App Store purchases..."
@@ -94,6 +118,37 @@ final class StoreKitSubscriptionManager: ObservableObject {
         }
 
         isBusy = false
+    }
+
+    /// Starts listening for transaction updates as soon as the manager is
+    /// created so successful purchases delivered outside `purchase()` are not
+    /// missed.
+    private func startObservingTransactionUpdates() {
+        guard updatesListenerTask == nil else { return }
+        updatesListenerTask = Task { [weak self] in
+            for await update in StoreKit.Transaction.updates {
+                await self?.handle(transactionUpdate: update)
+            }
+        }
+    }
+
+    private func handle(transactionUpdate result: VerificationResult<StoreKit.Transaction>) async {
+        guard let transaction = try? checkVerified(result) else { return }
+
+        guard let email = lastKnownEmail, !email.isEmpty else {
+            // No account context yet. Leave the transaction unfinished so StoreKit
+            // redelivers it once the user activates or restores a subscription.
+            return
+        }
+
+        do {
+            try await submit(transaction: transaction, email: email, token: lastKnownToken)
+            await transaction.finish()
+            errorMessage = nil
+            statusMessage = "Subscription updated from the App Store."
+        } catch {
+            errorMessage = "A subscription update could not be verified with backend."
+        }
     }
 
     private func submit(transaction: StoreKit.Transaction, email: String, token: String?) async throws {


### PR DESCRIPTION
## Summary
This change adds robust handling for App Store transactions that arrive outside the direct purchase flow, such as Ask to Buy approvals, subscription renewals, and purchases interrupted by app termination.

## Key Changes
- Added a long-lived `updatesListenerTask` that continuously observes `StoreKit.Transaction.updates` to capture transactions delivered asynchronously
- Implemented `startObservingTransactionUpdates()` method that begins listening as soon as the manager is initialized, ensuring no transactions are missed
- Added `handle(transactionUpdate:)` method to process out-of-band transactions and submit them to the backend with stored account context
- Store the most recent email and token (`lastKnownEmail`, `lastKnownToken`) from purchase/restore operations to use when handling background transactions
- Updated `purchase()` and `restore()` methods to cache the account context for later use
- Added proper cleanup in `deinit` to cancel the listener task when the manager is deallocated
- Implemented graceful handling when account context is not yet available—transactions are left unfinished so StoreKit will redeliver them once the user activates or restores a subscription

## Notable Implementation Details
- The transaction listener uses a weak self reference to prevent retain cycles
- Transaction verification is performed before processing to ensure authenticity
- The implementation defers transaction finishing until backend verification succeeds, allowing StoreKit to redeliver if needed
- User-facing status and error messages are updated to reflect subscription changes from background transactions

https://claude.ai/code/session_01DRhP7vV6JNf4qa8Uo6Fmii