### PR TITLE
Mark DemoDate and helper functions as nonisolated for actor safety

### DIFF
--- a/ios-app/pycashflow/PyCashFlowApp/Core/Demo/DemoDate.swift
+++ b/ios-app/pycashflow/PyCashFlowApp/Core/Demo/DemoDate.swift
@@ -13,7 +13,11 @@ import Foundation
 ///
 /// `weekday` follows Python's `date.weekday()` convention: Monday == 0 …
 /// Sunday == 6.
-struct DemoDate: Equatable, Comparable, Hashable, Codable {
+/// `nonisolated` so this pure value type stays usable from any isolation
+/// context (e.g. `DemoStore.todayLocal`). The target builds with default
+/// `@MainActor` isolation, which would otherwise infer main-actor isolation on
+/// this type's members even though it does only integer math.
+nonisolated struct DemoDate: Equatable, Comparable, Hashable, Codable {
     let year: Int
     let month: Int
     let day: Int
@@ -152,7 +156,7 @@ struct DemoDate: Equatable, Comparable, Hashable, Codable {
 
 /// Floored integer division (matches Python `//` for negative operands, which
 /// `addingMonths` relies on when subtracting months across year boundaries).
-private func floorDiv(_ a: Int, _ b: Int) -> Int {
+private nonisolated func floorDiv(_ a: Int, _ b: Int) -> Int {
     let q = a / b
     let r = a % b
     return (r != 0 && ((r < 0) != (b < 0))) ? q - 1 : q
@@ -160,7 +164,7 @@ private func floorDiv(_ a: Int, _ b: Int) -> Int {
 
 /// Floored modulo, paired with `floorDiv` so the remainder is always in
 /// `0..<b` for positive `b`.
-private func mod(_ a: Int, _ b: Int) -> Int {
+private nonisolated func mod(_ a: Int, _ b: Int) -> Int {
     let r = a % b
     return (r != 0 && ((r < 0) != (b < 0))) ? r + b : r
 }


### PR DESCRIPTION
## Summary
This change adds `nonisolated` annotations to `DemoDate` and its helper functions to ensure they remain usable from any isolation context, particularly when accessed from actor-isolated code like `DemoStore.todayLocal`.

## Key Changes
- Marked `DemoDate` struct as `nonisolated` to prevent the compiler from inferring `@MainActor` isolation on its members
- Added `nonisolated` modifier to private helper functions `floorDiv(_:_:)` and `mod(_:_:)`

## Implementation Details
The `nonisolated` annotation is necessary because:
- The target builds with default `@MainActor` isolation enabled
- Without `nonisolated`, the compiler would infer main-actor isolation on `DemoDate`'s members even though the type performs only pure integer math operations
- This prevents isolation-related compilation errors when `DemoDate` is used in actor-isolated contexts
- The helper functions are marked `nonisolated` for consistency and to ensure they can be called from the `nonisolated` struct without isolation violations

https://claude.ai/code/session_01823VTSKnYaV55scJju6k7a