### PR TITLE
Use Plotly strict CSP build so the chart renders with CSP enforced

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -331,7 +331,11 @@
 
 <!-- Plotly Chart Scripts -->
 <head>
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <!-- Strict CSP build: the standard plotly bundle pulls in a dependency that
+         uses the Function constructor, which requires script-src 'unsafe-eval'.
+         The strict build is eval-free and renders our SVG cartesian charts the
+         same, so CSP can be enforced (CSP_REPORT_ONLY=false) without breaking it. -->
+    <script src="https://cdn.plot.ly/plotly-strict-1.58.5.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script>
         function cb(selection) {

--- a/app/templates/index_guest.html
+++ b/app/templates/index_guest.html
@@ -184,7 +184,11 @@
 
 <!-- Plotly Chart Scripts -->
 <head>
-    <script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+    <!-- Strict CSP build: the standard plotly bundle pulls in a dependency that
+         uses the Function constructor, which requires script-src 'unsafe-eval'.
+         The strict build is eval-free and renders our SVG cartesian charts the
+         same, so CSP can be enforced (CSP_REPORT_ONLY=false) without breaking it. -->
+    <script src="https://cdn.plot.ly/plotly-strict-1.58.5.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script>
         function cb(selection) {


### PR DESCRIPTION
The standard plotly-latest bundle relies on a dependency that uses the
Function constructor, which needs script-src 'unsafe-eval'. With
CSP_REPORT_ONLY=true that violation is only reported, so the chart still
renders; with CSP_REPORT_ONLY=false it is enforced and Plotly fails to
initialize while jQuery/Bootstrap (no eval) keep working.

Switch both index templates to the eval-free plotly-strict build (same
1.58.5 version and cdn.plot.ly origin, already in the CSP allowlist), so
the SVG cartesian chart renders identically under an enforced CSP.