### PR TITLE
Add ProxyFix so per-IP rate limiting works behind a reverse proxy

### DIFF
--- a/app/.env_example
+++ b/app/.env_example
@@ -33,6 +33,16 @@ SESSION_COOKIE_SECURE=true
 #   RATELIMIT_STORAGE_URI=redis://localhost:6379/0
 RATELIMIT_STORAGE_URI=memory://
 
+# Number of trusted reverse-proxy hops in front of the app (X-Forwarded-* depth).
+# Single reverse proxy / PaaS ingress / load balancer = 1 (default).
+# Chained proxies (e.g. proxying CDN -> ingress) = 2.
+# Set 0 only when clients connect directly with no proxy.
+# Setting this HIGHER than the real hop count lets clients spoof their IP and
+# bypass per-IP rate limits.
+# Note: plain ProxyFix cannot restrict trust to a specific CDN's IP ranges;
+# deployments needing that should validate the CDN's client-IP header themselves.
+TRUSTED_PROXY_COUNT=1
+
 # Optional: HTTP security response headers (CSP, X-Frame-Options, HSTS,
 # X-Content-Type-Options, Referrer-Policy, no-store on authenticated HTML).
 # Set to false only to disable them entirely (not recommended).

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,6 +9,7 @@ from flask_migrate import Migrate
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_wtf.csrf import CSRFProtect
+from werkzeug.middleware.proxy_fix import ProxyFix
 from dotenv import load_dotenv
 
 logger = logging.getLogger(__name__)
@@ -268,5 +269,20 @@ def create_app():
                     "Bootstrap admin creation skipped (%s); tables may not exist yet",
                     type(exc).__name__,
                 )
+
+    # When deployed behind a reverse proxy / PaaS ingress, trust that many
+    # X-Forwarded-* hops so rate limiting keys on the real client IP rather than
+    # the proxy's address. x_proto makes request.is_secure reflect the original
+    # HTTPS scheme behind TLS termination; x_host restores the public hostname for
+    # absolute URLs (e.g. password-setup links). Set TRUSTED_PROXY_COUNT=0 when
+    # clients connect directly (no proxy) so spoofed headers are ignored.
+    _proxy_count = int(os.environ.get('TRUSTED_PROXY_COUNT', '1'))
+    if _proxy_count > 0:
+        app.wsgi_app = ProxyFix(
+            app.wsgi_app,
+            x_for=_proxy_count,
+            x_proto=_proxy_count,
+            x_host=_proxy_count,
+        )
 
     return app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -104,6 +104,18 @@ def flask_app():
     return _test_app
 
 
+@pytest.fixture(scope="session")
+def create_app():
+    """Return the real create_app factory captured before any module stubs.
+
+    Tests that need to build fresh app instances (e.g. to exercise ProxyFix
+    under different TRUSTED_PROXY_COUNT settings) must use this rather than
+    importing ``app`` directly, because other test modules replace
+    ``sys.modules['app']`` with a stub at import time.
+    """
+    return _create_app
+
+
 @pytest.fixture()
 def client(flask_app):
     """Per-test Flask test client (unauthenticated)."""

