### PR TITLE
Remove EMAIL_TRUSTED_AUTHSERV_ID config knob

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,11 +326,10 @@ For advanced users or custom deployments, PyCashFlow can be installed directly o
    # Optional: inbound balance-email authentication (app/getemail.py).
    # Balance emails are ingested only when the From address matches the
    # per-user "Allowed Sender" AND the message passes DKIM/SPF/DMARC.
-   # Set EMAIL_TRUSTED_AUTHSERV_ID to your receiving MTA's authserv-id so
-   # attacker-supplied Authentication-Results headers are ignored.
-   # EMAIL_REQUIRE_AUTH_RESULTS defaults to true; set to false only when a
-   # separate trusted ingestion path makes the headers redundant.
-   # EMAIL_TRUSTED_AUTHSERV_ID=mx.example.com
+   # Authentication uses your mailbox provider's (Gmail/Outlook/Fastmail/etc.)
+   # outermost Authentication-Results header automatically — no configuration
+   # needed. EMAIL_REQUIRE_AUTH_RESULTS defaults to true; set to false only when
+   # a separate trusted ingestion path makes the headers redundant.
    # EMAIL_REQUIRE_AUTH_RESULTS=true
 
    # Optional: Database URL (defaults to SQLite)

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -50,17 +50,11 @@ def create_app():
     # Inbound balance-email authentication (app/getemail.py).
     # Balance emails are only ingested when the From address matches the
     # per-user Allowed Sender AND the message passes sender authentication
-    # (DKIM/SPF/DMARC). Authentication-Results headers can be forged inside a
-    # message, so they are only trustworthy when stamped by an MTA you control:
-    # set EMAIL_TRUSTED_AUTHSERV_ID to that MTA's authserv-id (e.g.
-    # "mx.example.com") so attacker-supplied headers are ignored. Leaving it
-    # blank falls back to the outermost Authentication-Results header, a weaker
-    # heuristic. EMAIL_REQUIRE_AUTH_RESULTS may be set to "false" only when a
-    # separate trusted ingestion path makes the headers redundant (not
-    # recommended).
-    app.config["EMAIL_TRUSTED_AUTHSERV_ID"] = os.environ.get(
-        "EMAIL_TRUSTED_AUTHSERV_ID", ""
-    ).strip()
+    # (DKIM/SPF/DMARC). The mailbox provider (Gmail/Outlook/Fastmail/etc.)
+    # prepends the outermost Authentication-Results header on arrival, and that
+    # is the header we trust. EMAIL_REQUIRE_AUTH_RESULTS may be set to "false"
+    # only when a separate trusted ingestion path makes the headers redundant
+    # (not recommended).
     app.config["EMAIL_REQUIRE_AUTH_RESULTS"] = (
         os.environ.get("EMAIL_REQUIRE_AUTH_RESULTS", "true").lower() == "true"
     )

--- a/app/getemail.py
+++ b/app/getemail.py
@@ -84,31 +84,21 @@ def _email_message_datetime_utc(msg) -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
 
-def _parse_auth_results(msg, trusted_authserv_id: str = "") -> dict:
+def _parse_auth_results(msg) -> dict:
     """Parse *Authentication-Results* headers and return a mapping of
     mechanism → result for dkim, spf, and dmarc.
 
-    Authentication-Results headers are only trustworthy when stamped by an MTA
-    you control: a forged message can carry its own passing
-    Authentication-Results lines, and a receiving MTA only strips/relocates the
-    ones bearing its own authserv-id. When *trusted_authserv_id* is set, only
-    headers whose authserv-id token matches it are considered, pinning the
-    result to that trusted MTA. When it is empty, the first header found is used
-    (the outermost, provider-added one) — a weaker heuristic.
+    The outermost (first) Authentication-Results header is trusted: the user's
+    mailbox provider (Gmail/Outlook/Fastmail/etc.) prepends it on arrival, so it
+    reflects the provider's own authentication checks rather than any
+    attacker-supplied header deeper in the message.
 
     Only the first result found for each mechanism is kept.
 
     Example return value: {'dkim': 'pass', 'spf': 'pass', 'dmarc': 'pass'}
     """
-    trusted = (trusted_authserv_id or "").strip().lower()
     results: dict = {}
     for header_value in msg.get_all("Authentication-Results") or []:
