### PR TITLE
Fall back to in-app DKIM verification when no Authentication-Results header

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,9 +328,15 @@ For advanced users or custom deployments, PyCashFlow can be installed directly o
    # per-user "Allowed Sender" AND the message passes DKIM/SPF/DMARC.
    # Authentication uses your mailbox provider's (Gmail/Outlook/Fastmail/etc.)
    # outermost Authentication-Results header automatically — no configuration
-   # needed. EMAIL_REQUIRE_AUTH_RESULTS defaults to true; set to false only when
-   # a separate trusted ingestion path makes the headers redundant.
+   # needed. If the mailbox does not stamp that header (common on custom-domain
+   # or self-hosted mail hosts), the message's DKIM signature is verified
+   # in-app against DNS instead, and its signing domain must align with the
+   # Allowed Sender. EMAIL_VERIFY_DKIM defaults to true; set to false only in
+   # environments without outbound DNS. EMAIL_REQUIRE_AUTH_RESULTS defaults to
+   # true; set to false only when a separate trusted ingestion path makes the
+   # checks redundant.
    # EMAIL_REQUIRE_AUTH_RESULTS=true
+   # EMAIL_VERIFY_DKIM=true
 
    # Optional: Database URL (defaults to SQLite)
    DATABASE_URL=sqlite:///data/db.sqlite

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -58,6 +58,16 @@ def create_app():
     app.config["EMAIL_REQUIRE_AUTH_RESULTS"] = (
         os.environ.get("EMAIL_REQUIRE_AUTH_RESULTS", "true").lower() == "true"
     )
+    # Some mailboxes (notably custom-domain / self-hosted mail hosts) never
+    # stamp an Authentication-Results header, so an otherwise legitimate,
+    # DKIM-signed bank alert would be rejected as unauthenticated. When this is
+    # enabled (default), such messages fall back to in-app DKIM verification:
+    # the message's DKIM-Signature is verified against DNS and the signing
+    # domain must align with the Allowed Sender. Set to "false" only in
+    # environments without outbound DNS access.
+    app.config["EMAIL_VERIFY_DKIM"] = (
+        os.environ.get("EMAIL_VERIFY_DKIM", "true").lower() == "true"
+    )
 
     # Plaid Balance integration config (optional feature).
     # Treated as "configured" only when CLIENT_ID, SECRET, ENV, and PRODUCTS

--- a/app/getemail.py
+++ b/app/getemail.py
@@ -131,6 +131,80 @@ def _authentication_passes(auth: dict) -> tuple:
     return False, detail
 
 
+def _verify_dkim_signatures(raw_message_bytes: bytes, signature_count: int,
+                            dnsfunc=None) -> set:
+    """Cryptographically verify the message's DKIM-Signature headers via DNS.
+
+    Returns the set of lower-cased signing domains (the DKIM ``d=`` tag) whose
+    signature validates against the public key published in DNS.
+
+    This is the fallback used when the receiving mailbox does not stamp a
+    trustworthy Authentication-Results header — common on custom-domain and
+    self-hosted mailboxes, where a perfectly legitimate, DKIM-signed bank alert
+    arrives with no provider authentication header to read. Verifying the
+    signature ourselves authenticates the sender without depending on the
+    provider.
+
+    Never raises: any missing dependency, DNS, or parsing problem yields an
+    empty set, so a verification failure can only *deny* ingestion and never
+    enable spoofing.
+    """
+    try:
+        import dkim  # dkimpy; optional dependency
+    except ImportError:
+        logger.warning(
+            "dkimpy is not installed; cannot verify DKIM signatures in-app. "
+            "Install dkimpy to authenticate mail whose provider does not stamp "
+            "Authentication-Results, or set EMAIL_REQUIRE_AUTH_RESULTS=false."
+        )
+        return set()
+
+    verified: set = set()
+    for idx in range(signature_count):
+        try:
+            verifier = dkim.DKIM(raw_message_bytes)
+            if dnsfunc is None:
+                ok = verifier.verify(idx=idx)
+            else:
+                ok = verifier.verify(idx=idx, dnsfunc=dnsfunc)
+            if not ok:
+                continue
+            domain = verifier.domain or b""
+            if isinstance(domain, bytes):
+                domain = domain.decode("ascii", "ignore")
+            domain = domain.strip().lower().rstrip(".")
+            if domain:
+                verified.add(domain)
+        except Exception as exc:
+            logger.debug(
+                "DKIM verification error for signature %d: %s", idx, exc,
+            )
+    return verified
+
+
+def _dkim_domain_aligns(verified_domains, sender_address: str) -> bool:
+    """Return True when a verified DKIM signing domain aligns with the sender.
+
+    Relaxed alignment (DMARC-style): the From domain and a verified DKIM ``d=``
+    domain must be equal, or one an organisational subdomain of the other (e.g.
+    From ``alerts@ealerts.bankofamerica.com`` signed by ``bankofamerica.com``).
+    This pins a cryptographically-valid signature to the address that already
+    passed the Allowed Sender check, so a message carrying its own validly
+    signed — but unrelated — DKIM signature cannot authenticate as the bank.
+    """
+    from_domain = (sender_address or "").split("@")[-1].strip().lower().rstrip(".")
+    if not from_domain:
+        return False
+    for domain in verified_domains:
+        if not domain:
+            continue
+        if domain == from_domain:
+            return True
+        if from_domain.endswith("." + domain) or domain.endswith("." + from_domain):
+            return True
+    return False
+
+
 def process_email_balances():
     """
     Process email inboxes for all users with email settings configured
@@ -140,6 +214,11 @@ def process_email_balances():
     """
     # Authentication-enforcement policy (see app.create_app config comments).
     require_auth = current_app.config.get("EMAIL_REQUIRE_AUTH_RESULTS", True)