--- a/tests/test_proxy_fix.py
+++ b/tests/test_proxy_fix.py
@@ -1,0 +1,98 @@
+"""
+Tests for the ProxyFix middleware wiring in app/__init__.py.
+
+ProxyFix lets the app resolve the real client IP from X-Forwarded-For when
+deployed behind a reverse proxy, so Flask-Limiter keys per-IP rate limits on
+the actual client rather than the proxy's internal address.
+
+These tests build dedicated app instances (varying TRUSTED_PROXY_COUNT) and
+register a temporary route that reports request.remote_addr / request.is_secure,
+rather than reaching into Flask-Limiter internals.
+"""
+
+import os
+from contextlib import contextmanager
+
+from flask import request
+
+
+@contextmanager
+def _env(**overrides):
+    """Temporarily set environment variables, restoring prior values after."""
+    sentinel = object()
+    previous = {k: os.environ.get(k, sentinel) for k in overrides}
+    try:
+        for k, v in overrides.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        yield
+    finally:
+        for k, prev in previous.items():
+            if prev is sentinel:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def _build_app(create_app, trusted_proxy_count):
+    """Create an app with TRUSTED_PROXY_COUNT set, plus a probe route."""
+    with _env(TRUSTED_PROXY_COUNT=trusted_proxy_count):
+        app = create_app()
+    app.config.update(TESTING=True, WTF_CSRF_ENABLED=False)
+
+    @app.route("/_proxy_probe")
+    def _proxy_probe():
+        return {
+            "remote_addr": request.remote_addr,
+            "is_secure": request.is_secure,
+        }
+
+    return app
+
+
+def test_forwarded_ip_is_used_behind_proxy(create_app):
+    """With one trusted hop, X-Forwarded-For/-Proto drive remote_addr/is_secure."""
+    app = _build_app(create_app, "1")
+    client = app.test_client()
+
+    resp = client.get(
+        "/_proxy_probe",
+        headers={
+            "X-Forwarded-For": "203.0.113.7",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+
+    assert resp.json["remote_addr"] == "203.0.113.7"
+    assert resp.json["is_secure"] is True
+
+
+def test_direct_connection_uses_test_client_default(create_app):
+    """Without forwarded headers, remote_addr is the test client default."""
+    app = _build_app(create_app, "1")
+    client = app.test_client()
+
+    resp = client.get("/_proxy_probe")
+
+    assert resp.json["remote_addr"] == "127.0.0.1"
+    assert resp.json["is_secure"] is False
+
+
+def test_spoofed_header_ignored_when_proxy_count_zero(create_app):
+    """With TRUSTED_PROXY_COUNT=0, ProxyFix is off and forwarded headers can't
+    change the apparent client IP, so spoofing is ignored."""
+    app = _build_app(create_app, "0")
+    client = app.test_client()
+
+    resp = client.get(
+        "/_proxy_probe",
+        headers={
+            "X-Forwarded-For": "203.0.113.7",
+            "X-Forwarded-Proto": "https",
+        },
+    )
+
+    assert resp.json["remote_addr"] == "127.0.0.1"
+    assert resp.json["is_secure"] is False


### PR DESCRIPTION
Behind a TLS-terminating reverse proxy / PaaS ingress, request.remote_addr
is the proxy's internal IP for every request. Flask-Limiter keys on that
address (get_remote_address), so all users land in one shared rate-limit
bucket: the 10/min login limit becomes effectively global (a latent
all-user lockout) and provides no per-attacker throttling.

Wrap app.wsgi_app in Werkzeug's ProxyFix at the end of create_app() so the
real client IP is resolved from X-Forwarded-For. x_proto makes
request.is_secure reflect the original HTTPS scheme behind TLS termination,
and x_host restores the public hostname for absolute URLs (e.g.
password-setup links).

The trusted hop count is TRUSTED_PROXY_COUNT (default 1, matching a single
proxy in front of gunicorn). It must equal the REAL proxy depth: ProxyFix
trusts the last N X-Forwarded-For entries, so a count higher than the real
hop count lets any client forge the header and choose its apparent IP,
bypassing per-IP rate limits. Set 0 for direct connections; 2 for chained
proxies. x_port/x_prefix are intentionally left off (unneeded, extra
spoofable surface).

Tests build fresh apps under different TRUSTED_PROXY_COUNT values and assert
the forwarded IP/scheme are used with a proxy, the test-client default is
used without forwarded headers, and a spoofed header is ignored when the
count is 0. create_app is exposed via a conftest fixture because another
test module replaces sys.modules['app'] with a stub.

Post-deploy check (operator): confirm request.remote_addr reflects a real
public client IP (not an internal/private address) via proxy logs or a
temporary log line; if X-Forwarded-For shows a different hop depth than
expected, adjust TRUSTED_PROXY_COUNT. Note: plain ProxyFix cannot restrict
trust to a specific CDN's IP ranges; deployments needing that should
validate the CDN's client-IP header themselves.

https://claude.ai/code/session_01GDe81nJSaj1H7DN2MMisXo