### PR TITLE
Make guest user roles immutable

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -929,10 +929,14 @@ def update_user():
         current.name = new_name
         current.email = new_email
 
-        # Global admins can change roles, Account Owners cannot
-        if current_user.is_global_admin:
+        # Global admins can change roles, Account Owners cannot.
+        # Guest accounts are permanent: once a guest, always a guest. Any
+        # posted role for a guest is ignored so a guest can never be promoted
+        # (which would leave them with inconsistent ownership links).
+        is_guest = current.account_owner_id is not None or current.owner_user_id is not None
+        if current_user.is_global_admin and not is_guest:
             # Handle role assignment
-            role = request.form.get('role', 'guest')
+            role = request.form.get('role')
             if role == 'global_admin':
                 current.admin = True
                 current.is_global_admin = True
@@ -941,9 +945,9 @@ def update_user():
             elif role == 'admin':
                 current.admin = True
                 current.is_global_admin = False
-            else:  # guest
-                current.admin = False
-                current.is_global_admin = False
+            # Any other value is ignored: non-guests cannot be demoted to
+            # guests either, since real guests are created via add_guest and
+            # must be linked to an account owner.
 
         db.session.commit()
         flash("Updated Successfully")

--- a/app/templates/global_admin.html
+++ b/app/templates/global_admin.html
@@ -155,10 +155,7 @@
                                 </div>
                                 <div class="form-group-modern">
                                     <label class="form-label-modern"><i class="fa-solid fa-shield-halved"></i> User Role</label>
-                                    <select name="role" class="form-control-modern">
-                                        <option value="global_admin" {% if guest.is_global_admin %}selected{% endif %}>Global Admin</option>
-                                        <option value="admin" {% if not guest.is_global_admin %}selected{% endif %}>Account Owner</option>
-                                    </select>
+                                    <input type="text" class="form-control-modern" value="Guest" disabled>
                                 </div>
                                 <div style="display: flex; gap: 0.5rem; margin-top: 1.5rem;">
                                     <button class="btn-primary-modern btn-modern" type="submit" style="flex: 1;">
@@ -364,10 +361,7 @@
                                 </div>
                                 <div class="form-group-modern">
                                     <label class="form-label-modern"><i class="fa-solid fa-shield-halved"></i> User Role</label>
-                                    <select name="role" class="form-control-modern">
-                                        <option value="global_admin" {% if guest.is_global_admin %}selected{% endif %}>Global Admin</option>
-                                        <option value="admin" {% if not guest.is_global_admin %}selected{% endif %}>Account Owner</option>
-                                    </select>
+                                    <input type="text" class="form-control-modern" value="Guest" disabled>
                                 </div>
                                 <div style="display: flex; gap: 0.5rem; margin-top: 1.5rem;">
                                     <button class="btn-primary-modern btn-modern" type="submit" style="flex: 1;">

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -535,6 +535,99 @@ def test_delete_owner_with_guest_passkey_does_not_break_integrity(
     ).first() is None
 
 
+def test_update_user_cannot_change_guest_role(auth_client, app_ctx, user_model):
+    """Once a guest, always a guest: posted roles for guests are ignored."""
+    db = app_ctx
+    acting_admin = user_model.query.filter_by(email="admin@test.local").first()
+    acting_admin.is_global_admin = True
+    db.session.flush()
+
+    owner = user_model(
+        email="owner-guest-role@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Owner Of Guest",
+        admin=True,
+        is_active=True,
+        account_owner_id=None,
+        is_global_admin=False,
+    )
+    db.session.add(owner)
+    db.session.flush()
+
+    guest = user_model(
+        email="guest-role-locked@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Role Locked Guest",
+        admin=False,
+        is_active=True,
+        account_owner_id=owner.id,
+        owner_user_id=owner.id,
+        is_account_owner=False,
+        is_global_admin=False,
+    )
+    db.session.add(guest)
+    db.session.commit()
+    owner_id = owner.id
+    guest_id = guest.id
+
+    for role in ("admin", "global_admin"):
+        resp = auth_client.post(
+            "/update_user",
+            data={
+                "id": guest_id,
+                "name": "Role Locked Guest",
+                "email": "guest-role-locked@test.local",
+                "role": role,
+            },
+            follow_redirects=False,
+        )
+        assert resp.status_code in (301, 302)
+
+        refreshed = user_model.query.filter_by(id=guest_id).first()
+        assert refreshed.admin is False
+        assert refreshed.is_global_admin is False
+        assert refreshed.is_account_owner is False
+        assert refreshed.account_owner_id == owner_id
+        assert refreshed.owner_user_id == owner_id
+
+
+def test_update_user_cannot_demote_owner_to_guest(auth_client, app_ctx, user_model):
+    """The 'guest' role is never a valid target for an existing non-guest."""
+    db = app_ctx
+    acting_admin = user_model.query.filter_by(email="admin@test.local").first()
+    acting_admin.is_global_admin = True
+    db.session.flush()
+
+    owner = user_model(
+        email="owner-no-demotion@test.local",
+        password=generate_password_hash("testpass123", method="scrypt"),
+        name="Owner No Demotion",
+        admin=True,
+        is_active=True,
+        account_owner_id=None,
+        is_global_admin=False,
+    )
+    db.session.add(owner)
+    db.session.commit()
+    owner_id = owner.id
+
+    resp = auth_client.post(
+        "/update_user",
+        data={
+            "id": owner_id,
+            "name": "Owner No Demotion",
+            "email": "owner-no-demotion@test.local",
+            "role": "guest",
+        },
+        follow_redirects=False,
+    )
+    assert resp.status_code in (301, 302)
+
+    refreshed = user_model.query.filter_by(id=owner_id).first()
+    assert refreshed.admin is True
+    assert refreshed.is_global_admin is False
+
+
 def test_delete_my_account_blocks_global_admin(
     flask_app, app_ctx, user_model
 ):


### PR DESCRIPTION
Once a guest, always a guest. The global admin user-edit route previously
let a guest be assigned the Account Owner or Global Admin role, which
granted admin permissions while leaving account_owner_id/owner_user_id
pointing at the old owner and is_account_owner false, producing
inconsistent access to the owner's data.

- update_user now ignores any posted role when the target user is a
  guest, and no longer demotes non-guests when an unrecognized role
  (including 'guest') is posted, since real guests are only created via
  add_guest with an owner link.
- The guest edit modals in the global admin panel show a read-only
  'Guest' role instead of a Global Admin/Account Owner dropdown.
- Add regression tests covering both directions.

https://claude.ai/code/session_0123zHnMRkn78rpuXiFQujcG