### PR TITLE
Enforce sender authentication for bank-balance email ingestion (H1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,16 @@ For advanced users or custom deployments, PyCashFlow can be installed directly o
    # Optional: configure rate-limit backend (Redis recommended for multi-worker)
    # RATELIMIT_STORAGE_URI=redis://localhost:6379/0
 
+   # Optional: inbound balance-email authentication (app/getemail.py).
+   # Balance emails are ingested only when the From address matches the
+   # per-user "Allowed Sender" AND the message passes DKIM/SPF/DMARC.
+   # Set EMAIL_TRUSTED_AUTHSERV_ID to your receiving MTA's authserv-id so
+   # attacker-supplied Authentication-Results headers are ignored.
+   # EMAIL_REQUIRE_AUTH_RESULTS defaults to true; set to false only when a
+   # separate trusted ingestion path makes the headers redundant.
+   # EMAIL_TRUSTED_AUTHSERV_ID=mx.example.com
+   # EMAIL_REQUIRE_AUTH_RESULTS=true
+
    # Optional: Database URL (defaults to SQLite)
    DATABASE_URL=sqlite:///data/db.sqlite
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,6 +47,24 @@ def create_app():
     app.config["APPLE_BUNDLE_ID"] = os.environ.get("APPLE_BUNDLE_ID", "")
     app.config["APPLE_ENVIRONMENT"] = os.environ.get("APPLE_ENVIRONMENT", "production")
 
+    # Inbound balance-email authentication (app/getemail.py).
+    # Balance emails are only ingested when the From address matches the
+    # per-user Allowed Sender AND the message passes sender authentication
+    # (DKIM/SPF/DMARC). Authentication-Results headers can be forged inside a
+    # message, so they are only trustworthy when stamped by an MTA you control:
+    # set EMAIL_TRUSTED_AUTHSERV_ID to that MTA's authserv-id (e.g.
+    # "mx.example.com") so attacker-supplied headers are ignored. Leaving it
+    # blank falls back to the outermost Authentication-Results header, a weaker
+    # heuristic. EMAIL_REQUIRE_AUTH_RESULTS may be set to "false" only when a
+    # separate trusted ingestion path makes the headers redundant (not
+    # recommended).
+    app.config["EMAIL_TRUSTED_AUTHSERV_ID"] = os.environ.get(
+        "EMAIL_TRUSTED_AUTHSERV_ID", ""
+    ).strip()
+    app.config["EMAIL_REQUIRE_AUTH_RESULTS"] = (
+        os.environ.get("EMAIL_REQUIRE_AUTH_RESULTS", "true").lower() == "true"
+    )
+
     # Plaid Balance integration config (optional feature).
     # Treated as "configured" only when CLIENT_ID, SECRET, ENV, and PRODUCTS
     # are all populated; see app.plaid_service.plaid_is_configured().

--- a/app/getemail.py
+++ b/app/getemail.py
@@ -84,18 +84,31 @@ def _email_message_datetime_utc(msg) -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
-def _parse_auth_results(msg) -> dict:
+def _parse_auth_results(msg, trusted_authserv_id: str = "") -> dict:
     """Parse *Authentication-Results* headers and return a mapping of
     mechanism → result for dkim, spf, and dmarc.
 
-    Only the first result found for each mechanism is kept (the outermost
-    Authentication-Results header, added by the user's own mail provider,
-    appears first in the message).
+    Authentication-Results headers are only trustworthy when stamped by an MTA
+    you control: a forged message can carry its own passing
+    Authentication-Results lines, and a receiving MTA only strips/relocates the
+    ones bearing its own authserv-id. When *trusted_authserv_id* is set, only
+    headers whose authserv-id token matches it are considered, pinning the
+    result to that trusted MTA. When it is empty, the first header found is used
+    (the outermost, provider-added one) — a weaker heuristic.
+
+    Only the first result found for each mechanism is kept.
 
     Example return value: {'dkim': 'pass', 'spf': 'pass', 'dmarc': 'pass'}
     """
+    trusted = (trusted_authserv_id or "").strip().lower()
     results: dict = {}
     for header_value in msg.get_all("Authentication-Results") or []:
+        # The authserv-id is the first ';'-delimited field; an optional version
+        # token may follow it (e.g. "mx.example.com 1").
+        authserv_field = header_value.split(";", 1)[0].strip().lower()
+        authserv_id = authserv_field.split()[0] if authserv_field else ""
+        if trusted and authserv_id != trusted:
+            continue
         for mech, result in re.findall(
             r"\b(dkim|spf|dmarc)=(pass|fail|softfail|none|neutral|permerror|temperror)\b",
             header_value,
@@ -107,6 +120,27 @@ def _parse_auth_results(msg) -> dict:
     return results
 
 
+def _authentication_passes(auth: dict) -> tuple:
+    """Return ``(passed, detail)`` for the parsed Authentication-Results.
+
+    Policy: a message is authenticated when DMARC passes, or when both SPF and
+    DKIM pass. Absent or non-'pass' results are treated as failure so
+    unauthenticated — and therefore spoofable — mail can never set a balance.
+    *detail* is a short human-readable summary for logging.
+    """
+    dkim = auth.get("dkim")
+    spf = auth.get("spf")
+    dmarc = auth.get("dmarc")
+    detail = "dkim=%s spf=%s dmarc=%s" % (
+        dkim or "none", spf or "none", dmarc or "none",
+    )
+    if dmarc == "pass":
+        return True, detail
+    if spf == "pass" and dkim == "pass":
+        return True, detail
+    return False, detail
+
+
 def process_email_balances():
     """
     Process email inboxes for all users with email settings configured
@@ -114,6 +148,16 @@ def process_email_balances():
 
     This function supports both SQLite and PostgreSQL through SQLAlchemy.
     """
+    # Authentication-enforcement policy (see app.create_app config comments).
+    trusted_authserv_id = current_app.config.get("EMAIL_TRUSTED_AUTHSERV_ID", "")
+    require_auth = current_app.config.get("EMAIL_REQUIRE_AUTH_RESULTS", True)
+    if require_auth and not trusted_authserv_id:
+        logger.warning(
+            "EMAIL_TRUSTED_AUTHSERV_ID is not set; falling back to the "
+            "outermost Authentication-Results header. Set it to your receiving "
+            "MTA's authserv-id so forged auth headers cannot be trusted."
+        )
+
     # OUTER LOOP: Get all users with email settings configured
     users_with_email = db.session.query(User, Email).join(
         Email, User.id == Email.user_id
@@ -129,6 +173,19 @@ def process_email_balances():
         subjectstr = email_config.subjectstr
         startstr = email_config.startstr
         endstr = email_config.endstr
+        allowed_sender = email_config.allowed_sender
+
+        # Refuse to ingest balances when no Allowed Sender is configured: the
+        # From header alone is spoofable, so without a configured sender any
+        # message that can reach the inbox could set an arbitrary balance.
+        if not allowed_sender:
+            logger.warning(
+                "Skipping email balance import for user %s: no Allowed Sender "
+                "configured. Set an Allowed Sender in email settings to enable "
+                "balance ingestion.",
+                user_id,
+            )
+            continue
 
         try:
             # Create IMAP connection for THIS user
@@ -194,15 +251,7 @@ def process_email_balances():
                             sender_address = _extract_sender_address(
                                 From if isinstance(From, str) else str(From or "")
                             )
-                            allowed_sender = email_config.allowed_sender
-                            if not allowed_sender:
-                                logger.debug(
-                                    "No allowed_sender configured for user %s; "
-                                    "processing email without sender check",
-                                    user_id,
-                                )
-                                emails_allowed += 1
-                            elif not _sender_is_allowed(sender_address, allowed_sender):
+                            if not _sender_is_allowed(sender_address, allowed_sender):
                                 emails_rejected += 1
                                 logger.debug(
                                     "Rejected email for user %s: "
@@ -210,28 +259,25 @@ def process_email_balances():
                                     user_id,
                                 )
                                 break  # skip remaining responses for this email_id
-                            else:
-                                emails_allowed += 1
 
-                            # --- Authentication-Results inspection ---
-                            auth = _parse_auth_results(msg)
-                            for mech in ("dkim", "spf", "dmarc"):
-                                result = auth.get(mech)
-                                if result is None:
-                                    logger.debug(
-                                        "No %s result in Authentication-Results for user %s",
-                                        mech.upper(), user_id,
+                            # --- Authentication enforcement ---
+                            # Reject (do not merely log) messages that fail sender
+                            # authentication: a matching From header is trivially
+                            # forged, so DKIM/SPF/DMARC results from a trusted MTA
+                            # are what actually authenticate the sender.
+                            if require_auth:
+                                auth = _parse_auth_results(msg, trusted_authserv_id)
+                                passed, detail = _authentication_passes(auth)
+                                if not passed:
+                                    emails_rejected += 1
+                                    logger.warning(
+                                        "Rejected email for user %s: failed sender "
+                                        "authentication (%s)",
+                                        user_id, detail,
                                     )
-                                elif result != "pass":
-                                    logger.debug(
-                                        "user %s: %s check did not pass",
-                                        user_id, mech.upper(),
-                                    )
-                                else:
-                                    logger.debug(
-                                        "user %s: %s=pass",
-                                        user_id, mech.upper(),
-                                    )
+                                    break  # skip remaining responses for this email_id
+
+                            emails_allowed += 1
 
                             msg_datetime = _email_message_datetime_utc(msg)
 

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -500,8 +500,8 @@
                                value="{{ email_config.allowed_sender or '' if email_config else '' }}">
                         <small style="color: var(--text-muted, #6c757d); font-size: 0.75rem; margin-top: 0.25rem; display: block;">
                             Only parse balances from this sender. Use <code>@domain.com</code> to allow any address at
-                            a domain, or <code>user@domain.com</code> for an exact match. Leave blank to skip the check
-                            (not recommended).
+                            a domain, or <code>user@domain.com</code> for an exact match. <strong>Required:</strong> leaving
+                            this blank disables balance ingestion, since the sender address alone is spoofable.
                         </small>
                     </div>
 

--- a/tests/test_getemail_balance_datetime.py
+++ b/tests/test_getemail_balance_datetime.py
@@ -79,15 +79,22 @@ def _build_balance_email_bytes(
     sender: str = "alerts@bank.com",
     date_header: str = "Sun, 24 May 2026 09:30:00 +0000",
     body: str = "Your balance is $1234.56 USD today.",
+    auth_results: str | None = "mx.test.local; dkim=pass; spf=pass; dmarc=pass",
 ) -> bytes:
     lines = [
         f"From: {sender}",
         f"Subject: {subject}",
         f"Date: {date_header}",
-        "Content-Type: text/plain",
-        "",
-        body,
     ]
+    if auth_results is not None:
+        lines.append(f"Authentication-Results: {auth_results}")
+    lines.extend(
+        [
+            "Content-Type: text/plain",
+            "",
+            body,
+        ]
+    )
     return ("\r\n".join(lines)).encode()
 
 
@@ -113,7 +120,7 @@ class TestProcessEmailBalancesPersistsDatetime:
                 subjectstr="balance alert",
                 startstr="$",
                 endstr=" USD",
-                allowed_sender=None,
+                allowed_sender="alerts@bank.com",
             )
             db.session.add(cfg)
             db.session.commit()
@@ -228,6 +235,7 @@ class TestProcessEmailBalancesPersistsDatetime:
         lines = [
             "From: alerts@bank.com",
             "Subject: balance alert",
+            "Authentication-Results: mx.test.local; dkim=pass; spf=pass; dmarc=pass",
             "Content-Type: text/plain",
             "",
             "Your balance is $42.00 USD today.",
@@ -247,3 +255,174 @@ class TestProcessEmailBalancesPersistsDatetime:
                 <= cfg.balance_email_datetime
                 <= after + timedelta(seconds=5)
             )
+
+
+# ── Authentication enforcement (H1) ─────────────────────────────────────────
+
+
+class TestAuthResultHelpers:
+    def test_parse_filters_by_trusted_authserv_id(self):
+        raw = (
+            "From: alerts@bank.com\r\n"
+            "Subject: balance\r\n"
+            # Attacker-forged header bearing a passing result but a different
+            # authserv-id must be ignored when a trusted id is configured.
+            "Authentication-Results: attacker.example; dkim=pass; spf=pass; dmarc=pass\r\n"
+            "Authentication-Results: mx.test.local; dkim=fail; spf=fail; dmarc=fail\r\n"
+            "Content-Type: text/plain\r\n\r\nx"
+        ).encode()
+        msg = email_pkg.message_from_bytes(raw)
+
+        trusted = getemail._parse_auth_results(msg, "mx.test.local")
+        assert trusted == {"dkim": "fail", "spf": "fail", "dmarc": "fail"}
+
+        # With no trusted id the outermost (first) header is used.
+        outermost = getemail._parse_auth_results(msg)
+        assert outermost == {"dkim": "pass", "spf": "pass", "dmarc": "pass"}
+
+    def test_parse_handles_authserv_id_version_token(self):
+        raw = (
+            "Authentication-Results: mx.test.local 1; dkim=pass; spf=pass; dmarc=pass\r\n"
+            "Content-Type: text/plain\r\n\r\nx"
+        ).encode()
+        msg = email_pkg.message_from_bytes(raw)
+        assert getemail._parse_auth_results(msg, "mx.test.local") == {
+            "dkim": "pass",
+            "spf": "pass",
+            "dmarc": "pass",
+        }
+
+    def test_authentication_passes_policy(self):
+        assert getemail._authentication_passes({"dmarc": "pass"})[0] is True
+        assert getemail._authentication_passes(
+            {"spf": "pass", "dkim": "pass"}
+        )[0] is True
+        # Missing results, partial passes, and explicit failures all fail.
+        assert getemail._authentication_passes({})[0] is False
+        assert getemail._authentication_passes({"spf": "pass"})[0] is False
+        assert getemail._authentication_passes(
+            {"dmarc": "fail", "spf": "pass", "dkim": "pass"}
+        )[0] is True  # SPF+DKIM still authenticate even if DMARC reports fail
+        assert getemail._authentication_passes(
+            {"dmarc": "fail", "spf": "fail", "dkim": "fail"}
+        )[0] is False
+
+
+class TestProcessEmailBalancesEnforcesAuth:
+    """End-to-end: the ingestion path rejects spoofable mail (H1 fix)."""
+
+    @pytest.fixture()
+    def email_user(self, flask_app):
+        with flask_app.app_context():
+            user = User(
+                email=f"authcheck-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="Auth User",
+                admin=True,
+                is_active=True,
+            )
+            db.session.add(user)
+            db.session.commit()
+            cfg = Email(
+                user_id=user.id,
+                email="ingest@example.com",
+                password=encrypt_password("imap-pw"),
+                server="imap.example.com",
+                subjectstr="balance alert",
+                startstr="$",
+                endstr=" USD",
+                allowed_sender="alerts@bank.com",
+            )
+            db.session.add(cfg)
+            db.session.commit()
+            user_id = user.id
+        yield user_id
+        with flask_app.app_context():
+            Email.query.filter_by(user_id=user_id).delete()
+            Balance.query.filter_by(user_id=user_id).delete()
+            User.query.filter_by(id=user_id).delete()
+            db.session.commit()
+
+    def _run(self, flask_app, raw_emails):
+        with patch("app.getemail.imaplib.IMAP4_SSL") as mock_ssl:
+            imap = MagicMock()
+            imap.select.return_value = ("OK", [b"1"])
+            imap.search.return_value = (
+                "OK",
+                [b" ".join(str(i + 1).encode() for i in range(len(raw_emails)))],
+            )
+
+            def _fetch(eid, _spec):
+                return ("OK", [(b"1 (RFC822 {1})", raw_emails[int(eid) - 1])])
+
+            imap.fetch.side_effect = _fetch
+            mock_ssl.return_value = imap
+            getemail.process_email_balances()
+
+    def _today_balance(self, user_id):
+        return Balance.query.filter_by(
+            user_id=user_id, date=datetime.today().date()
+        ).first()
+
+    def test_rejects_email_with_no_auth_results(self, flask_app, email_user):
+        raw = _build_balance_email_bytes(auth_results=None)
+        with flask_app.app_context():
+            self._run(flask_app, [raw])
+            assert self._today_balance(email_user) is None
+
+    def test_rejects_email_failing_dmarc(self, flask_app, email_user):
+        raw = _build_balance_email_bytes(
+            auth_results="mx.test.local; dkim=fail; spf=fail; dmarc=fail"
+        )
+        with flask_app.app_context():
+            self._run(flask_app, [raw])
+            assert self._today_balance(email_user) is None
+
+    def test_rejects_forged_authserv_id_when_pinned(self, flask_app, email_user):
+        raw = _build_balance_email_bytes(
+            auth_results="attacker.example; dkim=pass; spf=pass; dmarc=pass"
+        )
+        with flask_app.app_context():
+            flask_app.config["EMAIL_TRUSTED_AUTHSERV_ID"] = "mx.test.local"
+            try:
+                self._run(flask_app, [raw])
+                assert self._today_balance(email_user) is None
+            finally:
+                flask_app.config["EMAIL_TRUSTED_AUTHSERV_ID"] = ""
+
+    def test_accepts_email_passing_auth(self, flask_app, email_user):
+        raw = _build_balance_email_bytes()
+        with flask_app.app_context():
+            self._run(flask_app, [raw])
+            row = self._today_balance(email_user)
+            assert row is not None
+            assert float(row.amount) == pytest.approx(1234.56)
+
+    def test_rejects_when_sender_not_allowed(self, flask_app, email_user):
+        raw = _build_balance_email_bytes(sender="evil@phisher.com")
+        with flask_app.app_context():
+            self._run(flask_app, [raw])
+            assert self._today_balance(email_user) is None
+
+    def test_skips_user_without_allowed_sender(self, flask_app, email_user):
+        with flask_app.app_context():
+            cfg = Email.query.filter_by(user_id=email_user).first()
+            cfg.allowed_sender = None
+            db.session.commit()
+            # Even a fully authenticated message is ignored: ingestion is
+            # disabled until an Allowed Sender is configured.
+            raw = _build_balance_email_bytes()
+            self._run(flask_app, [raw])
+            assert self._today_balance(email_user) is None
+
+    def test_auth_disabled_allows_unauthenticated(self, flask_app, email_user):
+        raw = _build_balance_email_bytes(auth_results=None)
+        with flask_app.app_context():
+            flask_app.config["EMAIL_REQUIRE_AUTH_RESULTS"] = False
+            try:
+                self._run(flask_app, [raw])
+                row = self._today_balance(email_user)
+                assert row is not None
+                assert float(row.amount) == pytest.approx(1234.56)
+            finally:
+                flask_app.config["EMAIL_REQUIRE_AUTH_RESULTS"] = True


### PR DESCRIPTION
Balance emails were written to a user's Balance table based only on a
From-address match against allowed_sender, and ANY sender was accepted
when allowed_sender was unset. DKIM/SPF/DMARC results were parsed but a
failure was only logged, never rejected, so anyone able to deliver mail
to the monitored inbox with a forged From: could set a victim's recorded
bank balance to an arbitrary value.

Changes:
- Require allowed_sender to be configured: users without it are skipped
  entirely instead of accepting any sender.
- Enforce (not just log) Authentication-Results: reject messages unless
  DMARC=pass, or both SPF=pass and DKIM=pass. Absent/non-pass results are
  treated as failure.
- Pin auth results to a trusted MTA via EMAIL_TRUSTED_AUTHSERV_ID so an
  attacker cannot supply their own passing Authentication-Results header.
- Add EMAIL_REQUIRE_AUTH_RESULTS (default true) escape hatch for trusted
  ingestion paths.
- Update settings help text and README; expand tests to cover sender and
  authentication enforcement.