### PR TITLE
Use published Plotly strict bundle (3.6.0) so the chart loads

### DIFF
--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -334,8 +334,10 @@
     <!-- Strict CSP build: the standard plotly bundle pulls in a dependency that
          uses the Function constructor, which requires script-src 'unsafe-eval'.
          The strict build is eval-free and renders our SVG cartesian charts the
-         same, so CSP can be enforced (CSP_REPORT_ONLY=false) without breaking it. -->
-    <script src="https://cdn.plot.ly/plotly-strict-1.58.5.min.js"></script>
+         same, so CSP can be enforced (CSP_REPORT_ONLY=false) without breaking it.
+         The strict bundle is only published for plotly.js v2+, so we pin the
+         latest released version (the v1 line never shipped a strict build). -->
+    <script src="https://cdn.plot.ly/plotly-strict-3.6.0.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script>
         function cb(selection) {

--- a/app/templates/index_guest.html
+++ b/app/templates/index_guest.html
@@ -187,8 +187,10 @@
     <!-- Strict CSP build: the standard plotly bundle pulls in a dependency that
          uses the Function constructor, which requires script-src 'unsafe-eval'.
          The strict build is eval-free and renders our SVG cartesian charts the
-         same, so CSP can be enforced (CSP_REPORT_ONLY=false) without breaking it. -->
-    <script src="https://cdn.plot.ly/plotly-strict-1.58.5.min.js"></script>
+         same, so CSP can be enforced (CSP_REPORT_ONLY=false) without breaking it.
+         The strict bundle is only published for plotly.js v2+, so we pin the
+         latest released version (the v1 line never shipped a strict build). -->
+    <script src="https://cdn.plot.ly/plotly-strict-3.6.0.min.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
     <script>
         function cb(selection) {


### PR DESCRIPTION
The v1 line never shipped a strict build, so plotly-strict-1.58.5.min.js
returns 403 from the CDN and leaves Plotly undefined, breaking the
dashboard chart. The strict bundle is only published for plotly.js v2+,
so pin the latest released strict build (3.6.0), which is eval-free and
CSP-safe. Our SVG cartesian scatter charts render the same, and the
server's plotly.py already emits v3-compatible figure JSON.

https://claude.ai/code/session_011YmZXyhJzNu2zR366bsHNJ