+    # When the receiving mailbox does not stamp a trustworthy
+    # Authentication-Results header, fall back to verifying the message's DKIM
+    # signature ourselves against DNS. Disable only in environments without
+    # outbound DNS.
+    verify_dkim = current_app.config.get("EMAIL_VERIFY_DKIM", True)
 
     # OUTER LOOP: Get all users with email settings configured
     users_with_email = db.session.query(User, Email).join(
@@ -205,7 +284,12 @@ def process_email_balances():
                     res, msg = imap.fetch(email_id, "(RFC822)")
                     for response in msg:
                         if isinstance(response, tuple):
-                            msg = email.message_from_bytes(response[1])
+                            # Keep the exact raw bytes: in-app DKIM verification
+                            # is byte-sensitive (canonicalization) and must run
+                            # against the message as received, not a re-serialized
+                            # copy.
+                            raw_bytes = response[1]
+                            msg = email.message_from_bytes(raw_bytes)
 
                             # Decode subject
                             subject, encoding = decode_header(msg["Subject"])[0]
@@ -251,6 +335,30 @@ def process_email_balances():
                             if require_auth:
                                 auth = _parse_auth_results(msg)
                                 passed, detail = _authentication_passes(auth)
+                                if not passed and verify_dkim:
+                                    # The provider stamped no usable
+                                    # Authentication-Results header (e.g. a
+                                    # custom-domain/self-hosted mailbox). Verify
+                                    # the DKIM signature ourselves and require it
+                                    # to align with the allowed sender domain.
+                                    sig_count = len(
+                                        msg.get_all("DKIM-Signature") or []
+                                    )
+                                    if sig_count:
+                                        verified = _verify_dkim_signatures(
+                                            raw_bytes, sig_count
+                                        )
+                                        if _dkim_domain_aligns(
+                                            verified, sender_address
+                                        ):
+                                            passed = True
+                                            detail = (
+                                                "%s; in-app dkim verified d=%s"
+                                                % (
+                                                    detail,
+                                                    ",".join(sorted(verified)),
+                                                )
+                                            )
                                 if not passed:
                                     emails_rejected += 1
                                     logger.warning(

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ Flask-Limiter
 Flask-WTF
 psycopg2-binary
 plaid-python
+dkimpy

--- a/tests/test_getemail_balance_datetime.py
+++ b/tests/test_getemail_balance_datetime.py
@@ -401,3 +401,200 @@ class TestProcessEmailBalancesEnforcesAuth:
                 assert float(row.amount) == pytest.approx(1234.56)
             finally:
                 flask_app.config["EMAIL_REQUIRE_AUTH_RESULTS"] = True
+
+
+# ── In-app DKIM verification fallback ────────────────────────────────────────
+
+
+def _build_dkim_signed_email_bytes(
+    subject: str = "balance alert",
+    sender: str = "alerts@bank.com",
+    body: str = "Your balance is $1234.56 USD today.",
+    signing_domain: str = "bank.com",
+) -> bytes:
+    """A message with a DKIM-Signature header but NO Authentication-Results,
+    mimicking a custom-domain/self-hosted mailbox that doesn't stamp auth
+    headers. The signature is not cryptographically valid here — tests patch
+    _verify_dkim_signatures to control the verified-domain outcome."""
+    lines = [
+        f"From: {sender}",
+        f"Subject: {subject}",
+        "Date: Sun, 24 May 2026 09:30:00 +0000",
+        (
+            f"DKIM-Signature: v=1; a=rsa-sha256; d={signing_domain}; s=sel; "
+            "h=from:subject:date; bh=abc; b=def"
+        ),
+        "Content-Type: text/plain",
+        "",
+        body,
+    ]
+    return ("\r\n".join(lines)).encode()
+
+
+class TestDkimDomainAligns:
+    def test_exact_domain_match(self):
+        assert getemail._dkim_domain_aligns({"bank.com"}, "alerts@bank.com")
+
+    def test_signing_org_domain_aligns_with_subdomain_sender(self):
+        # From on a subdomain, signed by the organisational domain.
+        assert getemail._dkim_domain_aligns(
+            {"bankofamerica.com"}, "alerts@ealerts.bankofamerica.com"
+        )
+
+    def test_signing_subdomain_aligns_with_org_sender(self):
+        assert getemail._dkim_domain_aligns(
+            {"ealerts.bank.com"}, "alerts@bank.com"
+        )
+
+    def test_unrelated_domain_does_not_align(self):
+        assert not getemail._dkim_domain_aligns({"phisher.com"}, "alerts@bank.com")
+
+    def test_empty_inputs_do_not_align(self):
+        assert not getemail._dkim_domain_aligns(set(), "alerts@bank.com")
+        assert not getemail._dkim_domain_aligns({"bank.com"}, "")
+
+
+class TestVerifyDkimSignatures:
+    def test_returns_verified_signing_domain(self):
+        fake_dkim = MagicMock()
+        verifier = MagicMock()
+        verifier.verify.return_value = True
+        verifier.domain = b"bank.com"
+        fake_dkim.DKIM.return_value = verifier
+        with patch.dict("sys.modules", {"dkim": fake_dkim}):
+            result = getemail._verify_dkim_signatures(b"raw", 1)
+        assert result == {"bank.com"}
+
+    def test_failed_verification_excluded(self):
+        fake_dkim = MagicMock()
+        verifier = MagicMock()
+        verifier.verify.return_value = False
+        fake_dkim.DKIM.return_value = verifier
+        with patch.dict("sys.modules", {"dkim": fake_dkim}):
+            result = getemail._verify_dkim_signatures(b"raw", 1)
+        assert result == set()
+
+    def test_exception_is_swallowed(self):
+        fake_dkim = MagicMock()
+        fake_dkim.DKIM.side_effect = RuntimeError("boom")
+        with patch.dict("sys.modules", {"dkim": fake_dkim}):
+            result = getemail._verify_dkim_signatures(b"raw", 1)
+        assert result == set()
+
+
+class TestProcessEmailBalancesDkimFallback:
+    """When the mailbox stamps no Authentication-Results header, ingestion
+    falls back to in-app DKIM verification (the custom-domain case)."""
+
+    @pytest.fixture()
+    def email_user(self, flask_app):
+        with flask_app.app_context():
+            user = User(
+                email=f"dkim-{datetime.utcnow().timestamp()}@test.local",
+                password=generate_password_hash("pw", method="scrypt"),
+                name="DKIM User",
+                admin=True,
+                is_active=True,
+            )
+            db.session.add(user)
+            db.session.commit()
+            cfg = Email(
+                user_id=user.id,
+                email="ingest@example.com",
+                password=encrypt_password("imap-pw"),
+                server="imap.example.com",
+                subjectstr="balance alert",
+                startstr="$",
+                endstr=" USD",
+                allowed_sender="alerts@bank.com",
+            )
+            db.session.add(cfg)
+            db.session.commit()
+            user_id = user.id
+        yield user_id
+        with flask_app.app_context():
+            Email.query.filter_by(user_id=user_id).delete()
+            Balance.query.filter_by(user_id=user_id).delete()
+            User.query.filter_by(id=user_id).delete()
+            db.session.commit()
+
+    def _run(self, flask_app, raw_emails):
+        with patch("app.getemail.imaplib.IMAP4_SSL") as mock_ssl:
+            imap = MagicMock()
+            imap.select.return_value = ("OK", [b"1"])
+            imap.search.return_value = (
+                "OK",
+                [b" ".join(str(i + 1).encode() for i in range(len(raw_emails)))],
+            )
+
+            def _fetch(eid, _spec):
+                return ("OK", [(b"1 (RFC822 {1})", raw_emails[int(eid) - 1])])
+
+            imap.fetch.side_effect = _fetch
+            mock_ssl.return_value = imap
+            getemail.process_email_balances()
+
+    def _today_balance(self, user_id):
+        return Balance.query.filter_by(
+            user_id=user_id, date=datetime.today().date()
+        ).first()
+
+    def test_accepts_when_dkim_verifies_and_aligns(self, flask_app, email_user):
+        raw = _build_dkim_signed_email_bytes(signing_domain="bank.com")
+        with flask_app.app_context():
+            with patch(
+                "app.getemail._verify_dkim_signatures",
+                return_value={"bank.com"},
+            ) as mock_verify:
+                self._run(flask_app, [raw])
+            mock_verify.assert_called_once()
+            row = self._today_balance(email_user)
+            assert row is not None
+            assert float(row.amount) == pytest.approx(1234.56)
+
+    def test_rejects_when_dkim_domain_does_not_align(self, flask_app, email_user):
+        raw = _build_dkim_signed_email_bytes(signing_domain="phisher.com")
+        with flask_app.app_context():
+            with patch(
+                "app.getemail._verify_dkim_signatures",
+                return_value={"phisher.com"},
+            ):
+                self._run(flask_app, [raw])
+            assert self._today_balance(email_user) is None
+
+    def test_rejects_when_dkim_does_not_verify(self, flask_app, email_user):
+        raw = _build_dkim_signed_email_bytes()
+        with flask_app.app_context():
+            with patch(
+                "app.getemail._verify_dkim_signatures", return_value=set()
+            ):
+                self._run(flask_app, [raw])
+            assert self._today_balance(email_user) is None
+
+    def test_dkim_fallback_disabled_rejects(self, flask_app, email_user):
+        raw = _build_dkim_signed_email_bytes(signing_domain="bank.com")
+        with flask_app.app_context():
+            flask_app.config["EMAIL_VERIFY_DKIM"] = False
+            try:
+                with patch(
+                    "app.getemail._verify_dkim_signatures",
+                    return_value={"bank.com"},
+                ) as mock_verify:
+                    self._run(flask_app, [raw])
+                # Fallback disabled: DKIM verification must not even run.
+                mock_verify.assert_not_called()
+                assert self._today_balance(email_user) is None
+            finally:
+                flask_app.config["EMAIL_VERIFY_DKIM"] = True
+
+    def test_provider_auth_header_skips_dkim_fallback(self, flask_app, email_user):
+        # When the provider DID stamp a passing Authentication-Results header,
+        # the DKIM fallback is unnecessary and must not run.
+        raw = _build_balance_email_bytes(
+            auth_results="mx.test.local; dkim=pass; spf=pass; dmarc=pass"
+        )
+        with flask_app.app_context():
+            with patch("app.getemail._verify_dkim_signatures") as mock_verify:
+                self._run(flask_app, [raw])
+            mock_verify.assert_not_called()
+            assert self._today_balance(email_user) is not None


### PR DESCRIPTION
The H1 sender-authentication enforcement rejects any balance email whose
message lacks a parseable Authentication-Results header. That header is
stamped by the *receiving* mailbox, not the bank, and many custom-domain
and self-hosted mail hosts never add it. As a result a legitimate,
DKIM-signed Bank of America balance alert was rejected with
"failed sender authentication (dkim=none spf=none dmarc=none)".

When the provider stamps no usable Authentication-Results header, fall
back to verifying the message's DKIM signature ourselves (dkimpy) against
DNS and require the verified signing domain to align (DMARC-style relaxed
alignment) with the address that already passed the Allowed Sender check.
This authenticates the sender without depending on the provider, while
preserving the anti-spoofing guarantee: a forged From cannot produce a
valid DKIM signature for the bank's domain.

- Add _verify_dkim_signatures() and _dkim_domain_aligns() helpers.
- Capture the raw received bytes for byte-sensitive DKIM canonicalization.
- Add EMAIL_VERIFY_DKIM config (default true; disable where no outbound DNS).
- Add dkimpy dependency; update README and settings docs.
- Add unit and end-to-end tests for the DKIM fallback path.