### PR TITLE
Add Combine framework import to DemoModeBanner

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoModeBanner.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoModeBanner.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 /// Shared Demo-mode navigation state so the persistent banner and the Settings


### PR DESCRIPTION
## Summary
Added the `Combine` framework import to the DemoModeBanner module to support reactive programming patterns.

## Key Changes
- Added `import Combine` at the top of DemoModeBanner.swift

## Implementation Details
This import enables the use of Combine's reactive types and operators (such as `@Published`, `ObservableObject`, `AnyCancellable`, etc.) within the DemoModeBanner feature, allowing for proper state management and reactive updates in the demo mode navigation state.

https://claude.ai/code/session_01J2GNPZMWRE1CJ6ecCDgbGq