### PR TITLE
Add ITSAppUsesNonExemptEncryption flag to app configuration

### DIFF
--- a/ios-app/pycashflow.xcodeproj/project.pbxproj
+++ b/ios-app/pycashflow.xcodeproj/project.pbxproj
@@ -376,6 +376,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = PyCashFlow;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -414,6 +415,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = PyCashFlow;
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.finance";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";


### PR DESCRIPTION
## Summary
This PR adds the `ITSAppUsesNonExemptEncryption` Info.plist key to the PyCashFlow app configuration, declaring that the app does not use non-exempt encryption.

## Changes
- Added `INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO` to both Debug and Release build configurations in the Xcode project file

## Details
This configuration key is required by Apple's App Store Connect for apps that may use encryption. By setting this value to `NO`, we're explicitly declaring that PyCashFlow does not implement or use any non-exempt encryption algorithms. This helps ensure compliance with App Store submission requirements and avoids potential review delays related to encryption declarations.

The change was applied to both build configurations to maintain consistency across Debug and Release builds.

https://claude.ai/code/session_01F8zhhL6bLAM6Y7QiR9v3KQ