### PR TITLE
Own StoreKit updates listener at app lifetime

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/App/PyCashFlowApp.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/PyCashFlowApp.swift
@@ -6,6 +6,7 @@ import UIKit
 @main
 struct PyCashFlowApp: App {
     @StateObject private var session = SessionManager()
+    @StateObject private var subscriptionManager = StoreKitSubscriptionManager()
     @Environment(\.scenePhase) private var scenePhase
 
     init() {
@@ -16,11 +17,13 @@ struct PyCashFlowApp: App {
         WindowGroup {
             RootView()
                 .environmentObject(session)
+                .environmentObject(subscriptionManager)
         }
         .onChange(of: scenePhase) { _, newPhase in
             guard newPhase == .active, session.isAuthenticated else { return }
             Task {
                 await session.refreshSubscriptionState(forceProfileRefresh: false)
+                await subscriptionManager.reprocessPendingTransactions()
             }
         }
     }

--- a/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/App/RootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct RootView: View {
     @EnvironmentObject var session: SessionManager
+    @EnvironmentObject var subscriptionManager: StoreKitSubscriptionManager
     @State private var selectedSection: AppSection = .dashboard
 
     var body: some View {
@@ -29,7 +30,22 @@ struct RootView: View {
             }
         }
         .task {
+            // Let out-of-band StoreKit transactions resolve account context from
+            // the live session, so renewals or interrupted purchases redelivered
+            // on a later launch are reconciled with the backend without
+            // persisting the bearer token to disk.
+            subscriptionManager.accountContextProvider = { [weak session] in
+                guard let session, session.isAuthenticated,
+                      let email = session.user?.email, !email.isEmpty else {
+                    return nil
+                }
+                return StoreKitSubscriptionManager.AccountContext(
+                    email: email,
+                    token: session.token
+                )
+            }
             await session.bootstrap()
+            await subscriptionManager.reprocessPendingTransactions()
         }
         .onChange(of: session.isAuthenticated) { _, isAuthenticated in
             if isAuthenticated {

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -19,6 +19,22 @@ final class StoreKitSubscriptionManager: ObservableObject {
     private var lastKnownEmail: String?
     private var lastKnownToken: String?
 
+    /// Account context for the signed-in user, derived from the live session
+    /// rather than persisted to disk. This lets transactions delivered outside
+    /// an explicit purchase/restore (renewals, Ask to Buy approvals, or
+    /// purchases redelivered on a later launch) be reconciled with the backend
+    /// even when this manager's in-memory context has been lost to a relaunch.
+    var accountContextProvider: (() -> AccountContext?)?
+
+    struct AccountContext {
+        let email: String
+        let token: String?
+    }
+
+    /// Guards against the cold-launch and scene-activation paths sweeping
+    /// `Transaction.unfinished` at the same time and submitting a transaction twice.
+    private var isReprocessing = false
+
     init() {
         startObservingTransactionUpdates()
     }
@@ -132,23 +148,48 @@ final class StoreKitSubscriptionManager: ObservableObject {
         }
     }
 
+    /// Submits and finishes any transactions StoreKit is still holding as
+    /// unfinished. Call this once account context becomes available (for
+    /// example after the session loads its user) so a purchase interrupted by
+    /// app termination is reconciled with the backend on the next launch rather
+    /// than only the one after that.
+    func reprocessPendingTransactions() async {
+        guard !isReprocessing else { return }
+        isReprocessing = true
+        defer { isReprocessing = false }
+
+        for await update in StoreKit.Transaction.unfinished {
+            await handle(transactionUpdate: update)
+        }
+    }
+
     private func handle(transactionUpdate result: VerificationResult<StoreKit.Transaction>) async {
         guard let transaction = try? checkVerified(result) else { return }
 
-        guard let email = lastKnownEmail, !email.isEmpty else {
+        guard let context = resolvedAccountContext() else {
             // No account context yet. Leave the transaction unfinished so StoreKit
-            // redelivers it once the user activates or restores a subscription.
+            // redelivers it once the user signs in, activates, or restores a
+            // subscription and account context becomes available.
             return
         }
 
         do {
-            try await submit(transaction: transaction, email: email, token: lastKnownToken)
+            try await submit(transaction: transaction, email: context.email, token: context.token)
             await transaction.finish()
             errorMessage = nil
             statusMessage = "Subscription updated from the App Store."
         } catch {
             errorMessage = "A subscription update could not be verified with backend."
         }
+    }
+
+    /// Prefers the email/token captured by an in-progress purchase or restore,
+    /// then falls back to the signed-in session so context survives relaunches.
+    private func resolvedAccountContext() -> AccountContext? {
+        if let email = lastKnownEmail, !email.isEmpty {
+            return AccountContext(email: email, token: lastKnownToken)
+        }
+        return accountContextProvider?()
     }
 
     private func submit(transaction: StoreKit.Transaction, email: String, token: String?) async throws {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -3,7 +3,7 @@ import StoreKit
 
 struct SubscriptionPaywallView: View {
     @EnvironmentObject var session: SessionManager
-    @StateObject private var manager = StoreKitSubscriptionManager()
+    @EnvironmentObject private var manager: StoreKitSubscriptionManager
     @State private var cloudEmail: String
     private let showsEmailField: Bool
 


### PR DESCRIPTION
The Transaction.updates listener previously lived on the
StoreKitSubscriptionManager that SubscriptionPaywallView created as a
@StateObject. Since the paywall is only shown to blocked cloud users,
already-active users had no listener alive, so renewal/refund/Ask-to-Buy
updates delivered while on the dashboard or settings were never submitted
to the backend or finished.

Move the manager to an app-lifetime @StateObject in PyCashFlowApp and
inject it as an environment object so the listener runs for the whole
session. SubscriptionPaywallView now consumes the shared manager.

The account context for out-of-band transactions was also only kept in
memory, so a purchase interrupted by app termination could not be
reconciled after relaunch. Derive context from the live session
(keychain token + profile email) via an accountContextProvider instead of
persisting the bearer token to disk, and sweep Transaction.unfinished once
the session loads its user (cold launch and scene activation).