### PR TITLE
Make DemoStore.todayLocal nonisolated for use as default argument

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Demo/DemoStore.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Demo/DemoStore.swift
@@ -40,7 +40,11 @@ final class DemoStore: ObservableObject {
     }
 
     /// Today's date in the device's local calendar.
-    static var todayLocal: DemoDate {
+    ///
+    /// `nonisolated` so it can be used as a default argument (e.g. `projection`),
+    /// which Swift evaluates outside the enclosing type's `@MainActor` isolation.
+    /// It touches only value types (`Calendar`, `Date`, `DemoDate`), so it's safe.
+    nonisolated static var todayLocal: DemoDate {
         let comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
         return DemoDate(comps.year ?? 2000, comps.month ?? 1, comps.day ?? 1)
     }


### PR DESCRIPTION
## Summary
Updated the `todayLocal` static property in `DemoStore` to be `nonisolated`, allowing it to be used as a default argument value in methods that require `@MainActor` isolation.

## Changes
- Added `nonisolated` modifier to `DemoStore.todayLocal` static property
- Added documentation explaining the rationale: Swift evaluates default arguments outside the enclosing type's isolation context, so this property needs to be marked `nonisolated`
- Clarified in comments that this is safe because the property only touches value types (`Calendar`, `Date`, `DemoDate`)

## Details
This change enables `todayLocal` to be used as a default argument (e.g., in the `projection` method) without triggering isolation violations. The property is safe to mark as `nonisolated` since it only operates on value types and has no side effects.

https://claude.ai/code/session_01823VTSKnYaV55scJju6k7a