### PR TITLE
Apply demo mode banner to individual screens instead of TabView

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoBalanceView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoBalanceView.swift
@@ -91,6 +91,7 @@ struct DemoBalanceView: View {
         }
         .appBackground()
         .navigationTitle("Balance")
+        .localModeBanner()
     }
 
     private func saveBalance() {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoDashboardView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoDashboardView.swift
@@ -63,6 +63,7 @@ struct DemoDashboardView: View {
         }
         .appBackground()
         .navigationTitle("Dashboard")
+        .localModeBanner()
     }
 
     private func points(_ series: [DemoProjectionEngine.SeriesPoint]) -> [ProjectionPointDTO] {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoHoldsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoHoldsView.swift
@@ -42,6 +42,7 @@ struct DemoHoldsView: View {
         }
         .appBackground()
         .navigationTitle("Holds")
+        .localModeBanner()
     }
 
     @ViewBuilder

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoModeBanner.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoModeBanner.swift
@@ -44,3 +44,18 @@ struct DemoModeBanner: View {
         .accessibilityAddTraits(.isButton)
     }
 }
+
+extension View {
+    /// Pins the persistent Local Mode banner to the top of a Local Mode screen,
+    /// reserving safe-area space so the screen's content is offset below the
+    /// banner instead of sliding underneath it.
+    ///
+    /// Applied per screen rather than once on the enclosing `TabView`, because a
+    /// `safeAreaInset` on a `TabView` does not propagate the inset into each
+    /// tab's scroll/list content and leaves the content tucked under the banner.
+    func localModeBanner() -> some View {
+        safeAreaInset(edge: .top, spacing: 0) {
+            DemoModeBanner()
+        }
+    }
+}

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoRootView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoRootView.swift
@@ -42,16 +42,16 @@ struct DemoRootView: View {
                     .tabItem { Label("Settings", systemImage: "gearshape") }
                     .tag(DemoSection.settings)
             }
-            .safeAreaInset(edge: .top, spacing: 0) {
-                DemoModeBanner()
-            }
         }
         .environmentObject(store)
         .environmentObject(nav)
         .preferredColorScheme(.dark)
         .sheet(isPresented: $nav.showPaywall) {
+            // Open the 2-step paywall: collect the Cloud email first, then hand
+            // off to SubscriptionPaywallView (matching the login trial flow),
+            // rather than dropping the user straight onto the subscribe screen.
             NavigationStack {
-                SubscriptionPaywallView()
+                CloudActivationEmailView()
                     .toolbar {
                         ToolbarItem(placement: .topBarTrailing) {
                             Button("Done") { nav.showPaywall = false }

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoScenariosView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoScenariosView.swift
@@ -148,6 +148,7 @@ struct DemoScenariosView: View {
         .listStyle(.plain)
         .appBackground()
         .navigationTitle("Scenarios")
+        .localModeBanner()
     }
 
     private func pickerRow(label: String, selection: Binding<String>, options: [String]) -> some View {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoSchedulesView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoSchedulesView.swift
@@ -171,6 +171,7 @@ struct DemoSchedulesView: View {
         .listStyle(.plain)
         .appBackground()
         .navigationTitle("Schedules")
+        .localModeBanner()
     }
 
     private func pickerRow(label: String, selection: Binding<String>, options: [String]) -> some View {

--- a/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoSettingsView.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Features/Demo/DemoSettingsView.swift
@@ -42,5 +42,6 @@ struct DemoSettingsView: View {
         }
         .appBackground()
         .navigationTitle("Settings")
+        .localModeBanner()
     }
 }


### PR DESCRIPTION
## Summary
Refactored the demo mode banner implementation to apply it per-screen rather than once on the enclosing `TabView`. This fixes a layout issue where content was sliding underneath the banner instead of being properly offset below it.

## Key Changes
- Created a new `localModeBanner()` view modifier extension that wraps `safeAreaInset(edge: .top)` with the `DemoModeBanner`
- Removed the `safeAreaInset` modifier from `DemoRootView`'s `TabView` 
- Applied the new `.localModeBanner()` modifier to all individual tab screens:
  - `DemoBalanceView`
  - `DemoDashboardView`
  - `DemoHoldsView`
  - `DemoScenariosView`
  - `DemoSchedulesView`
  - `DemoSettingsView`
- Updated the paywall sheet in `DemoRootView` to show `CloudActivationEmailView` instead of `SubscriptionPaywallView` for a 2-step flow

## Implementation Details
The `safeAreaInset` modifier on a `TabView` does not properly propagate the inset into each tab's scroll/list content, leaving content tucked under the banner. By applying the modifier per-screen instead, the safe area inset is correctly applied within each tab's view hierarchy, ensuring content is properly offset below the banner.

https://claude.ai/code/session_01DM2sku4yE4CxUXoFtCHGYu