### PR TITLE
Harden billing endpoint and fix admin user-edit bugs

### DIFF
--- a/app/api/routes/billing.py
+++ b/app/api/routes/billing.py
@@ -14,7 +14,7 @@ from flask import current_app, request
 from sqlalchemy.exc import IntegrityError
 from werkzeug.security import generate_password_hash
 
-from app import db
+from app import db, limiter
 from app.models import Subscription, User
 from app.getemail import send_password_setup_email
 from app.password_setup import (
@@ -462,6 +462,7 @@ def api_stripe_webhook():
 
 
 @api.route("/billing/verify-appstore", methods=["POST"])
+@limiter.limit("10 per hour")
 def api_verify_appstore():
     body = request.get_json(silent=True) or {}
 

--- a/app/main.py
+++ b/app/main.py
@@ -934,16 +934,16 @@ def update_user():
             # Handle role assignment
             role = request.form.get('role', 'guest')
             if role == 'global_admin':
-                my_data.admin = True
-                my_data.is_global_admin = True
+                current.admin = True
+                current.is_global_admin = True
                 # IMPORTANT: Global admins must always be active
-                my_data.is_active = True
+                current.is_active = True
             elif role == 'admin':
-                my_data.admin = True
-                my_data.is_global_admin = False
+                current.admin = True
+                current.is_global_admin = False
             else:  # guest
-                my_data.admin = False
-                my_data.is_global_admin = False
+                current.admin = False
+                current.is_global_admin = False
 
         db.session.commit()
         flash("Updated Successfully")

--- a/app/templates/global_admin.html
+++ b/app/templates/global_admin.html
@@ -189,6 +189,7 @@
                     </div>
                     <div class="modal-body">
                         <form action="{{url_for('main.update_user')}}" method="POST">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <input type="hidden" name="id" value="{{user.id}}">
                             <div class="form-group-modern">
                                 <label class="form-label-modern"><i class="fa-solid fa-user"></i> Name</label>
@@ -397,6 +398,7 @@
                     </div>
                     <div class="modal-body">
                         <form action="{{url_for('main.update_user')}}" method="POST">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <input type="hidden" name="id" value="{{owner.id}}">
                             <div class="form-group-modern">
                                 <label class="form-label-modern"><i class="fa-solid fa-user"></i> Name</label>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ os.environ.setdefault("PAYMENTS_ENABLED", "false")
 # ── Capture real app references BEFORE stubs are set up ──────────────────────
 # conftest.py is loaded before test_*.py files, so all imports here use the
 # real modules.  Stubs installed later do NOT affect already-bound names.
-from app import create_app as _create_app, db as _db               # noqa: E402
+from app import create_app as _create_app, db as _db, limiter as _limiter  # noqa: E402
 from app.models import (
     User as _User,
     Balance as _Balance,
@@ -56,11 +56,16 @@ from werkzeug.security import generate_password_hash                # noqa: E402
 # Calling create_app() here ensures internal blueprint/model imports happen
 # with the real modules, so route handlers work correctly in route tests.
 _test_app = _create_app()
+# Flask-Limiter reads RATELIMIT_ENABLED during init_app() (already run inside
+# create_app), so updating config afterwards is not enough; disable the live
+# singleton directly so rate limits don't interfere with the test suite.
+_limiter.enabled = False
 _test_app.config.update(
     {
         "TESTING": True,
         "WTF_CSRF_ENABLED": False,
         "WTF_CSRF_CHECK_DEFAULT": False,
+        "RATELIMIT_ENABLED": False,  # mirrored on the limiter singleton below
         "SESSION_COOKIE_SECURE": False,
         "SECRET_KEY": "pytest-secret-key-32chars-minimum!",
     }


### PR DESCRIPTION
- Add 10/hour rate limit to unauthenticated /billing/verify-appstore to
  prevent account-creation/password-setup-email abuse (email bombing,
  account squatting).
- Fix NameError in update_user: role assignment wrote to an undefined
  'my_data' instead of the fetched 'current' user, causing every
  global-admin role change to 500 before commit.
- Add missing CSRF token fields to the two update_user forms in
  global_admin.html (previously rejected with 400).
- Disable Flask-Limiter in the test harness so suite-wide repeated calls
  don't trip the new limit.