-        # The authserv-id is the first ';'-delimited field; an optional version
-        # token may follow it (e.g. "mx.example.com 1").
-        authserv_field = header_value.split(";", 1)[0].strip().lower()
-        authserv_id = authserv_field.split()[0] if authserv_field else ""
-        if trusted and authserv_id != trusted:
-            continue
         for mech, result in re.findall(
             r"\b(dkim|spf|dmarc)=(pass|fail|softfail|none|neutral|permerror|temperror)\b",
             header_value,
@@ -149,14 +139,7 @@ def process_email_balances():
     This function supports both SQLite and PostgreSQL through SQLAlchemy.
     """
     # Authentication-enforcement policy (see app.create_app config comments).
-    trusted_authserv_id = current_app.config.get("EMAIL_TRUSTED_AUTHSERV_ID", "")
     require_auth = current_app.config.get("EMAIL_REQUIRE_AUTH_RESULTS", True)
-    if require_auth and not trusted_authserv_id:
-        logger.warning(
-            "EMAIL_TRUSTED_AUTHSERV_ID is not set; falling back to the "
-            "outermost Authentication-Results header. Set it to your receiving "
-            "MTA's authserv-id so forged auth headers cannot be trusted."
-        )
 
     # OUTER LOOP: Get all users with email settings configured
     users_with_email = db.session.query(User, Email).join(
@@ -266,7 +249,7 @@ def process_email_balances():
                             # forged, so DKIM/SPF/DMARC results from a trusted MTA
                             # are what actually authenticate the sender.
                             if require_auth:
-                                auth = _parse_auth_results(msg, trusted_authserv_id)
+                                auth = _parse_auth_results(msg)
                                 passed, detail = _authentication_passes(auth)
                                 if not passed:
                                     emails_rejected += 1

--- a/tests/test_getemail_balance_datetime.py
+++ b/tests/test_getemail_balance_datetime.py
@@ -261,32 +261,19 @@ class TestProcessEmailBalancesPersistsDatetime:
 
 
 class TestAuthResultHelpers:
-    def test_parse_filters_by_trusted_authserv_id(self):
+    def test_parse_first_header_result_wins_per_mechanism(self):
+        # The outermost (first) header is the provider-stamped one and is
+        # trusted; results from later headers must not override it.
         raw = (
             "From: alerts@bank.com\r\n"
             "Subject: balance\r\n"
-            # Attacker-forged header bearing a passing result but a different
-            # authserv-id must be ignored when a trusted id is configured.
-            "Authentication-Results: attacker.example; dkim=pass; spf=pass; dmarc=pass\r\n"
-            "Authentication-Results: mx.test.local; dkim=fail; spf=fail; dmarc=fail\r\n"
+            "Authentication-Results: mx.test.local; dkim=pass; spf=pass; dmarc=pass\r\n"
+            "Authentication-Results: deeper.example; dkim=fail; spf=fail; dmarc=fail\r\n"
             "Content-Type: text/plain\r\n\r\nx"
         ).encode()
         msg = email_pkg.message_from_bytes(raw)
 
-        trusted = getemail._parse_auth_results(msg, "mx.test.local")
-        assert trusted == {"dkim": "fail", "spf": "fail", "dmarc": "fail"}
-
-        # With no trusted id the outermost (first) header is used.
-        outermost = getemail._parse_auth_results(msg)
-        assert outermost == {"dkim": "pass", "spf": "pass", "dmarc": "pass"}
-
-    def test_parse_handles_authserv_id_version_token(self):
-        raw = (
-            "Authentication-Results: mx.test.local 1; dkim=pass; spf=pass; dmarc=pass\r\n"
-            "Content-Type: text/plain\r\n\r\nx"
-        ).encode()
-        msg = email_pkg.message_from_bytes(raw)
-        assert getemail._parse_auth_results(msg, "mx.test.local") == {
+        assert getemail._parse_auth_results(msg) == {
             "dkim": "pass",
             "spf": "pass",
             "dmarc": "pass",
@@ -377,18 +364,6 @@ class TestProcessEmailBalancesEnforcesAuth:
         with flask_app.app_context():
             self._run(flask_app, [raw])
             assert self._today_balance(email_user) is None
-
-    def test_rejects_forged_authserv_id_when_pinned(self, flask_app, email_user):
-        raw = _build_balance_email_bytes(
-            auth_results="attacker.example; dkim=pass; spf=pass; dmarc=pass"
-        )
-        with flask_app.app_context():
-            flask_app.config["EMAIL_TRUSTED_AUTHSERV_ID"] = "mx.test.local"
-            try:
-                self._run(flask_app, [raw])
-                assert self._today_balance(email_user) is None
-            finally:
-                flask_app.config["EMAIL_TRUSTED_AUTHSERV_ID"] = ""
 
     def test_accepts_email_passing_auth(self, flask_app, email_user):
         raw = _build_balance_email_bytes()


### PR DESCRIPTION
Trust the outermost (provider-stamped) Authentication-Results header that
the mailbox provider prepends on arrival, rather than pinning a specific
MTA authserv-id. The per-user allowed_sender requirement and DKIM/SPF/DMARC
enforcement (EMAIL_REQUIRE_AUTH_RESULTS, default true) are unchanged.