### PR TITLE
Add annual subscription plan with best value comparison

### DIFF
--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -46,7 +46,13 @@ These values are hardcoded in `PyCashFlowApp/Core/Config/Config.swift`:
 
 - `API_BASE_URL` => `https://app.pycashflow.com/api/v1`
 - `SELF_HOSTED_API_BASE_URL` => `http://127.0.0.1:5000/api/v1`
-- `APP_STORE_PRODUCT_IDS` => `com.h3consultingpartners.pycashflow.cloud.monthly`
+- `APP_STORE_PRODUCT_IDS` => `com.h3consultingpartners.pycashflow.cloud.monthly,com.h3consultingpartners.pycashflow.cloud.annual`
+
+`APP_STORE_PRODUCT_IDS` is a comma-separated list. Both the monthly and annual
+auto-renewing subscriptions unlock the same PyCashFlow Cloud access; the paywall
+lists every configured product, orders them cheapest-first, and flags the plan
+with the lowest per-month price as the best value. Add or remove product IDs
+here to change which plans appear — no other code changes are required.
 
 `APIClient` normalizes base URLs so host-only values automatically use `/api/v1`.
 For security, remote self-hosted servers must use HTTPS. Plain HTTP is only

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/StoreKitSubscriptionManager.swift
@@ -50,8 +50,11 @@ final class StoreKitSubscriptionManager: ObservableObject {
         }
 
         do {
+            // Sort by the numeric price rather than the localized display string
+            // so the monthly plan reliably precedes the higher-priced annual plan
+            // regardless of currency formatting.
             availableProducts = try await Product.products(for: AppEnvironment.appStoreProductIDs)
-                .sorted { $0.displayPrice < $1.displayPrice }
+                .sorted { $0.price < $1.price }
             if availableProducts.isEmpty {
                 errorMessage = "No App Store products are currently available."
             } else {

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Billing/SubscriptionPlanValue.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Billing/SubscriptionPlanValue.swift
@@ -1,0 +1,52 @@
+import Foundation
+import StoreKit
+
+/// Pure helpers for comparing subscription plans of different cadences
+/// (for example monthly vs. annual) so the paywall can surface which plan is
+/// the best value and how much it saves.
+///
+/// All math is driven by the live App Store prices and subscription periods,
+/// so nothing here assumes a specific price point.
+enum SubscriptionPlanValue {
+    /// Number of months represented by a StoreKit subscription period. Weeks and
+    /// days are converted to a fractional month using 30-day months so shorter
+    /// cadences can still be normalized for comparison.
+    static func months(in period: Product.SubscriptionPeriod) -> Decimal {
+        let value = Decimal(period.value)
+        switch period.unit {
+        case .day:
+            return value / 30
+        case .week:
+            return value * 7 / 30
+        case .month:
+            return value
+        case .year:
+            return value * 12
+        @unknown default:
+            return value
+        }
+    }
+
+    /// Price normalized to a per-month figure so plans billed on different
+    /// cadences can be compared directly. Returns `nil` when the period does not
+    /// represent a positive span of time.
+    static func monthlyEquivalentPrice(price: Decimal, period: Product.SubscriptionPeriod) -> Decimal? {
+        let months = months(in: period)
+        guard months > 0 else { return nil }
+        return price / months
+    }
+
+    /// Percentage saved by a plan whose per-month cost is `monthlyEquivalent`
+    /// relative to the most expensive per-month cost in `comparisons`.
+    ///
+    /// Returns `nil` when there is no baseline to compare against or the plan is
+    /// not actually cheaper, so callers can hide the badge instead of showing
+    /// "Save 0%".
+    static func savingsPercent(monthlyEquivalent plan: Decimal, comparedTo comparisons: [Decimal]) -> Int? {
+        guard let baseline = comparisons.max(), baseline > 0, plan < baseline else { return nil }
+        let fraction = (baseline - plan) / baseline
+        let percent = NSDecimalNumber(decimal: fraction).doubleValue * 100
+        let rounded = Int(percent.rounded())
+        return rounded > 0 ? rounded : nil
+    }
+}

--- a/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Config/Config.swift
@@ -3,5 +3,8 @@ import Foundation
 enum AppConfig {
     static let apiBaseURL = "https://app.pycashflow.com/api/v1"
     static let selfHostedAPIBaseURL = "http://127.0.0.1:5000/api/v1"
-    static let appStoreProductIDs = "com.h3consultingpartners.pycashflow.cloud.monthly"
+    /// Comma-separated App Store product identifiers offered on the paywall.
+    /// The monthly and annual auto-renewing subscriptions unlock the same
+    /// PyCashFlow Cloud access; the annual plan is the lower-cost cadence.
+    static let appStoreProductIDs = "com.h3consultingpartners.pycashflow.cloud.monthly,com.h3consultingpartners.pycashflow.cloud.annual"
 }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Subscription/SubscriptionPaywallView.swift
@@ -49,8 +49,17 @@ struct SubscriptionPaywallView: View {
                         .foregroundStyle(AppTheme.textMuted)
                         .cardRow()
                 } else {
+                    if manager.availableProducts.count > 1 {
+                        Text("Choose your plan")
+                            .font(.headline)
+                            .foregroundStyle(AppTheme.textPrimary)
+                    }
+
                     ForEach(manager.availableProducts, id: \.id) { product in
                         VStack(alignment: .leading, spacing: 8) {
+                            if isBestValue(product) {
+                                bestValueBadge(savings: savingsPercent(for: product))
+                            }
                             SubscriptionDisclosure(product: product)
                             Text("Your 7 day free trial begins when activated. The \(product.displayPrice) subscription begins after the 7 day trial if not cancelled.")
                                 .font(.footnote)
@@ -114,6 +123,47 @@ struct SubscriptionPaywallView: View {
 
     private var resolvedEmail: String {
         cloudEmail.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// A small capsule highlighting the lowest per-month plan, optionally with
+    /// how much it saves versus the pricier cadence.
+    private func bestValueBadge(savings: Int?) -> some View {
+        let label = savings.map { "Best value · Save \($0)%" } ?? "Best value"
+        return Text(label)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(AppTheme.textPrimary)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(AppTheme.success.opacity(0.9), in: Capsule())
+    }
+
+    /// The plan's price normalized to a per-month figure, or `nil` when its
+    /// subscription period is unavailable (e.g. in previews).
+    private func monthlyEquivalent(for product: Product) -> Decimal? {
+        guard let period = product.subscription?.subscriptionPeriod else { return nil }
+        return SubscriptionPlanValue.monthlyEquivalentPrice(price: product.price, period: period)
+    }
+
+    private var monthlyEquivalents: [Decimal] {
+        manager.availableProducts.compactMap { monthlyEquivalent(for: $0) }
+    }
+
+    /// True only for the single plan with the lowest per-month cost when more
+    /// than one plan is offered, so ties never flag multiple "best" plans.
+    private func isBestValue(_ product: Product) -> Bool {
+        let values = monthlyEquivalents
+        guard manager.availableProducts.count > 1,
+              values.count > 1,
+              let mine = monthlyEquivalent(for: product),
+              let cheapest = values.min(),
+              values.filter({ $0 == cheapest }).count == 1 else { return false }
+        return mine == cheapest
+    }
+
+    private func savingsPercent(for product: Product) -> Int? {
+        guard manager.availableProducts.count > 1,
+              let mine = monthlyEquivalent(for: product) else { return nil }
+        return SubscriptionPlanValue.savingsPercent(monthlyEquivalent: mine, comparedTo: monthlyEquivalents)
     }
 
     private func statusLine(label: String, value: String) -> some View {

--- a/ios-app/pycashflowTests/SubscriptionPlanValueTests.swift
+++ b/ios-app/pycashflowTests/SubscriptionPlanValueTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import StoreKit
+@testable import pycashflow
+
+final class SubscriptionPlanValueTests: XCTestCase {
+    func testConfiguredProductIDsIncludeMonthlyAndAnnual() {
+        XCTAssertEqual(
+            AppEnvironment.appStoreProductIDs,
+            [
+                "com.h3consultingpartners.pycashflow.cloud.monthly",
+                "com.h3consultingpartners.pycashflow.cloud.annual"
+            ]
+        )
+    }
+
+    func testMonthsInPeriodForSupportedCadences() {
+        XCTAssertEqual(
+            SubscriptionPlanValue.months(in: Product.SubscriptionPeriod(value: 1, unit: .month)),
+            1
+        )
+        XCTAssertEqual(
+            SubscriptionPlanValue.months(in: Product.SubscriptionPeriod(value: 1, unit: .year)),
+            12
+        )
+        XCTAssertEqual(
+            SubscriptionPlanValue.months(in: Product.SubscriptionPeriod(value: 3, unit: .month)),
+            3
+        )
+    }
+
+    func testMonthlyEquivalentPriceNormalizesAnnualToPerMonth() {
+        let annual = SubscriptionPlanValue.monthlyEquivalentPrice(
+            price: Decimal(48),
+            period: Product.SubscriptionPeriod(value: 1, unit: .year)
+        )
+        XCTAssertEqual(annual, 4)
+
+        let monthly = SubscriptionPlanValue.monthlyEquivalentPrice(
+            price: Decimal(string: "5.99")!,
+            period: Product.SubscriptionPeriod(value: 1, unit: .month)
+        )
+        XCTAssertEqual(monthly, Decimal(string: "5.99"))
+    }
+
+    func testSavingsPercentComparesAnnualAgainstMonthly() {
+        // Monthly $5.00/mo vs annual $48.00/yr ($4.00/mo) => 20% saved.
+        let monthlyPerMonth = SubscriptionPlanValue.monthlyEquivalentPrice(
+            price: Decimal(5),
+            period: Product.SubscriptionPeriod(value: 1, unit: .month)
+        )!
+        let annualPerMonth = SubscriptionPlanValue.monthlyEquivalentPrice(
+            price: Decimal(48),
+            period: Product.SubscriptionPeriod(value: 1, unit: .year)
+        )!
+
+        let savings = SubscriptionPlanValue.savingsPercent(
+            monthlyEquivalent: annualPerMonth,
+            comparedTo: [monthlyPerMonth, annualPerMonth]
+        )
+        XCTAssertEqual(savings, 20)
+    }
+
+    func testSavingsPercentIsNilWhenPlanIsNotCheaper() {
+        let monthlyPerMonth = SubscriptionPlanValue.monthlyEquivalentPrice(
+            price: Decimal(string: "5.99")!,
+            period: Product.SubscriptionPeriod(value: 1, unit: .month)
+        )!
+        XCTAssertNil(
+            SubscriptionPlanValue.savingsPercent(
+                monthlyEquivalent: monthlyPerMonth,
+                comparedTo: [monthlyPerMonth]
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds support for displaying multiple subscription plans (monthly and annual) on the paywall, with automatic comparison logic to highlight the best value plan and calculate savings percentages.

## Key Changes
- **New `SubscriptionPlanValue` utility**: Pure helper functions to normalize subscription plans across different billing cadences (monthly, annual, etc.) to a per-month figure for fair comparison
  - `months(in:)` converts subscription periods to months, handling days/weeks/months/years
  - `monthlyEquivalentPrice(price:period:)` calculates the per-month cost
  - `savingsPercent(monthlyEquivalent:comparedTo:)` computes savings relative to the most expensive plan

- **Updated paywall UI**: Enhanced `SubscriptionPaywallView` to display multiple plans with value indicators
  - Shows "Choose your plan" heading when multiple products are available
  - Displays a "Best value" badge on the cheapest per-month plan
  - Badge includes savings percentage when applicable (e.g., "Best value · Save 20%")
  - Plans are sorted by numeric price for consistent ordering regardless of currency formatting

- **Configuration updates**:
  - Added annual subscription product ID to `AppConfig.appStoreProductIDs`
  - Updated `StoreKitSubscriptionManager` to sort by numeric price instead of display string for reliable ordering

- **Comprehensive test coverage**: New `SubscriptionPlanValueTests` validates all comparison logic with realistic pricing scenarios

## Implementation Details
- The comparison logic is currency-agnostic and driven entirely by live App Store prices and subscription periods
- The "best value" badge only appears when there's a clear winner (no ties) and actual savings exist
- Product IDs are comma-separated in config, allowing easy addition/removal of plans without code changes
- All math uses `Decimal` for precision in financial calculations

https://claude.ai/code/session_01FdEjCzf7KDZbAZgpZKHqqV